### PR TITLE
ci: add Rust-crate testing and unbreak the red build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-${{ matrix.ubuntu }}
     strategy:
       matrix:
-        ubuntu: ['24.04']
+        ubuntu: ['22.04', '24.04']
 
     steps:
       - name: Checkout
@@ -101,3 +101,36 @@ jobs:
             --inline-suppr \
             -I include/ \
             src/ helper/
+
+  rust-crate:
+    name: Rust crate (libdrmtap-sys + libdrmtap)
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            gcc pkg-config \
+            libdrm-dev libcap-dev libseccomp-dev \
+            libegl-dev libgles2-mesa-dev
+
+      - name: Build workspace
+        working-directory: bindings/rust
+        run: cargo build --workspace --verbose
+
+      - name: Test workspace
+        working-directory: bindings/rust
+        run: cargo test --workspace --verbose
+
+      # The published crates are the actual distributed artifact (libdrmtap-sys
+      # statically embeds the C sources and builds the privileged helper). Verify
+      # they stay buildable-from-package and publishable.
+      - name: Package check (libdrmtap-sys)
+        working-directory: bindings/rust
+        run: cargo package -p libdrmtap-sys
+
+      - name: Package check (libdrmtap)
+        working-directory: bindings/rust
+        run: cargo package -p libdrmtap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -76,7 +78,9 @@ jobs:
     name: Static Analysis
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -106,7 +110,9 @@ jobs:
     name: Rust crate (libdrmtap-sys + libdrmtap)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![crates.io](https://img.shields.io/crates/v/libdrmtap.svg)](https://crates.io/crates/libdrmtap)
 [![Built with AI](https://img.shields.io/badge/Built%20with-AI%20Agents-blueviolet)](docs/AI_DEVELOPMENT.md)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/fxd0h/libdrmtap?utm_source=oss&utm_medium=github&utm_campaign=fxd0h%2Flibdrmtap&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 *Capture any Linux display — no Wayland, no PipeWire, no user prompts.*
 

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -377,7 +377,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         if (hresult.dmabuf_fd >= 0) {
             free(pixel_buf);  /* Don't need pixel buffer */
 
-            int prime_fd = hresult.dmabuf_fd;
+            int dmabuf_fd = hresult.dmabuf_fd;
             size_t mmap_size = (size_t)frame->stride * frame->height;
 
             /* Clean up previous frame's DMA-BUF resources (they change every frame
@@ -386,28 +386,28 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 munmap(priv->mapped, priv->mapped_size);
                 priv->mapped = MAP_FAILED;
             }
-            if (priv->prime_fd >= 0 && priv->prime_fd != prime_fd) {
+            if (priv->prime_fd >= 0 && priv->prime_fd != dmabuf_fd) {
                 close(priv->prime_fd);
             }
 
             /* mmap the DMA-BUF in the parent */
             void *mapped = mmap(NULL, mmap_size, PROT_READ, MAP_SHARED,
-                                prime_fd, 0);
+                                dmabuf_fd, 0);
 
-            priv->prime_fd = prime_fd;
+            priv->prime_fd = dmabuf_fd;
             priv->is_heap_buf = 0;
 
             if (mapped != MAP_FAILED) {
                 priv->mapped = mapped;
                 priv->mapped_size = mmap_size;
                 frame->data = mapped;
-                frame->dma_buf_fd = prime_fd;
+                frame->dma_buf_fd = dmabuf_fd;
                 frame->_priv = priv;
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap'd DMA-BUF fd=%d (%zu bytes), "
                     "EGL deswizzle available",
-                    prime_fd, mmap_size);
+                    dmabuf_fd, mmap_size);
 
                 if (do_mmap) {
                     gpu_auto_process(ctx, mapped, frame);
@@ -417,12 +417,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 priv->mapped = MAP_FAILED;
                 priv->mapped_size = 0;
                 frame->data = NULL;
-                frame->dma_buf_fd = prime_fd;
+                frame->dma_buf_fd = dmabuf_fd;
                 frame->_priv = priv;
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap failed but DMA-BUF fd=%d available "
-                    "for EGL zero-copy", prime_fd);
+                    "for EGL zero-copy", dmabuf_fd);
 
                 if (do_mmap) {
                     gpu_auto_process(ctx, NULL, frame);

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -376,6 +376,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* V3: helper sent DMA-BUF fd via SCM_RIGHTS */
         if (hresult.dmabuf_fd >= 0) {
             free(pixel_buf);  /* Don't need pixel buffer */
+            /* priv->mapped aliased pixel_buf (set above for the heap-buffer
+             * path); it is now dangling. Clear it before the cleanup block so we
+             * don't munmap a freed pointer. priv is freshly calloc'd, so there
+             * is no real previous-frame mmap to release here anyway. */
+            priv->mapped = MAP_FAILED;
+            priv->is_heap_buf = 0;
 
             int dmabuf_fd = hresult.dmabuf_fd;
             size_t mmap_size = (size_t)frame->stride * frame->height;

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -102,6 +102,7 @@ struct drm_virtgpu_3d_wait {
 /* Command structure for CMD_GRAB (client to helper) */
 struct helper_cmd_grab {
     uint8_t  cmd;           /* CMD_GRAB (0x01) */
+    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
     uint8_t  _pad1[3];      /* align to 4 bytes */
     uint32_t crtc_id;       /* target CRTC id (0 = auto-select first active) */
 };
@@ -124,6 +125,7 @@ struct grab_metadata {
     uint32_t seq;
     uint64_t timestamp_ms;
     uint32_t flags;
+    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
     uint32_t _pad;
 };
 

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -509,14 +509,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     {
         static int frame_num = 0;
         frame_num++;
-        uint32_t *pixels = (uint32_t *)mapped;
-        uint32_t stride_px = meta.stride / 4;
-        uint32_t p_top = pixels[960 < (meta.stride/4) ? 960 : 0];
-        uint32_t p_clock = (94 * stride_px + 960 < mapped_size/4) ?
-                           pixels[94 * stride_px + 960] : 0;
-        uint32_t p_mid = (500 * stride_px + 960 < mapped_size/4) ?
-                         pixels[500 * stride_px + 960] : 0;
         if (frame_num <= 5 || frame_num % 60 == 0) {
+            uint32_t *pixels = (uint32_t *)mapped;
+            uint32_t stride_px = meta.stride / 4;
+            uint32_t p_top = pixels[960 < (meta.stride/4) ? 960 : 0];
+            uint32_t p_clock = (94 * stride_px + 960 < mapped_size/4) ?
+                               pixels[94 * stride_px + 960] : 0;
+            uint32_t p_mid = (500 * stride_px + 960 < mapped_size/4) ?
+                             pixels[500 * stride_px + 960] : 0;
             fprintf(stderr,
                 "drmtap-helper: frame=%d fb=%u mod=0x%lx top=%08x clock=%08x mid=%08x\n",
                 frame_num, meta.fb_id, (unsigned long)meta.modifier,

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -102,6 +102,7 @@ struct drm_virtgpu_3d_wait {
 /* Command structure for CMD_GRAB (client to helper) */
 struct helper_cmd_grab {
     uint8_t  cmd;           /* CMD_GRAB (0x01) */
+    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
     uint8_t  _pad1[3];      /* align to 4 bytes */
     uint32_t crtc_id;       /* target CRTC id (0 = auto-select first active) */
 };
@@ -124,6 +125,7 @@ struct grab_metadata {
     uint32_t seq;
     uint64_t timestamp_ms;
     uint32_t flags;
+    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
     uint32_t _pad;
 };
 

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -509,14 +509,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     {
         static int frame_num = 0;
         frame_num++;
-        uint32_t *pixels = (uint32_t *)mapped;
-        uint32_t stride_px = meta.stride / 4;
-        uint32_t p_top = pixels[960 < (meta.stride/4) ? 960 : 0];
-        uint32_t p_clock = (94 * stride_px + 960 < mapped_size/4) ?
-                           pixels[94 * stride_px + 960] : 0;
-        uint32_t p_mid = (500 * stride_px + 960 < mapped_size/4) ?
-                         pixels[500 * stride_px + 960] : 0;
         if (frame_num <= 5 || frame_num % 60 == 0) {
+            uint32_t *pixels = (uint32_t *)mapped;
+            uint32_t stride_px = meta.stride / 4;
+            uint32_t p_top = pixels[960 < (meta.stride/4) ? 960 : 0];
+            uint32_t p_clock = (94 * stride_px + 960 < mapped_size/4) ?
+                               pixels[94 * stride_px + 960] : 0;
+            uint32_t p_mid = (500 * stride_px + 960 < mapped_size/4) ?
+                             pixels[500 * stride_px + 960] : 0;
             fprintf(stderr,
                 "drmtap-helper: frame=%d fb=%u mod=0x%lx top=%08x clock=%08x mid=%08x\n",
                 frame_num, meta.fb_id, (unsigned long)meta.modifier,

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -377,7 +377,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         if (hresult.dmabuf_fd >= 0) {
             free(pixel_buf);  /* Don't need pixel buffer */
 
-            int prime_fd = hresult.dmabuf_fd;
+            int dmabuf_fd = hresult.dmabuf_fd;
             size_t mmap_size = (size_t)frame->stride * frame->height;
 
             /* Clean up previous frame's DMA-BUF resources (they change every frame
@@ -386,28 +386,28 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 munmap(priv->mapped, priv->mapped_size);
                 priv->mapped = MAP_FAILED;
             }
-            if (priv->prime_fd >= 0 && priv->prime_fd != prime_fd) {
+            if (priv->prime_fd >= 0 && priv->prime_fd != dmabuf_fd) {
                 close(priv->prime_fd);
             }
 
             /* mmap the DMA-BUF in the parent */
             void *mapped = mmap(NULL, mmap_size, PROT_READ, MAP_SHARED,
-                                prime_fd, 0);
+                                dmabuf_fd, 0);
 
-            priv->prime_fd = prime_fd;
+            priv->prime_fd = dmabuf_fd;
             priv->is_heap_buf = 0;
 
             if (mapped != MAP_FAILED) {
                 priv->mapped = mapped;
                 priv->mapped_size = mmap_size;
                 frame->data = mapped;
-                frame->dma_buf_fd = prime_fd;
+                frame->dma_buf_fd = dmabuf_fd;
                 frame->_priv = priv;
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap'd DMA-BUF fd=%d (%zu bytes), "
                     "EGL deswizzle available",
-                    prime_fd, mmap_size);
+                    dmabuf_fd, mmap_size);
 
                 if (do_mmap) {
                     gpu_auto_process(ctx, mapped, frame);
@@ -417,12 +417,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 priv->mapped = MAP_FAILED;
                 priv->mapped_size = 0;
                 frame->data = NULL;
-                frame->dma_buf_fd = prime_fd;
+                frame->dma_buf_fd = dmabuf_fd;
                 frame->_priv = priv;
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap failed but DMA-BUF fd=%d available "
-                    "for EGL zero-copy", prime_fd);
+                    "for EGL zero-copy", dmabuf_fd);
 
                 if (do_mmap) {
                     gpu_auto_process(ctx, NULL, frame);

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -376,6 +376,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* V3: helper sent DMA-BUF fd via SCM_RIGHTS */
         if (hresult.dmabuf_fd >= 0) {
             free(pixel_buf);  /* Don't need pixel buffer */
+            /* priv->mapped aliased pixel_buf (set above for the heap-buffer
+             * path); it is now dangling. Clear it before the cleanup block so we
+             * don't munmap a freed pointer. priv is freshly calloc'd, so there
+             * is no real previous-frame mmap to release here anyway. */
+            priv->mapped = MAP_FAILED;
+            priv->is_heap_buf = 0;
 
             int dmabuf_fd = hresult.dmabuf_fd;
             size_t mmap_size = (size_t)frame->stride * frame->height;


### PR DESCRIPTION
Adds CI coverage for the Rust crate and unbreaks the pre-existing red build. Setting up proper CI immediately surfaced that `main`'s CI was fully red and caught a real use-after-free in the capture path.

## What this adds
- **Rust crate job** (`bindings/rust`): `cargo build --workspace`, `cargo test --workspace`, and `cargo package` for both `libdrmtap-sys` and `libdrmtap`. The crate is the actual distributed artifact (it statically embeds the C sources and builds the privileged `drmtap-helper`) and was previously not exercised by CI at all.
- **Ubuntu 22.04** added to the C build matrix (validates the documented minimum: kernel 5.4 / GETFB2).

## What this fixes (the build was red on `main`)
- **Static analysis** (cppcheck): targeted inline suppressions for the intentional wire-format padding fields; renamed a shadowing `prime_fd` in the V3 path; reduced a debug variable's scope.
- **Release build** (`-Werror=use-after-free`): a **use-after-free in `do_grab()`** (V3 DMA-BUF path) — `pixel_buf` was freed then `munmap`'d via a dangling `priv->mapped` alias. Fixed. (`Fixes #9`)

## Verification
Locally before/after: `cppcheck` clean, debug + release (werror) builds green, `cargo build/test/package` green, and DRM capture (V3 DMA-BUF + EGL detile on Intel i915) verified end-to-end.

Closes #7. Fixes #9.