### PR TITLE
Harden the privileged helper + fix capture-path correctness (Nvidia, DMA-BUF sync, buffer lifetime)

### DIFF
--- a/bindings/rust/libdrmtap-sys/build.rs
+++ b/bindings/rust/libdrmtap-sys/build.rs
@@ -76,7 +76,15 @@ fn main() {
         .arg("-D_GNU_SOURCE")
         .arg("-D_POSIX_C_SOURCE=200809L")
         .arg("-DHAVE_SECCOMP=1")
-        .arg("-DHAVE_LIBCAP=1");
+        .arg("-DHAVE_LIBCAP=1")
+        // Exploit-mitigation hardening for this privileged (CAP_SYS_ADMIN) binary.
+        .arg("-O2")
+        .arg("-fstack-protector-strong")
+        .arg("-U_FORTIFY_SOURCE")
+        .arg("-D_FORTIFY_SOURCE=2")
+        .arg("-fPIE")
+        .arg("-pie")
+        .arg("-Wl,-z,relro,-z,now");
 
     // Include libdrm headers for drmtap-helper.c (same probe as the library).
     match pkg_config::Config::new().cargo_metadata(false).probe("libdrm") {

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -73,6 +73,8 @@ typedef struct {
     uint32_t gem_handle;    /* GEM handle (needs close) */
     int used_dumb_map;      /* 1 if mapped via dumb buffer (virtio_gpu) */
     int is_heap_buf;        /* 1 if mapped is malloc'd (helper v2 pixel path) */
+    int sync_started;       /* 1 if dmabuf_sync_start succeeded — release issues
+                               the matching SYNC_END only then (no END w/o START) */
 } frame_priv_t;
 
 /* ========================================================================= */
@@ -280,6 +282,21 @@ static void *virtio_dumb_mmap(drmtap_ctx *ctx, uint32_t handle, size_t size) {
 /* Core capture logic                                                        */
 /* ========================================================================= */
 
+/* Reject framebuffer geometry whose byte size (stride * height) would overflow
+ * size_t (a concern on 32-bit builds) or exceed DRMTAP_MAX_FB_BYTES, before any
+ * downstream multiply feeds an allocation or mmap. stride/height come from
+ * drmModeGetFB2 or the helper wire and are not under our control, so validating
+ * once at each entry point keeps all later stride*height computations safe. */
+static int validate_fb_size(uint32_t stride, uint32_t height) {
+    if (stride == 0 || height == 0) {
+        return -EINVAL;
+    }
+    if ((size_t)height > DRMTAP_MAX_FB_BYTES / stride) {
+        return -EFBIG;
+    }
+    return 0;
+}
+
 // Internal capture that populates frame_info
 // If do_mmap is true, also maps the pixel data to frame->data
 static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
@@ -320,6 +337,14 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                      fb2->width, fb2->height,
                      (const char *)&fb2->pixel_format,
                      (unsigned long)fb2->modifier);
+
+    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    if (ret != 0) {
+        drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
+                         fb2->width, fb2->height, fb2->pitches[0]);
+        drmModeFreeFB2(fb2);
+        return ret;
+    }
 
     /* Cache multi-plane info for EGL CCS import */
     ctx->fb2_num_planes = 0;
@@ -406,6 +431,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         frame->modifier = hresult.wire.modifier;
         frame->fb_id = hresult.wire.fb_id;
 
+        /* The helper validates its own geometry, but it sends stride/height over
+         * the wire — re-check before we mmap/size anything from those values. */
+        ret = validate_fb_size(frame->stride, frame->height);
+        if (ret != 0) {
+            drmtap_set_error(ctx, "helper sent invalid geometry %ux%u stride=%u",
+                             frame->width, frame->height, frame->stride);
+            free(priv);
+            drmModeFreeFB2(fb2);
+            return ret;
+        }
+
         /* V3: helper sent DMA-BUF fd via SCM_RIGHTS */
         if (hresult.dmabuf_fd >= 0) {
             /* The helper passed a DMA-BUF fd instead of pixels; ctx->pixel_buf
@@ -434,7 +470,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                  * cache-coherency is correct (stale pixels otherwise, notably on
                  * ARM/Jetson). The matching SYNC_END runs in the cleanup block. */
                 priv->used_dumb_map = 0;
-                dmabuf_sync_start(dmabuf_fd);
+                priv->sync_started = (dmabuf_sync_start(dmabuf_fd) == 0);
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap'd DMA-BUF fd=%d (%zu bytes), "
@@ -539,9 +575,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             drmtap_debug_log(ctx, "mmap failed, falling back to zero-copy");
             frame->data = NULL;
         } else {
-            /* Unconditionally invalidate CPU caches using SYNC_START */
-            /* Crucial for virtio_gpu where the transfer arrives in system RAM asynchronously */
-            dmabuf_sync_start(prime_fd);
+            /* Invalidate CPU caches with SYNC_START and remember it succeeded so
+             * release issues the matching SYNC_END (and only then). Crucial for
+             * virtio_gpu where the transfer arrives in system RAM asynchronously. */
+            priv->sync_started = (dmabuf_sync_start(prime_fd) == 0);
 
             priv->mapped = mapped;
             priv->mapped_size = size;
@@ -594,18 +631,21 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     #define DRM_FMT_AR30 0x30335241u  /* fourcc('A','R','3','0') */
     #define DRM_FMT_XR24 0x34325258u  /* fourcc('X','R','2','4') */
 
-    /* Ensure shadow buffer is allocated (grow-once, capped — see ensure_buf).
-     * This runs before both the EGL and CPU detile paths, so the cap also
-     * bounds the EGL output (width*4*height <= stride*height = size). */
+    /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
+     * see ensure_buf). frame->stride/height are validated at every entry point
+     * (validate_fb_size), so this multiply cannot overflow. NOTE: this does NOT
+     * bound the EGL output, which is always 4-byte RGBA — a sub-4-byte source
+     * (e.g. RG16) can expand past stride*height, so the EGL path caps egl_size
+     * separately below. */
     size_t size = (size_t)frame->stride * frame->height;
-    int br = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
-    if (br != 0) {
-        if (br == -EFBIG) {
+    int bres = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    if (bres != 0) {
+        if (bres == -EFBIG) {
             drmtap_set_error(ctx,
                 "framebuffer too large for deswizzle: %zu bytes (max %zu)",
                 size, (size_t)DRMTAP_MAX_FB_BYTES);
         }
-        return br;
+        return bres;
     }
 
     /* --- EGL path: import DMA-BUF, GPU renders to linear RGBA ---
@@ -631,6 +671,15 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                                           modifier, &egl_data, &egl_size);
         drmtap_debug_log(ctx, "EGL convert: ret=%d data=%p", ret, egl_data);
         if (ret == 0 && egl_data) {
+            /* The EGL output is 4-byte RGBA and can exceed the source
+             * stride*height for sub-4-byte formats, so cap it independently
+             * before adopting it as the context buffer. */
+            if (egl_size > DRMTAP_MAX_FB_BYTES) {
+                free(egl_data);
+                drmtap_set_error(ctx, "EGL output too large: %zu bytes (max %zu)",
+                                 egl_size, (size_t)DRMTAP_MAX_FB_BYTES);
+                return -EFBIG;
+            }
             /* Store in ctx for reuse / cleanup */
             free(ctx->deswizzle_buf);
             ctx->deswizzle_buf = egl_data;
@@ -727,7 +776,7 @@ void drmtap_frame_release(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             if (priv->is_heap_buf) {
                 free(priv->mapped);
             } else if (priv->mapped != MAP_FAILED) {
-                if (!priv->used_dumb_map && priv->prime_fd >= 0) {
+                if (priv->sync_started && priv->prime_fd >= 0) {
                     dmabuf_sync_end(priv->prime_fd);
                 }
                 munmap(priv->mapped, priv->mapped_size);
@@ -922,6 +971,14 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         drmModeFreeFB2(fb2);
         drmtap_set_error(ctx, "fast2: handles[0]==0, no CAP_SYS_ADMIN");
         return -EACCES;
+    }
+
+    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    if (ret != 0) {
+        drmtap_set_error(ctx, "fast2: rejecting geometry %ux%u stride=%u",
+                         fb2->width, fb2->height, fb2->pitches[0]);
+        drmModeFreeFB2(fb2);
+        return ret;
     }
 
     /* Export DMA-BUF */

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -192,6 +192,32 @@ static int dmabuf_sync_end(int fd) {
     return ioctl(fd, DMA_BUF_IOCTL_SYNC, &sync);
 }
 
+/* Ensure *buf holds at least `size` bytes, growing once and never shrinking so
+ * steady-state capture reuses one allocation instead of malloc/free per frame.
+ * Caps the allocation at DRMTAP_MAX_FB_BYTES as a guard against a bogus/hostile
+ * framebuffer geometry forcing an unbounded request. Contents are not preserved
+ * across a grow. Returns 0, -EINVAL (zero size), -EFBIG (over the cap), or
+ * -ENOMEM. */
+static int ensure_buf(void **buf, size_t *cap, size_t size) {
+    if (size == 0) {
+        return -EINVAL;
+    }
+    if (size > DRMTAP_MAX_FB_BYTES) {
+        return -EFBIG;
+    }
+    if (*buf && *cap >= size) {
+        return 0;
+    }
+    free(*buf);
+    *buf = malloc(size);
+    if (!*buf) {
+        *cap = 0;
+        return -ENOMEM;
+    }
+    *cap = size;
+    return 0;
+}
+
 /* ========================================================================= */
 /* virtio_gpu transfer helpers                                               */
 /* ========================================================================= */
@@ -327,19 +353,26 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         drmtap_debug_log(ctx,
             "No CAP_SYS_ADMIN (needs helper), trying helper...");
 
-        /* Allocate pixel buffer for helper to fill */
+        /* Receive buffer for the helper to fill. ctx-owned, grow-once and
+         * reused across grabs (never per-frame churn), capped — see ensure_buf.
+         * Freed in drmtap_close(). */
         size_t buf_size = (size_t)fb2->pitches[0] * fb2->height;
-        void *pixel_buf = malloc(buf_size);
-        if (!pixel_buf) {
+        ret = ensure_buf(&ctx->pixel_buf, &ctx->pixel_buf_size, buf_size);
+        if (ret != 0) {
+            if (ret == -EFBIG) {
+                drmtap_set_error(ctx,
+                    "framebuffer too large: %zu bytes (max %zu)",
+                    buf_size, (size_t)DRMTAP_MAX_FB_BYTES);
+            }
             drmModeFreeFB2(fb2);
-            return -ENOMEM;
+            return ret;
         }
+        void *pixel_buf = ctx->pixel_buf;
 
         /* Helper reads pixels in its own process and sends via socket */
         helper_grab_result_t hresult;
         ret = drmtap_helper_grab(ctx, &hresult, pixel_buf, buf_size);
         if (ret < 0) {
-            free(pixel_buf);
             drmtap_set_error(ctx,
                 "No CAP_SYS_ADMIN and helper failed (ret=%d). "
                 "Install the helper: sudo cp drmtap-helper /usr/local/bin/ "
@@ -352,17 +385,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* Allocate private state */
         priv = calloc(1, sizeof(frame_priv_t));
         if (!priv) {
-            free(pixel_buf);
             drmModeFreeFB2(fb2);
             return -ENOMEM;
         }
         priv->helper_drm_fd = -1;
         priv->prime_fd = -1;
         priv->gem_handle = 0;
-        priv->mapped = pixel_buf;       /* reuse mapped field for free() */
-        priv->mapped_size = buf_size;
+        /* pixel_buf is ctx-owned and reused; priv must never free/munmap it. */
+        priv->mapped = MAP_FAILED;
+        priv->mapped_size = 0;
         priv->used_dumb_map = 1;        /* skip dmabuf_sync in release */
-        priv->is_heap_buf = 1;          /* free() instead of munmap() */
+        priv->is_heap_buf = 0;          /* ctx owns the buffer; do not free */
 
         /* Fill frame info from helper metadata */
         memset(frame, 0, sizeof(*frame));
@@ -375,33 +408,18 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
         /* V3: helper sent DMA-BUF fd via SCM_RIGHTS */
         if (hresult.dmabuf_fd >= 0) {
-            free(pixel_buf);  /* Don't need pixel buffer */
-            /* priv->mapped aliased pixel_buf (set above for the heap-buffer
-             * path); it is now dangling. Clear it before the cleanup block so we
-             * don't munmap a freed pointer. priv is freshly calloc'd, so there
-             * is no real previous-frame mmap to release here anyway. */
-            priv->mapped = MAP_FAILED;
-            priv->is_heap_buf = 0;
-
+            /* The helper passed a DMA-BUF fd instead of pixels; ctx->pixel_buf
+             * stays allocated for reuse on the next grab. priv is freshly
+             * calloc'd (mapped=MAP_FAILED, prime_fd=-1), so there is no prior
+             * mapping to release here. */
             int dmabuf_fd = hresult.dmabuf_fd;
             size_t mmap_size = (size_t)frame->stride * frame->height;
-
-            /* Clean up previous frame's DMA-BUF resources (they change every frame
-             * because the compositor flips between framebuffers) */
-            if (priv->mapped != MAP_FAILED && priv->mapped != NULL) {
-                munmap(priv->mapped, priv->mapped_size);
-                priv->mapped = MAP_FAILED;
-            }
-            if (priv->prime_fd >= 0 && priv->prime_fd != dmabuf_fd) {
-                close(priv->prime_fd);
-            }
 
             /* mmap the DMA-BUF in the parent */
             void *mapped = mmap(NULL, mmap_size, PROT_READ, MAP_SHARED,
                                 dmabuf_fd, 0);
 
             priv->prime_fd = dmabuf_fd;
-            priv->is_heap_buf = 0;
 
             if (mapped != MAP_FAILED) {
                 priv->mapped = mapped;
@@ -409,6 +427,14 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 frame->data = mapped;
                 frame->dma_buf_fd = dmabuf_fd;
                 frame->_priv = priv;
+
+                /* This is a real DMA-BUF the helper exported via PrimeHandleToFD,
+                 * not a dumb buffer. Clear the dumb-map flag inherited from the
+                 * heap path above and bracket the CPU read with DMA_BUF_SYNC so
+                 * cache-coherency is correct (stale pixels otherwise, notably on
+                 * ARM/Jetson). The matching SYNC_END runs in the cleanup block. */
+                priv->used_dumb_map = 0;
+                dmabuf_sync_start(dmabuf_fd);
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap'd DMA-BUF fd=%d (%zu bytes), "
@@ -439,7 +465,9 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             return 0;
         }
 
-        /* V2 fallback: pixel data received via socket */
+        /* V2 fallback: pixel data received into ctx->pixel_buf. frame->data
+         * borrows that buffer — valid until the next grab or drmtap_close();
+         * priv must not free it (is_heap_buf=0, mapped=MAP_FAILED above). */
         frame->dma_buf_fd = -1;
         frame->data = pixel_buf;
         frame->_priv = priv;
@@ -566,16 +594,18 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     #define DRM_FMT_AR30 0x30335241u  /* fourcc('A','R','3','0') */
     #define DRM_FMT_XR24 0x34325258u  /* fourcc('X','R','2','4') */
 
-    /* Ensure shadow buffer is allocated */
+    /* Ensure shadow buffer is allocated (grow-once, capped — see ensure_buf).
+     * This runs before both the EGL and CPU detile paths, so the cap also
+     * bounds the EGL output (width*4*height <= stride*height = size). */
     size_t size = (size_t)frame->stride * frame->height;
-    if (ctx->deswizzle_buf_size < size) {
-        free(ctx->deswizzle_buf);
-        ctx->deswizzle_buf = malloc(size);
-        if (!ctx->deswizzle_buf) {
-            ctx->deswizzle_buf_size = 0;
-            return -ENOMEM;
+    int br = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    if (br != 0) {
+        if (br == -EFBIG) {
+            drmtap_set_error(ctx,
+                "framebuffer too large for deswizzle: %zu bytes (max %zu)",
+                size, (size_t)DRMTAP_MAX_FB_BYTES);
         }
-        ctx->deswizzle_buf_size = size;
+        return br;
     }
 
     /* --- EGL path: import DMA-BUF, GPU renders to linear RGBA ---

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -501,6 +501,19 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             return 0;
         }
 
+        /* The V2 payload must be exactly one full frame. ctx->pixel_buf is reused
+         * across grabs, so accepting a short payload would expose stale pixels
+         * from a previous frame behind the advertised stride*height geometry.
+         * (frame->stride/height were validated above, so this can't overflow.) */
+        if (hresult.wire.data_size != (size_t)frame->stride * frame->height) {
+            drmtap_set_error(ctx, "helper V2 payload %u != expected %zu bytes",
+                             hresult.wire.data_size,
+                             (size_t)frame->stride * frame->height);
+            free(priv);
+            drmModeFreeFB2(fb2);
+            return -EPROTO;
+        }
+
         /* V2 fallback: pixel data received into ctx->pixel_buf. frame->data
          * borrows that buffer — valid until the next grab or drmtap_close();
          * priv must not free it (is_heap_buf=0, mapped=MAP_FAILED above). */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -89,6 +89,19 @@ struct drm_virtgpu_3d_wait {
     DRM_IOW(DRM_COMMAND_BASE + DRM_VIRTGPU_WAIT, \
             struct drm_virtgpu_3d_wait)
 #endif
+/* GETPARAM (used to detect virgl 3D) lives in <drm/virtgpu_drm.h>, not in
+ * <linux/virtio_gpu.h>; provide the uapi definition if it's missing. */
+#ifndef DRM_IOCTL_VIRTGPU_GETPARAM
+struct drm_virtgpu_getparam {
+    __u64 param;
+    __u64 value;
+};
+#define VIRTGPU_PARAM_3D_FEATURES 1
+#define DRM_VIRTGPU_GETPARAM 0x03
+#define DRM_IOCTL_VIRTGPU_GETPARAM \
+    DRM_IOWR(DRM_COMMAND_BASE + DRM_VIRTGPU_GETPARAM, \
+             struct drm_virtgpu_getparam)
+#endif
 #endif
 
 /* Socket fd inherited from parent (via socketpair) */
@@ -457,7 +470,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
     uint32_t gem_handle = fb2->handles[0];
 
-    /* virtio_gpu: transfer pixels from host GPU to guest RAM */
+    /* virtio_gpu: transfer pixels from host GPU to guest RAM, then wait. */
     if (is_virtio) {
 #ifdef __linux__
         struct drm_virtgpu_3d_transfer_from_host xfer = {0};
@@ -470,6 +483,30 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
             wait_args.handle = gem_handle;
             drmIoctl(drm_fd, DRM_IOCTL_VIRTGPU_WAIT, &wait_args);
         }
+#endif
+    }
+
+    /* Decide once whether this virtio-gpu is "plain" (no virgl 3D). Without 3D
+     * the scanout is a 2D dumb buffer in guest RAM that we can export as a
+     * DMA-BUF and let the parent map directly (zero-copy), instead of copying
+     * the whole framebuffer over the socket every frame. With virgl the scanout
+     * can be a host-side 3D resource, so we keep the proven copy-after-transfer
+     * path there until the zero-copy path is validated on virgl. */
+    static int virtio_plain = -1;
+    if (is_virtio && virtio_plain < 0) {
+        virtio_plain = 0;
+#if defined(__linux__) && defined(DRM_IOCTL_VIRTGPU_GETPARAM)
+        uint64_t features = 0;
+        struct drm_virtgpu_getparam gp = {
+            .param = VIRTGPU_PARAM_3D_FEATURES,
+            .value = (uint64_t)(uintptr_t)&features,
+        };
+        if (drmIoctl(drm_fd, DRM_IOCTL_VIRTGPU_GETPARAM, &gp) == 0 && features == 0) {
+            virtio_plain = 1;
+        }
+        fprintf(stderr, "drmtap-helper: virtio 3D features=%llu -> %s path\n",
+                (unsigned long long)features,
+                virtio_plain ? "zero-copy DMA-BUF" : "pixel-copy");
 #endif
     }
 
@@ -495,13 +532,20 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
     int ret;
 
-    /* Preferred path for tiled (non-linear) framebuffers: export the GEM buffer
-     * as a DMA-BUF fd and pass it via SCM_RIGHTS so the parent can EGL-import and
-     * GPU-deswizzle it. Done BEFORE any MODE_MAP_DUMB on purpose: scanout buffers
-     * on some drivers are not dumb-mappable (nvidia-drm on Tegra fails
-     * MODE_MAP_DUMB with "Failed to lookup gem object"), so requiring a dumb map
-     * first would break capture on those GPUs even though the export works. */
-    if (meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio) {
+    /* Export the GEM buffer as a DMA-BUF fd and pass it via SCM_RIGHTS so the
+     * parent maps it directly — no per-frame pixel copy over the socket. Two
+     * cases take this path:
+     *   - tiled (non-linear) non-virtio framebuffers: the parent EGL-imports and
+     *     GPU-deswizzles. Done BEFORE any MODE_MAP_DUMB on purpose: scanout
+     *     buffers on some drivers are not dumb-mappable (nvidia-drm on Tegra
+     *     fails MODE_MAP_DUMB with "Failed to lookup gem object"), so requiring a
+     *     dumb map first would break capture there even though the export works.
+     *   - plain virtio-gpu (guest-rendered, no host transfer): a linear scanout
+     *     in guest RAM the parent maps directly (no detile). Replaces the V2
+     *     pixel copy, dropping the helper's per-frame CPU cost.
+     * Either way, if the export fails we fall through to the dumb-map pixel path. */
+    if ((meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio)
+        || (is_virtio && virtio_plain)) {
         int prime_fd = -1;
         int prime_ret = drmPrimeHandleToFD(drm_fd, gem_handle,
                                             DRM_CLOEXEC | DRM_RDWR, &prime_fd);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -468,6 +468,16 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
         return send_error(sock, "handles[0]==0 (CAP_SYS_ADMIN not set?)");
     }
 
+    /* Reject absurd geometry before any size computation: bound pitch*height so a
+     * hostile framebuffer cannot overflow size_t, and so the uint32 data_size we
+     * put on the wire cannot disagree with the size_t payload we send. Cap at one
+     * 8K BGRA frame (~126 MB, well under UINT32_MAX). */
+    if (fb2->pitches[0] == 0 || fb2->height == 0 ||
+        (size_t)fb2->height > ((size_t)7680 * 4320 * 4) / fb2->pitches[0]) {
+        drmModeFreeFB2(fb2);
+        return send_error(sock, "rejecting framebuffer geometry (too large)");
+    }
+
     uint32_t gem_handle = fb2->handles[0];
 
     /* virtio_gpu: transfer pixels from host GPU to guest RAM, then wait. */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -197,9 +197,12 @@ static int install_seccomp(void) {
         perror("cap_set_proc failed"); return -1;
     }
 
+    /* NOTE: open/openat are deliberately NOT allowed. The DRM device is opened
+     * once in main() before this filter is installed, and the grab loop only
+     * ever reuses that fd — so a compromised helper cannot open arbitrary files
+     * even though it holds CAP_SYS_ADMIN. */
     int allowed[] = {
         SCMP_SYS(read), SCMP_SYS(write), SCMP_SYS(close),
-        SCMP_SYS(openat), SCMP_SYS(open),
         SCMP_SYS(ioctl),       /* DRM ioctls */
         SCMP_SYS(sendto),      /* send() */
         SCMP_SYS(sendmsg),     /* sendmsg() for SCM_RIGHTS */
@@ -580,12 +583,34 @@ int main(int argc, char *argv[]) {
     (void)argc;
     (void)argv;
 
-    /* Validate socket fd */
+    /* Validate socket fd. F_GETFD only tells us fd 3 is open; SO_PEERCRED
+     * additionally requires it to be a connected AF_UNIX socket and tells us who
+     * is on the other end. This is defense-in-depth, not access control: it
+     * rejects being exec'd with fd 3 pointing at an arbitrary open file, or by a
+     * different user. Real access control to DRM scanout is enforced by the
+     * helper's install permissions (root:rustdesk-capture 0750), not here. */
     if (fcntl(HELPER_SOCKET_FD, F_GETFD) < 0) {
         fprintf(stderr,
                 "drmtap-helper: fd %d not valid — must be spawned by "
                 "libdrmtap, not run directly\n", HELPER_SOCKET_FD);
         return 1;
+    }
+    {
+        struct ucred peer;
+        socklen_t plen = sizeof(peer);
+        if (getsockopt(HELPER_SOCKET_FD, SOL_SOCKET, SO_PEERCRED,
+                       &peer, &plen) != 0) {
+            fprintf(stderr,
+                    "drmtap-helper: fd %d is not a socket — must be spawned by "
+                    "libdrmtap, not run directly\n", HELPER_SOCKET_FD);
+            return 1;
+        }
+        if (peer.uid != getuid()) {
+            fprintf(stderr,
+                    "drmtap-helper: refusing to serve peer uid %u (expected %u)\n",
+                    (unsigned)peer.uid, (unsigned)getuid());
+            return 1;
+        }
     }
 
     int sock = HELPER_SOCKET_FD;
@@ -621,31 +646,18 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    /* The whole point of this helper is to run privileged but confined. If we
-     * cannot establish the confinement, refuse to serve rather than run with
-     * CAP_SYS_ADMIN unconfined. */
-#ifdef HAVE_LIBCAP
-    if (drop_caps() != 0) {
-        fprintf(stderr,
-                "drmtap-helper: refusing to run: could not drop capabilities\n");
-        return 1;
-    }
-#endif
-
-#ifdef HAVE_SECCOMP
-    if (install_seccomp() != 0) {
-        fprintf(stderr,
-                "drmtap-helper: refusing to run: could not install seccomp filter\n");
-        return 1;
-    }
-#endif
-
     /* ================================================================
      * Persistent DRM fd — opened ONCE, reused for all frames.
      * This is the key performance optimization: avoids the expensive
      * open()/close() + drmSetClientCap() on every frame.
+     *
+     * Opened BEFORE seccomp so the filter can forbid open/openat entirely: the
+     * grab loop never opens another path, it only reuses this fd. Opened
+     * read-only because we issue only read ioctls (GetFB2 / PrimeHandleToFD /
+     * SetClientCap) and never modify KMS state; on the DRM master / CAP_SYS_ADMIN
+     * path these all work on an O_RDONLY fd.
      * ================================================================ */
-    int drm_fd = open(device, O_RDWR | O_CLOEXEC);
+    int drm_fd = open(device, O_RDONLY | O_CLOEXEC);
     if (drm_fd < 0) {
         fprintf(stderr, "drmtap-helper: failed to open %s: %s\n",
                 device, strerror(errno));
@@ -665,6 +677,26 @@ int main(int argc, char *argv[]) {
     }
     fprintf(stderr, "drmtap-helper: persistent fd=%d device=%s virtio=%d\n",
             drm_fd, device, is_virtio);
+
+    /* The whole point of this helper is to run privileged but confined. With the
+     * device already open, drop everything but CAP_SYS_ADMIN and install the
+     * seccomp filter. If we cannot establish the confinement, refuse to serve
+     * rather than run with CAP_SYS_ADMIN unconfined. */
+#ifdef HAVE_LIBCAP
+    if (drop_caps() != 0) {
+        fprintf(stderr,
+                "drmtap-helper: refusing to run: could not drop capabilities\n");
+        return 1;
+    }
+#endif
+
+#ifdef HAVE_SECCOMP
+    if (install_seccomp() != 0) {
+        fprintf(stderr,
+                "drmtap-helper: refusing to run: could not install seccomp filter\n");
+        return 1;
+    }
+#endif
 
     /* Event loop: receive commands, process with persistent fd */
     while (1) {

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -473,29 +473,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 #endif
     }
 
-    /* dumb_mmap — map the framebuffer in THIS process */
+    /* Build metadata from the framebuffer (independent of how we move pixels). */
     mapped_size = (size_t)fb2->pitches[0] * fb2->height;
-    struct drm_mode_map_dumb map = {0};
-    map.handle = gem_handle;
-    if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
-        drmModeFreeFB2(fb2);
-        return send_error(sock, "MODE_MAP_DUMB failed");
-    }
-    mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
-                  drm_fd, map.offset);
-    if (mapped == MAP_FAILED) {
-        drmModeFreeFB2(fb2);
-        return send_error(sock, "mmap failed");
-    }
-
-    /* Build metadata */
     struct grab_metadata meta = {0};
     meta.width = fb2->width;
     meta.height = fb2->height;
     meta.stride = fb2->pitches[0];
     meta.format = fb2->pixel_format;
     meta.fb_id = fb_id;
-    meta.data_size = (uint32_t)mapped_size;
     meta.modifier = fb2->modifier;
 
     drmModeFreeFB2(fb2);
@@ -507,6 +492,46 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     clock_gettime(CLOCK_REALTIME, &ts);
     meta.seq = seq_counter;
     meta.timestamp_ms = (uint64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+
+    int ret;
+
+    /* Preferred path for tiled (non-linear) framebuffers: export the GEM buffer
+     * as a DMA-BUF fd and pass it via SCM_RIGHTS so the parent can EGL-import and
+     * GPU-deswizzle it. Done BEFORE any MODE_MAP_DUMB on purpose: scanout buffers
+     * on some drivers are not dumb-mappable (nvidia-drm on Tegra fails
+     * MODE_MAP_DUMB with "Failed to lookup gem object"), so requiring a dumb map
+     * first would break capture on those GPUs even though the export works. */
+    if (meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio) {
+        int prime_fd = -1;
+        int prime_ret = drmPrimeHandleToFD(drm_fd, gem_handle,
+                                            DRM_CLOEXEC | DRM_RDWR, &prime_fd);
+        if (prime_ret == 0 && prime_fd >= 0) {
+            meta.flags = FLAG_HAS_DMABUF;
+            meta.data_size = 0;  /* no pixel data follows */
+            ret = send_fd(sock, prime_fd, &meta, sizeof(meta));
+            close(prime_fd);
+            return ret;
+        }
+        /* Export failed — fall through to the dumb-map pixel path. */
+        fprintf(stderr,
+            "drmtap-helper: drmPrimeHandleToFD failed (%d), falling back to pixels\n",
+            prime_ret);
+    }
+
+    /* Pixel-data path (linear modifier, virtio, or DMA-BUF export failed):
+     * dumb-map the framebuffer in this process and send the pixels directly. */
+    struct drm_mode_map_dumb map = {0};
+    map.handle = gem_handle;
+    if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
+        return send_error(sock, "MODE_MAP_DUMB failed");
+    }
+    mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
+                  drm_fd, map.offset);
+    if (mapped == MAP_FAILED) {
+        return send_error(sock, "mmap failed");
+    }
+    meta.flags = 0;
+    meta.data_size = (uint32_t)mapped_size;
 
     /* Debug: print pixel values to verify freshness */
     {
@@ -527,31 +552,6 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
         }
     }
 
-    int ret;
-
-    /* Non-linear modifier: export DMA-BUF fd via drmPrimeHandleToFD
-     * and send it via SCM_RIGHTS — the parent can then EGL-import it
-     * for GPU deswizzle. We still send the mmap'd pixels as fallback data. */
-    if (meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio) {
-        int prime_fd = -1;
-        int prime_ret = drmPrimeHandleToFD(drm_fd, gem_handle,
-                                            DRM_CLOEXEC | DRM_RDWR, &prime_fd);
-        if (prime_ret == 0 && prime_fd >= 0) {
-            meta.flags = FLAG_HAS_DMABUF;
-            meta.data_size = 0;  /* no pixel data follows */
-            ret = send_fd(sock, prime_fd, &meta, sizeof(meta));
-            close(prime_fd);
-            munmap(mapped, mapped_size);
-            return ret;
-        }
-        /* drmPrimeHandleToFD failed — fall through to pixel data path */
-        fprintf(stderr,
-            "drmtap-helper: drmPrimeHandleToFD failed (%d), falling back to pixels\n",
-            prime_ret);
-    }
-
-    /* Linear modifier (or Prime failed): send pixel data directly */
-    meta.flags = 0;
     ret = send_all(sock, &meta, sizeof(meta));
     if (ret == 0) {
         ret = send_all(sock, mapped, mapped_size);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -292,6 +292,16 @@ void drmtap_close(drmtap_ctx *ctx) {
         ctx->drm_fd = -1;
     }
 
+    /* Context-owned, reused-across-frames buffers (the deswizzle/EGL shadow and
+     * the helper-mode pixel receive buffer) must be released here —
+     * frame_release only drops per-frame state. */
+    free(ctx->deswizzle_buf);
+    ctx->deswizzle_buf = NULL;
+    ctx->deswizzle_buf_size = 0;
+    free(ctx->pixel_buf);
+    ctx->pixel_buf = NULL;
+    ctx->pixel_buf_size = 0;
+
     pthread_mutex_destroy(&ctx->lock);
     free(ctx);
 }

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -26,6 +26,13 @@
 /* Context structure (shared across modules)                                 */
 /* ========================================================================= */
 
+/* Upper bound on any CPU-side framebuffer buffer we allocate from a GetFB2
+ * report. Doubles as a DoS guard: a bogus or hostile width/height/stride
+ * (the framebuffer geometry is not under our control) cannot force an
+ * unbounded allocation. Sized for one 8K BGRA frame (7680 x 4320 x 4 bytes,
+ * ~126 MB). */
+#define DRMTAP_MAX_FB_BYTES ((size_t)7680 * 4320 * 4)
+
 struct drmtap_ctx {
     /* DRM device */
     int drm_fd;
@@ -73,9 +80,17 @@ struct drmtap_ctx {
     uint32_t fast_last_fb_id;       /* fb_id from last capture (change detect) */
     int      fast_initialized;      /* 1 = plane found, slots ready */
 
-    /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs) */
+    /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
+     * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;
+     * freed in drmtap_close(). */
     void *deswizzle_buf;
     size_t deswizzle_buf_size;
+
+    /* Helper-mode (V2) pixel receive buffer. Same model as deswizzle_buf:
+     * ctx-owned, grow-once, reused across grabs, capped, freed in
+     * drmtap_close() — never a per-frame malloc/free. */
+    void *pixel_buf;
+    size_t pixel_buf_size;
 
     /* Cached FB2 multi-plane info (for EGL CCS import) */
     uint32_t fb2_pitches[4];

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -89,6 +89,19 @@ struct drm_virtgpu_3d_wait {
     DRM_IOW(DRM_COMMAND_BASE + DRM_VIRTGPU_WAIT, \
             struct drm_virtgpu_3d_wait)
 #endif
+/* GETPARAM (used to detect virgl 3D) lives in <drm/virtgpu_drm.h>, not in
+ * <linux/virtio_gpu.h>; provide the uapi definition if it's missing. */
+#ifndef DRM_IOCTL_VIRTGPU_GETPARAM
+struct drm_virtgpu_getparam {
+    __u64 param;
+    __u64 value;
+};
+#define VIRTGPU_PARAM_3D_FEATURES 1
+#define DRM_VIRTGPU_GETPARAM 0x03
+#define DRM_IOCTL_VIRTGPU_GETPARAM \
+    DRM_IOWR(DRM_COMMAND_BASE + DRM_VIRTGPU_GETPARAM, \
+             struct drm_virtgpu_getparam)
+#endif
 #endif
 
 /* Socket fd inherited from parent (via socketpair) */
@@ -457,7 +470,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
     uint32_t gem_handle = fb2->handles[0];
 
-    /* virtio_gpu: transfer pixels from host GPU to guest RAM */
+    /* virtio_gpu: transfer pixels from host GPU to guest RAM, then wait. */
     if (is_virtio) {
 #ifdef __linux__
         struct drm_virtgpu_3d_transfer_from_host xfer = {0};
@@ -470,6 +483,30 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
             wait_args.handle = gem_handle;
             drmIoctl(drm_fd, DRM_IOCTL_VIRTGPU_WAIT, &wait_args);
         }
+#endif
+    }
+
+    /* Decide once whether this virtio-gpu is "plain" (no virgl 3D). Without 3D
+     * the scanout is a 2D dumb buffer in guest RAM that we can export as a
+     * DMA-BUF and let the parent map directly (zero-copy), instead of copying
+     * the whole framebuffer over the socket every frame. With virgl the scanout
+     * can be a host-side 3D resource, so we keep the proven copy-after-transfer
+     * path there until the zero-copy path is validated on virgl. */
+    static int virtio_plain = -1;
+    if (is_virtio && virtio_plain < 0) {
+        virtio_plain = 0;
+#if defined(__linux__) && defined(DRM_IOCTL_VIRTGPU_GETPARAM)
+        uint64_t features = 0;
+        struct drm_virtgpu_getparam gp = {
+            .param = VIRTGPU_PARAM_3D_FEATURES,
+            .value = (uint64_t)(uintptr_t)&features,
+        };
+        if (drmIoctl(drm_fd, DRM_IOCTL_VIRTGPU_GETPARAM, &gp) == 0 && features == 0) {
+            virtio_plain = 1;
+        }
+        fprintf(stderr, "drmtap-helper: virtio 3D features=%llu -> %s path\n",
+                (unsigned long long)features,
+                virtio_plain ? "zero-copy DMA-BUF" : "pixel-copy");
 #endif
     }
 
@@ -495,13 +532,20 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
     int ret;
 
-    /* Preferred path for tiled (non-linear) framebuffers: export the GEM buffer
-     * as a DMA-BUF fd and pass it via SCM_RIGHTS so the parent can EGL-import and
-     * GPU-deswizzle it. Done BEFORE any MODE_MAP_DUMB on purpose: scanout buffers
-     * on some drivers are not dumb-mappable (nvidia-drm on Tegra fails
-     * MODE_MAP_DUMB with "Failed to lookup gem object"), so requiring a dumb map
-     * first would break capture on those GPUs even though the export works. */
-    if (meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio) {
+    /* Export the GEM buffer as a DMA-BUF fd and pass it via SCM_RIGHTS so the
+     * parent maps it directly — no per-frame pixel copy over the socket. Two
+     * cases take this path:
+     *   - tiled (non-linear) non-virtio framebuffers: the parent EGL-imports and
+     *     GPU-deswizzles. Done BEFORE any MODE_MAP_DUMB on purpose: scanout
+     *     buffers on some drivers are not dumb-mappable (nvidia-drm on Tegra
+     *     fails MODE_MAP_DUMB with "Failed to lookup gem object"), so requiring a
+     *     dumb map first would break capture there even though the export works.
+     *   - plain virtio-gpu (guest-rendered, no host transfer): a linear scanout
+     *     in guest RAM the parent maps directly (no detile). Replaces the V2
+     *     pixel copy, dropping the helper's per-frame CPU cost.
+     * Either way, if the export fails we fall through to the dumb-map pixel path. */
+    if ((meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio)
+        || (is_virtio && virtio_plain)) {
         int prime_fd = -1;
         int prime_ret = drmPrimeHandleToFD(drm_fd, gem_handle,
                                             DRM_CLOEXEC | DRM_RDWR, &prime_fd);

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -468,6 +468,16 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
         return send_error(sock, "handles[0]==0 (CAP_SYS_ADMIN not set?)");
     }
 
+    /* Reject absurd geometry before any size computation: bound pitch*height so a
+     * hostile framebuffer cannot overflow size_t, and so the uint32 data_size we
+     * put on the wire cannot disagree with the size_t payload we send. Cap at one
+     * 8K BGRA frame (~126 MB, well under UINT32_MAX). */
+    if (fb2->pitches[0] == 0 || fb2->height == 0 ||
+        (size_t)fb2->height > ((size_t)7680 * 4320 * 4) / fb2->pitches[0]) {
+        drmModeFreeFB2(fb2);
+        return send_error(sock, "rejecting framebuffer geometry (too large)");
+    }
+
     uint32_t gem_handle = fb2->handles[0];
 
     /* virtio_gpu: transfer pixels from host GPU to guest RAM, then wait. */

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -197,9 +197,12 @@ static int install_seccomp(void) {
         perror("cap_set_proc failed"); return -1;
     }
 
+    /* NOTE: open/openat are deliberately NOT allowed. The DRM device is opened
+     * once in main() before this filter is installed, and the grab loop only
+     * ever reuses that fd — so a compromised helper cannot open arbitrary files
+     * even though it holds CAP_SYS_ADMIN. */
     int allowed[] = {
         SCMP_SYS(read), SCMP_SYS(write), SCMP_SYS(close),
-        SCMP_SYS(openat), SCMP_SYS(open),
         SCMP_SYS(ioctl),       /* DRM ioctls */
         SCMP_SYS(sendto),      /* send() */
         SCMP_SYS(sendmsg),     /* sendmsg() for SCM_RIGHTS */
@@ -580,12 +583,34 @@ int main(int argc, char *argv[]) {
     (void)argc;
     (void)argv;
 
-    /* Validate socket fd */
+    /* Validate socket fd. F_GETFD only tells us fd 3 is open; SO_PEERCRED
+     * additionally requires it to be a connected AF_UNIX socket and tells us who
+     * is on the other end. This is defense-in-depth, not access control: it
+     * rejects being exec'd with fd 3 pointing at an arbitrary open file, or by a
+     * different user. Real access control to DRM scanout is enforced by the
+     * helper's install permissions (root:rustdesk-capture 0750), not here. */
     if (fcntl(HELPER_SOCKET_FD, F_GETFD) < 0) {
         fprintf(stderr,
                 "drmtap-helper: fd %d not valid — must be spawned by "
                 "libdrmtap, not run directly\n", HELPER_SOCKET_FD);
         return 1;
+    }
+    {
+        struct ucred peer;
+        socklen_t plen = sizeof(peer);
+        if (getsockopt(HELPER_SOCKET_FD, SOL_SOCKET, SO_PEERCRED,
+                       &peer, &plen) != 0) {
+            fprintf(stderr,
+                    "drmtap-helper: fd %d is not a socket — must be spawned by "
+                    "libdrmtap, not run directly\n", HELPER_SOCKET_FD);
+            return 1;
+        }
+        if (peer.uid != getuid()) {
+            fprintf(stderr,
+                    "drmtap-helper: refusing to serve peer uid %u (expected %u)\n",
+                    (unsigned)peer.uid, (unsigned)getuid());
+            return 1;
+        }
     }
 
     int sock = HELPER_SOCKET_FD;
@@ -621,31 +646,18 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    /* The whole point of this helper is to run privileged but confined. If we
-     * cannot establish the confinement, refuse to serve rather than run with
-     * CAP_SYS_ADMIN unconfined. */
-#ifdef HAVE_LIBCAP
-    if (drop_caps() != 0) {
-        fprintf(stderr,
-                "drmtap-helper: refusing to run: could not drop capabilities\n");
-        return 1;
-    }
-#endif
-
-#ifdef HAVE_SECCOMP
-    if (install_seccomp() != 0) {
-        fprintf(stderr,
-                "drmtap-helper: refusing to run: could not install seccomp filter\n");
-        return 1;
-    }
-#endif
-
     /* ================================================================
      * Persistent DRM fd — opened ONCE, reused for all frames.
      * This is the key performance optimization: avoids the expensive
      * open()/close() + drmSetClientCap() on every frame.
+     *
+     * Opened BEFORE seccomp so the filter can forbid open/openat entirely: the
+     * grab loop never opens another path, it only reuses this fd. Opened
+     * read-only because we issue only read ioctls (GetFB2 / PrimeHandleToFD /
+     * SetClientCap) and never modify KMS state; on the DRM master / CAP_SYS_ADMIN
+     * path these all work on an O_RDONLY fd.
      * ================================================================ */
-    int drm_fd = open(device, O_RDWR | O_CLOEXEC);
+    int drm_fd = open(device, O_RDONLY | O_CLOEXEC);
     if (drm_fd < 0) {
         fprintf(stderr, "drmtap-helper: failed to open %s: %s\n",
                 device, strerror(errno));
@@ -665,6 +677,26 @@ int main(int argc, char *argv[]) {
     }
     fprintf(stderr, "drmtap-helper: persistent fd=%d device=%s virtio=%d\n",
             drm_fd, device, is_virtio);
+
+    /* The whole point of this helper is to run privileged but confined. With the
+     * device already open, drop everything but CAP_SYS_ADMIN and install the
+     * seccomp filter. If we cannot establish the confinement, refuse to serve
+     * rather than run with CAP_SYS_ADMIN unconfined. */
+#ifdef HAVE_LIBCAP
+    if (drop_caps() != 0) {
+        fprintf(stderr,
+                "drmtap-helper: refusing to run: could not drop capabilities\n");
+        return 1;
+    }
+#endif
+
+#ifdef HAVE_SECCOMP
+    if (install_seccomp() != 0) {
+        fprintf(stderr,
+                "drmtap-helper: refusing to run: could not install seccomp filter\n");
+        return 1;
+    }
+#endif
 
     /* Event loop: receive commands, process with persistent fd */
     while (1) {

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -473,29 +473,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 #endif
     }
 
-    /* dumb_mmap — map the framebuffer in THIS process */
+    /* Build metadata from the framebuffer (independent of how we move pixels). */
     mapped_size = (size_t)fb2->pitches[0] * fb2->height;
-    struct drm_mode_map_dumb map = {0};
-    map.handle = gem_handle;
-    if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
-        drmModeFreeFB2(fb2);
-        return send_error(sock, "MODE_MAP_DUMB failed");
-    }
-    mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
-                  drm_fd, map.offset);
-    if (mapped == MAP_FAILED) {
-        drmModeFreeFB2(fb2);
-        return send_error(sock, "mmap failed");
-    }
-
-    /* Build metadata */
     struct grab_metadata meta = {0};
     meta.width = fb2->width;
     meta.height = fb2->height;
     meta.stride = fb2->pitches[0];
     meta.format = fb2->pixel_format;
     meta.fb_id = fb_id;
-    meta.data_size = (uint32_t)mapped_size;
     meta.modifier = fb2->modifier;
 
     drmModeFreeFB2(fb2);
@@ -507,6 +492,46 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     clock_gettime(CLOCK_REALTIME, &ts);
     meta.seq = seq_counter;
     meta.timestamp_ms = (uint64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+
+    int ret;
+
+    /* Preferred path for tiled (non-linear) framebuffers: export the GEM buffer
+     * as a DMA-BUF fd and pass it via SCM_RIGHTS so the parent can EGL-import and
+     * GPU-deswizzle it. Done BEFORE any MODE_MAP_DUMB on purpose: scanout buffers
+     * on some drivers are not dumb-mappable (nvidia-drm on Tegra fails
+     * MODE_MAP_DUMB with "Failed to lookup gem object"), so requiring a dumb map
+     * first would break capture on those GPUs even though the export works. */
+    if (meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio) {
+        int prime_fd = -1;
+        int prime_ret = drmPrimeHandleToFD(drm_fd, gem_handle,
+                                            DRM_CLOEXEC | DRM_RDWR, &prime_fd);
+        if (prime_ret == 0 && prime_fd >= 0) {
+            meta.flags = FLAG_HAS_DMABUF;
+            meta.data_size = 0;  /* no pixel data follows */
+            ret = send_fd(sock, prime_fd, &meta, sizeof(meta));
+            close(prime_fd);
+            return ret;
+        }
+        /* Export failed — fall through to the dumb-map pixel path. */
+        fprintf(stderr,
+            "drmtap-helper: drmPrimeHandleToFD failed (%d), falling back to pixels\n",
+            prime_ret);
+    }
+
+    /* Pixel-data path (linear modifier, virtio, or DMA-BUF export failed):
+     * dumb-map the framebuffer in this process and send the pixels directly. */
+    struct drm_mode_map_dumb map = {0};
+    map.handle = gem_handle;
+    if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
+        return send_error(sock, "MODE_MAP_DUMB failed");
+    }
+    mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
+                  drm_fd, map.offset);
+    if (mapped == MAP_FAILED) {
+        return send_error(sock, "mmap failed");
+    }
+    meta.flags = 0;
+    meta.data_size = (uint32_t)mapped_size;
 
     /* Debug: print pixel values to verify freshness */
     {
@@ -527,31 +552,6 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
         }
     }
 
-    int ret;
-
-    /* Non-linear modifier: export DMA-BUF fd via drmPrimeHandleToFD
-     * and send it via SCM_RIGHTS — the parent can then EGL-import it
-     * for GPU deswizzle. We still send the mmap'd pixels as fallback data. */
-    if (meta.modifier != 0 /* DRM_FORMAT_MOD_LINEAR */ && !is_virtio) {
-        int prime_fd = -1;
-        int prime_ret = drmPrimeHandleToFD(drm_fd, gem_handle,
-                                            DRM_CLOEXEC | DRM_RDWR, &prime_fd);
-        if (prime_ret == 0 && prime_fd >= 0) {
-            meta.flags = FLAG_HAS_DMABUF;
-            meta.data_size = 0;  /* no pixel data follows */
-            ret = send_fd(sock, prime_fd, &meta, sizeof(meta));
-            close(prime_fd);
-            munmap(mapped, mapped_size);
-            return ret;
-        }
-        /* drmPrimeHandleToFD failed — fall through to pixel data path */
-        fprintf(stderr,
-            "drmtap-helper: drmPrimeHandleToFD failed (%d), falling back to pixels\n",
-            prime_ret);
-    }
-
-    /* Linear modifier (or Prime failed): send pixel data directly */
-    meta.flags = 0;
     ret = send_all(sock, &meta, sizeof(meta));
     if (ret == 0) {
         ret = send_all(sock, mapped, mapped_size);

--- a/meson.build
+++ b/meson.build
@@ -129,9 +129,10 @@ endif
 
 # Exploit-mitigation hardening for the privileged (CAP_SYS_ADMIN) helper.
 helper_c_args += '-fstack-protector-strong'
-# _FORTIFY_SOURCE needs an optimized build; at -O0 it only warns, and the CI
-# build uses -Werror, so gate it on optimization being enabled.
-if get_option('optimization') not in ['0', 'g']
+# _FORTIFY_SOURCE needs an optimized build; at -O0 — and in 'plain' mode, where
+# Meson adds no -O flag at all — it only warns, and the CI build uses -Werror, so
+# enable it only when optimization is on. -Og ('g') satisfies Fortify, so keep it.
+if get_option('optimization') not in ['plain', '0']
     helper_c_args += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=2']
 endif
 helper_link_args = ['-Wl,-z,relro,-z,now']

--- a/meson.build
+++ b/meson.build
@@ -127,10 +127,21 @@ if libcap_dep.found()
     helper_c_args += '-DHAVE_LIBCAP=1'
 endif
 
+# Exploit-mitigation hardening for the privileged (CAP_SYS_ADMIN) helper.
+helper_c_args += '-fstack-protector-strong'
+# _FORTIFY_SOURCE needs an optimized build; at -O0 it only warns, and the CI
+# build uses -Werror, so gate it on optimization being enabled.
+if get_option('optimization') not in ['0', 'g']
+    helper_c_args += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=2']
+endif
+helper_link_args = ['-Wl,-z,relro,-z,now']
+
 executable('drmtap-helper',
     'helper/drmtap-helper.c',
     dependencies: helper_deps,
     c_args: helper_c_args,
+    link_args: helper_link_args,
+    pie: true,
     install: true,
     install_dir: get_option('libexecdir'),
 )

--- a/meson.build
+++ b/meson.build
@@ -184,13 +184,21 @@ test('deswizzle', test_deswizzle, suite: 'unit')
 test('helper', test_helper, suite: 'unit')
 
 # Integration tests (need vkms or real GPU)
+# LSan: suppress the deliberate process-lifetime EGL/Mesa display allocation
+# (see tests/lsan.supp) so a real leak in a sanitized run stands out.
+lsan_supp = meson.project_source_root() / 'tests' / 'lsan.supp'
+integration_env = [
+    'DRM_DEVICE=/dev/dri/card1',
+    'LSAN_OPTIONS=suppressions=' + lsan_supp,
+]
+
 test('enumerate', test_enumerate, suite: 'integration',
-    env: ['DRM_DEVICE=/dev/dri/card1'],
+    env: integration_env,
     is_parallel: false,
 )
 
 test('capture', test_capture, suite: 'integration',
-    env: ['DRM_DEVICE=/dev/dri/card1'],
+    env: integration_env,
     is_parallel: false,
 )
 

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -73,6 +73,8 @@ typedef struct {
     uint32_t gem_handle;    /* GEM handle (needs close) */
     int used_dumb_map;      /* 1 if mapped via dumb buffer (virtio_gpu) */
     int is_heap_buf;        /* 1 if mapped is malloc'd (helper v2 pixel path) */
+    int sync_started;       /* 1 if dmabuf_sync_start succeeded — release issues
+                               the matching SYNC_END only then (no END w/o START) */
 } frame_priv_t;
 
 /* ========================================================================= */
@@ -280,6 +282,21 @@ static void *virtio_dumb_mmap(drmtap_ctx *ctx, uint32_t handle, size_t size) {
 /* Core capture logic                                                        */
 /* ========================================================================= */
 
+/* Reject framebuffer geometry whose byte size (stride * height) would overflow
+ * size_t (a concern on 32-bit builds) or exceed DRMTAP_MAX_FB_BYTES, before any
+ * downstream multiply feeds an allocation or mmap. stride/height come from
+ * drmModeGetFB2 or the helper wire and are not under our control, so validating
+ * once at each entry point keeps all later stride*height computations safe. */
+static int validate_fb_size(uint32_t stride, uint32_t height) {
+    if (stride == 0 || height == 0) {
+        return -EINVAL;
+    }
+    if ((size_t)height > DRMTAP_MAX_FB_BYTES / stride) {
+        return -EFBIG;
+    }
+    return 0;
+}
+
 // Internal capture that populates frame_info
 // If do_mmap is true, also maps the pixel data to frame->data
 static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
@@ -320,6 +337,14 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                      fb2->width, fb2->height,
                      (const char *)&fb2->pixel_format,
                      (unsigned long)fb2->modifier);
+
+    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    if (ret != 0) {
+        drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
+                         fb2->width, fb2->height, fb2->pitches[0]);
+        drmModeFreeFB2(fb2);
+        return ret;
+    }
 
     /* Cache multi-plane info for EGL CCS import */
     ctx->fb2_num_planes = 0;
@@ -406,6 +431,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         frame->modifier = hresult.wire.modifier;
         frame->fb_id = hresult.wire.fb_id;
 
+        /* The helper validates its own geometry, but it sends stride/height over
+         * the wire — re-check before we mmap/size anything from those values. */
+        ret = validate_fb_size(frame->stride, frame->height);
+        if (ret != 0) {
+            drmtap_set_error(ctx, "helper sent invalid geometry %ux%u stride=%u",
+                             frame->width, frame->height, frame->stride);
+            free(priv);
+            drmModeFreeFB2(fb2);
+            return ret;
+        }
+
         /* V3: helper sent DMA-BUF fd via SCM_RIGHTS */
         if (hresult.dmabuf_fd >= 0) {
             /* The helper passed a DMA-BUF fd instead of pixels; ctx->pixel_buf
@@ -434,7 +470,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                  * cache-coherency is correct (stale pixels otherwise, notably on
                  * ARM/Jetson). The matching SYNC_END runs in the cleanup block. */
                 priv->used_dumb_map = 0;
-                dmabuf_sync_start(dmabuf_fd);
+                priv->sync_started = (dmabuf_sync_start(dmabuf_fd) == 0);
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap'd DMA-BUF fd=%d (%zu bytes), "
@@ -539,9 +575,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             drmtap_debug_log(ctx, "mmap failed, falling back to zero-copy");
             frame->data = NULL;
         } else {
-            /* Unconditionally invalidate CPU caches using SYNC_START */
-            /* Crucial for virtio_gpu where the transfer arrives in system RAM asynchronously */
-            dmabuf_sync_start(prime_fd);
+            /* Invalidate CPU caches with SYNC_START and remember it succeeded so
+             * release issues the matching SYNC_END (and only then). Crucial for
+             * virtio_gpu where the transfer arrives in system RAM asynchronously. */
+            priv->sync_started = (dmabuf_sync_start(prime_fd) == 0);
 
             priv->mapped = mapped;
             priv->mapped_size = size;
@@ -594,18 +631,21 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     #define DRM_FMT_AR30 0x30335241u  /* fourcc('A','R','3','0') */
     #define DRM_FMT_XR24 0x34325258u  /* fourcc('X','R','2','4') */
 
-    /* Ensure shadow buffer is allocated (grow-once, capped — see ensure_buf).
-     * This runs before both the EGL and CPU detile paths, so the cap also
-     * bounds the EGL output (width*4*height <= stride*height = size). */
+    /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
+     * see ensure_buf). frame->stride/height are validated at every entry point
+     * (validate_fb_size), so this multiply cannot overflow. NOTE: this does NOT
+     * bound the EGL output, which is always 4-byte RGBA — a sub-4-byte source
+     * (e.g. RG16) can expand past stride*height, so the EGL path caps egl_size
+     * separately below. */
     size_t size = (size_t)frame->stride * frame->height;
-    int br = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
-    if (br != 0) {
-        if (br == -EFBIG) {
+    int bres = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    if (bres != 0) {
+        if (bres == -EFBIG) {
             drmtap_set_error(ctx,
                 "framebuffer too large for deswizzle: %zu bytes (max %zu)",
                 size, (size_t)DRMTAP_MAX_FB_BYTES);
         }
-        return br;
+        return bres;
     }
 
     /* --- EGL path: import DMA-BUF, GPU renders to linear RGBA ---
@@ -631,6 +671,15 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                                           modifier, &egl_data, &egl_size);
         drmtap_debug_log(ctx, "EGL convert: ret=%d data=%p", ret, egl_data);
         if (ret == 0 && egl_data) {
+            /* The EGL output is 4-byte RGBA and can exceed the source
+             * stride*height for sub-4-byte formats, so cap it independently
+             * before adopting it as the context buffer. */
+            if (egl_size > DRMTAP_MAX_FB_BYTES) {
+                free(egl_data);
+                drmtap_set_error(ctx, "EGL output too large: %zu bytes (max %zu)",
+                                 egl_size, (size_t)DRMTAP_MAX_FB_BYTES);
+                return -EFBIG;
+            }
             /* Store in ctx for reuse / cleanup */
             free(ctx->deswizzle_buf);
             ctx->deswizzle_buf = egl_data;
@@ -727,7 +776,7 @@ void drmtap_frame_release(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             if (priv->is_heap_buf) {
                 free(priv->mapped);
             } else if (priv->mapped != MAP_FAILED) {
-                if (!priv->used_dumb_map && priv->prime_fd >= 0) {
+                if (priv->sync_started && priv->prime_fd >= 0) {
                     dmabuf_sync_end(priv->prime_fd);
                 }
                 munmap(priv->mapped, priv->mapped_size);
@@ -922,6 +971,14 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         drmModeFreeFB2(fb2);
         drmtap_set_error(ctx, "fast2: handles[0]==0, no CAP_SYS_ADMIN");
         return -EACCES;
+    }
+
+    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    if (ret != 0) {
+        drmtap_set_error(ctx, "fast2: rejecting geometry %ux%u stride=%u",
+                         fb2->width, fb2->height, fb2->pitches[0]);
+        drmModeFreeFB2(fb2);
+        return ret;
     }
 
     /* Export DMA-BUF */

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -192,6 +192,32 @@ static int dmabuf_sync_end(int fd) {
     return ioctl(fd, DMA_BUF_IOCTL_SYNC, &sync);
 }
 
+/* Ensure *buf holds at least `size` bytes, growing once and never shrinking so
+ * steady-state capture reuses one allocation instead of malloc/free per frame.
+ * Caps the allocation at DRMTAP_MAX_FB_BYTES as a guard against a bogus/hostile
+ * framebuffer geometry forcing an unbounded request. Contents are not preserved
+ * across a grow. Returns 0, -EINVAL (zero size), -EFBIG (over the cap), or
+ * -ENOMEM. */
+static int ensure_buf(void **buf, size_t *cap, size_t size) {
+    if (size == 0) {
+        return -EINVAL;
+    }
+    if (size > DRMTAP_MAX_FB_BYTES) {
+        return -EFBIG;
+    }
+    if (*buf && *cap >= size) {
+        return 0;
+    }
+    free(*buf);
+    *buf = malloc(size);
+    if (!*buf) {
+        *cap = 0;
+        return -ENOMEM;
+    }
+    *cap = size;
+    return 0;
+}
+
 /* ========================================================================= */
 /* virtio_gpu transfer helpers                                               */
 /* ========================================================================= */
@@ -327,19 +353,26 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         drmtap_debug_log(ctx,
             "No CAP_SYS_ADMIN (needs helper), trying helper...");
 
-        /* Allocate pixel buffer for helper to fill */
+        /* Receive buffer for the helper to fill. ctx-owned, grow-once and
+         * reused across grabs (never per-frame churn), capped — see ensure_buf.
+         * Freed in drmtap_close(). */
         size_t buf_size = (size_t)fb2->pitches[0] * fb2->height;
-        void *pixel_buf = malloc(buf_size);
-        if (!pixel_buf) {
+        ret = ensure_buf(&ctx->pixel_buf, &ctx->pixel_buf_size, buf_size);
+        if (ret != 0) {
+            if (ret == -EFBIG) {
+                drmtap_set_error(ctx,
+                    "framebuffer too large: %zu bytes (max %zu)",
+                    buf_size, (size_t)DRMTAP_MAX_FB_BYTES);
+            }
             drmModeFreeFB2(fb2);
-            return -ENOMEM;
+            return ret;
         }
+        void *pixel_buf = ctx->pixel_buf;
 
         /* Helper reads pixels in its own process and sends via socket */
         helper_grab_result_t hresult;
         ret = drmtap_helper_grab(ctx, &hresult, pixel_buf, buf_size);
         if (ret < 0) {
-            free(pixel_buf);
             drmtap_set_error(ctx,
                 "No CAP_SYS_ADMIN and helper failed (ret=%d). "
                 "Install the helper: sudo cp drmtap-helper /usr/local/bin/ "
@@ -352,17 +385,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* Allocate private state */
         priv = calloc(1, sizeof(frame_priv_t));
         if (!priv) {
-            free(pixel_buf);
             drmModeFreeFB2(fb2);
             return -ENOMEM;
         }
         priv->helper_drm_fd = -1;
         priv->prime_fd = -1;
         priv->gem_handle = 0;
-        priv->mapped = pixel_buf;       /* reuse mapped field for free() */
-        priv->mapped_size = buf_size;
+        /* pixel_buf is ctx-owned and reused; priv must never free/munmap it. */
+        priv->mapped = MAP_FAILED;
+        priv->mapped_size = 0;
         priv->used_dumb_map = 1;        /* skip dmabuf_sync in release */
-        priv->is_heap_buf = 1;          /* free() instead of munmap() */
+        priv->is_heap_buf = 0;          /* ctx owns the buffer; do not free */
 
         /* Fill frame info from helper metadata */
         memset(frame, 0, sizeof(*frame));
@@ -375,33 +408,18 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
         /* V3: helper sent DMA-BUF fd via SCM_RIGHTS */
         if (hresult.dmabuf_fd >= 0) {
-            free(pixel_buf);  /* Don't need pixel buffer */
-            /* priv->mapped aliased pixel_buf (set above for the heap-buffer
-             * path); it is now dangling. Clear it before the cleanup block so we
-             * don't munmap a freed pointer. priv is freshly calloc'd, so there
-             * is no real previous-frame mmap to release here anyway. */
-            priv->mapped = MAP_FAILED;
-            priv->is_heap_buf = 0;
-
+            /* The helper passed a DMA-BUF fd instead of pixels; ctx->pixel_buf
+             * stays allocated for reuse on the next grab. priv is freshly
+             * calloc'd (mapped=MAP_FAILED, prime_fd=-1), so there is no prior
+             * mapping to release here. */
             int dmabuf_fd = hresult.dmabuf_fd;
             size_t mmap_size = (size_t)frame->stride * frame->height;
-
-            /* Clean up previous frame's DMA-BUF resources (they change every frame
-             * because the compositor flips between framebuffers) */
-            if (priv->mapped != MAP_FAILED && priv->mapped != NULL) {
-                munmap(priv->mapped, priv->mapped_size);
-                priv->mapped = MAP_FAILED;
-            }
-            if (priv->prime_fd >= 0 && priv->prime_fd != dmabuf_fd) {
-                close(priv->prime_fd);
-            }
 
             /* mmap the DMA-BUF in the parent */
             void *mapped = mmap(NULL, mmap_size, PROT_READ, MAP_SHARED,
                                 dmabuf_fd, 0);
 
             priv->prime_fd = dmabuf_fd;
-            priv->is_heap_buf = 0;
 
             if (mapped != MAP_FAILED) {
                 priv->mapped = mapped;
@@ -409,6 +427,14 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 frame->data = mapped;
                 frame->dma_buf_fd = dmabuf_fd;
                 frame->_priv = priv;
+
+                /* This is a real DMA-BUF the helper exported via PrimeHandleToFD,
+                 * not a dumb buffer. Clear the dumb-map flag inherited from the
+                 * heap path above and bracket the CPU read with DMA_BUF_SYNC so
+                 * cache-coherency is correct (stale pixels otherwise, notably on
+                 * ARM/Jetson). The matching SYNC_END runs in the cleanup block. */
+                priv->used_dumb_map = 0;
+                dmabuf_sync_start(dmabuf_fd);
 
                 drmtap_debug_log(ctx,
                     "helper V3: mmap'd DMA-BUF fd=%d (%zu bytes), "
@@ -439,7 +465,9 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             return 0;
         }
 
-        /* V2 fallback: pixel data received via socket */
+        /* V2 fallback: pixel data received into ctx->pixel_buf. frame->data
+         * borrows that buffer — valid until the next grab or drmtap_close();
+         * priv must not free it (is_heap_buf=0, mapped=MAP_FAILED above). */
         frame->dma_buf_fd = -1;
         frame->data = pixel_buf;
         frame->_priv = priv;
@@ -566,16 +594,18 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     #define DRM_FMT_AR30 0x30335241u  /* fourcc('A','R','3','0') */
     #define DRM_FMT_XR24 0x34325258u  /* fourcc('X','R','2','4') */
 
-    /* Ensure shadow buffer is allocated */
+    /* Ensure shadow buffer is allocated (grow-once, capped — see ensure_buf).
+     * This runs before both the EGL and CPU detile paths, so the cap also
+     * bounds the EGL output (width*4*height <= stride*height = size). */
     size_t size = (size_t)frame->stride * frame->height;
-    if (ctx->deswizzle_buf_size < size) {
-        free(ctx->deswizzle_buf);
-        ctx->deswizzle_buf = malloc(size);
-        if (!ctx->deswizzle_buf) {
-            ctx->deswizzle_buf_size = 0;
-            return -ENOMEM;
+    int br = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    if (br != 0) {
+        if (br == -EFBIG) {
+            drmtap_set_error(ctx,
+                "framebuffer too large for deswizzle: %zu bytes (max %zu)",
+                size, (size_t)DRMTAP_MAX_FB_BYTES);
         }
-        ctx->deswizzle_buf_size = size;
+        return br;
     }
 
     /* --- EGL path: import DMA-BUF, GPU renders to linear RGBA ---

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -501,6 +501,19 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             return 0;
         }
 
+        /* The V2 payload must be exactly one full frame. ctx->pixel_buf is reused
+         * across grabs, so accepting a short payload would expose stale pixels
+         * from a previous frame behind the advertised stride*height geometry.
+         * (frame->stride/height were validated above, so this can't overflow.) */
+        if (hresult.wire.data_size != (size_t)frame->stride * frame->height) {
+            drmtap_set_error(ctx, "helper V2 payload %u != expected %zu bytes",
+                             hresult.wire.data_size,
+                             (size_t)frame->stride * frame->height);
+            free(priv);
+            drmModeFreeFB2(fb2);
+            return -EPROTO;
+        }
+
         /* V2 fallback: pixel data received into ctx->pixel_buf. frame->data
          * borrows that buffer — valid until the next grab or drmtap_close();
          * priv must not free it (is_heap_buf=0, mapped=MAP_FAILED above). */

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -292,6 +292,16 @@ void drmtap_close(drmtap_ctx *ctx) {
         ctx->drm_fd = -1;
     }
 
+    /* Context-owned, reused-across-frames buffers (the deswizzle/EGL shadow and
+     * the helper-mode pixel receive buffer) must be released here —
+     * frame_release only drops per-frame state. */
+    free(ctx->deswizzle_buf);
+    ctx->deswizzle_buf = NULL;
+    ctx->deswizzle_buf_size = 0;
+    free(ctx->pixel_buf);
+    ctx->pixel_buf = NULL;
+    ctx->pixel_buf_size = 0;
+
     pthread_mutex_destroy(&ctx->lock);
     free(ctx);
 }

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -26,6 +26,13 @@
 /* Context structure (shared across modules)                                 */
 /* ========================================================================= */
 
+/* Upper bound on any CPU-side framebuffer buffer we allocate from a GetFB2
+ * report. Doubles as a DoS guard: a bogus or hostile width/height/stride
+ * (the framebuffer geometry is not under our control) cannot force an
+ * unbounded allocation. Sized for one 8K BGRA frame (7680 x 4320 x 4 bytes,
+ * ~126 MB). */
+#define DRMTAP_MAX_FB_BYTES ((size_t)7680 * 4320 * 4)
+
 struct drmtap_ctx {
     /* DRM device */
     int drm_fd;
@@ -73,9 +80,17 @@ struct drmtap_ctx {
     uint32_t fast_last_fb_id;       /* fb_id from last capture (change detect) */
     int      fast_initialized;      /* 1 = plane found, slots ready */
 
-    /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs) */
+    /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
+     * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;
+     * freed in drmtap_close(). */
     void *deswizzle_buf;
     size_t deswizzle_buf_size;
+
+    /* Helper-mode (V2) pixel receive buffer. Same model as deswizzle_buf:
+     * ctx-owned, grow-once, reused across grabs, capped, freed in
+     * drmtap_close() — never a per-frame malloc/free. */
+    void *pixel_buf;
+    size_t pixel_buf_size;
 
     /* Cached FB2 multi-plane info (for EGL CCS import) */
     uint32_t fb2_pitches[4];

--- a/tests/lsan.supp
+++ b/tests/lsan.supp
@@ -1,0 +1,12 @@
+# LeakSanitizer suppressions for libdrmtap integration tests.
+#
+# drmtap_gpu_egl_available() calls eglInitialize() on a process-shared
+# EGLDisplay and deliberately never calls eglTerminate(): terminating the
+# shared display would invalidate it for other capture threads mid-detile and
+# corrupt their output (see the comment in src/gpu_egl.c). The EGL/Mesa driver
+# state allocated by eglInitialize is therefore intentionally kept alive for the
+# whole process lifetime and reclaimed by the OS at exit. It is not a leak we
+# can or should free, so suppress it here — this keeps the ASan integration run
+# meaningful (a real, fixable leak still shows up instead of drowning in EGL
+# driver allocations).
+leak:drmtap_gpu_egl_available


### PR DESCRIPTION
## What this does

Hardens the privileged `drmtap-helper` and fixes several capture-path correctness issues. Most items come from the RustDesk maintainer's security review of the upstreaming PR (rustdesk/rustdesk#15420); a few more were found while validating the changes on real hardware (Intel, Nvidia Tegra, virtio).

Each change was validated end to end, not just compiled — see the matrix below.

## Changes

**Helper hardening**
- **#2** Open the DRM node *before* installing the seccomp filter, then drop `open`/`openat` from the allowlist entirely. The grab loop only ever reuses that one fd, so a compromised helper can't open arbitrary files even with `CAP_SYS_ADMIN`.
- **#4** Open the node `O_RDONLY` — capture only issues read ioctls (`GetFB2` / `PrimeHandleToFD` / `SetClientCap`) and never modifies KMS state.
- **#1** Check the inherited socket with `SO_PEERCRED`: it must be a connected `AF_UNIX` socket whose peer uid matches our own. Defense-in-depth (real access control is the install permissions), but it rejects being exec'd with fd 3 pointing at an arbitrary file or by another user.
- **#3** Exploit-mitigation compile flags for the helper (stack-protector-strong, `_FORTIFY_SOURCE=2`, PIE, full RELRO/BIND_NOW).

**Capture-path correctness**
- **#12** Export the DMA-BUF *before* `MODE_MAP_DUMB`. The helper used to dumb-map unconditionally and fail hard, which broke helper-mode (non-root) capture on `nvidia-drm`/Tegra (scanout buffers aren't dumb-mappable). Now tiled modifiers export first; `MODE_MAP_DUMB` is only the linear/virtio fallback.
- **#10** Bracket the V3 helper-mapped DMA-BUF CPU read with `DMA_BUF_SYNC_START/END` (clear the inherited `used_dumb_map`), matching the non-helper path — avoids stale pixels on non-coherent GPUs.
- **#11** Make the deswizzle/EGL buffer and the helper-mode pixel buffer context-owned, grow-once-and-cap (`DRMTAP_MAX_FB_BYTES`, a DoS guard against hostile framebuffer geometry), reused across grabs and freed in `drmtap_close()`. Fixes a real ~33 MB leak at close (found via ASan) and removes per-frame churn. Adds `tests/lsan.supp` so the sanitized run surfaces real leaks instead of the deliberate `eglInitialize` allocation.

**Performance**
- **#14** On virtio_gpu the helper used to copy the whole framebuffer over the socket every frame (~14% of one core). When the device has no virgl 3D (`VIRTGPU_PARAM_3D_FEATURES == 0`) the scanout is a 2D dumb buffer in guest RAM, so the helper now exports it as a DMA-BUF and passes the fd (zero-copy), like the tiled GPUs. virgl keeps the proven copy path until validated there.

## Validation

| Platform | Arch | Path | Result |
|---|---|---|---|
| Intel i915 (4K) | x86_64 | V3 DMA-BUF + EGL | release + ASan/UBSan integration + cursor clean; forced-V2 reuse verified |
| Nvidia Orin Nano (1080p) | aarch64 | V3 DMA-BUF + EGL (helper) | capture works after #12; image + advancing clock verified visually |
| virtio_gpu (Ubuntu 26.04 VM) | x86_64 | V2 pixel (helper) | `is_virtio` + V2 `pixel_buf` exercised natively; image verified |

Gates green on all: meson release+werror, meson debug+asan+ubsan+werror (unit + integration, no leaks), cppcheck, and the Rust crate build/test/package.

CPU/throughput (helper path, CPU as % of one core):

| Platform | @60fps total | helper | max fps |
|---|---|---|---|
| i915 4K | ~16% | 0.4% | ~115 |
| Orin Nano 1080p | ~11% | 0.4% | ~236 |
| virtio 1280×800 (before #14) | ~19% | 14% | ~236 |
| virtio 1280×800 (after #14) | ~1.2% | 0.7% | ~236 |

V3 zero-copy keeps the privileged helper near 0.4–0.7% (it only passes the fd); the old virtio pixel copy carried ~14% in the helper.

Closes #1, #2, #3, #4, #10, #11, #12, #14.
