### PR TITLE
helper: accurate failure diagnostics + coherent library version

### DIFF
--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -182,23 +182,29 @@ static int send_fd(int sock, int fd, const void *meta, size_t meta_len) {
 static int drop_caps(void) {
     cap_t caps = cap_init();
     if (!caps) {
-        perror("cap_set_proc failed"); return -1;
+        perror("drmtap-helper: cap_init failed"); return -1;
     }
 
     cap_value_t keep[] = { CAP_SYS_ADMIN };
     if (cap_set_flag(caps, CAP_PERMITTED, 1, keep, CAP_SET) != 0 ||
         cap_set_flag(caps, CAP_EFFECTIVE, 1, keep, CAP_SET) != 0) {
+        int saved = errno;       /* cap_free() may clobber errno */
         cap_free(caps);
-        perror("cap_set_proc failed"); return -1;
+        errno = saved;
+        perror("drmtap-helper: cap_set_flag failed"); return -1;
     }
 
     int ret = cap_set_proc(caps);
+    int saved = errno;           /* preserve before cap_free() touches errno */
     cap_free(caps);
 
-    if (ret == 0) {
-        fprintf(stderr, "drmtap-helper: dropped caps, keeping CAP_SYS_ADMIN\n");
+    if (ret != 0) {
+        errno = saved;
+        perror("drmtap-helper: cap_set_proc failed");
+        return -1;
     }
-    return ret;
+    fprintf(stderr, "drmtap-helper: dropped caps, keeping CAP_SYS_ADMIN\n");
+    return 0;
 }
 #endif
 
@@ -207,7 +213,8 @@ static int drop_caps(void) {
 static int install_seccomp(void) {
     scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_KILL_PROCESS);
     if (!ctx) {
-        perror("cap_set_proc failed"); return -1;
+        /* seccomp_init does not set errno; perror would print a stale value. */
+        fprintf(stderr, "drmtap-helper: seccomp_init failed\n"); return -1;
     }
 
     /* NOTE: open/openat are deliberately NOT allowed. The DRM device is opened
@@ -232,19 +239,27 @@ static int install_seccomp(void) {
     };
 
     for (size_t i = 0; i < sizeof(allowed) / sizeof(allowed[0]); i++) {
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, allowed[i], 0) != 0) {
+        /* seccomp_rule_add returns -errno (it does not set errno itself). */
+        int rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, allowed[i], 0);
+        if (rc != 0) {
             seccomp_release(ctx);
-            perror("cap_set_proc failed"); return -1;
+            fprintf(stderr, "drmtap-helper: seccomp_rule_add failed: %s\n",
+                    strerror(-rc));
+            return -1;
         }
     }
 
     int ret = seccomp_load(ctx);
     seccomp_release(ctx);
 
-    if (ret == 0) {
-        fprintf(stderr, "drmtap-helper: seccomp filter installed\n");
+    if (ret != 0) {
+        /* seccomp_load also returns -errno. */
+        fprintf(stderr, "drmtap-helper: seccomp_load failed: %s\n",
+                strerror(-ret));
+        return -1;
     }
-    return ret;
+    fprintf(stderr, "drmtap-helper: seccomp filter installed\n");
+    return 0;
 }
 #endif
 
@@ -259,19 +274,30 @@ static int send_all(int sock, const void *buf, size_t len) {
     while (sent < len) {
         ssize_t n = send(sock, p + sent, len - sent, MSG_NOSIGNAL);
         if (n <= 0) {
-            perror("cap_set_proc failed"); return -1;
+            perror("drmtap-helper: send failed"); return -1;
         }
         sent += (size_t)n;
     }
     return 0;
 }
 
-// Send error: metadata with data_size=0
+// Send error: metadata with data_size=0. For logical/validation failures where
+// errno carries no useful information about the cause.
 static int send_error(int sock, const char *reason) {
     fprintf(stderr, "drmtap-helper: %s\n", reason);
     struct grab_metadata meta = {0};  /* data_size=0 signals error */
     send_all(sock, &meta, sizeof(meta));
-    perror("cap_set_proc failed"); return -1;
+    return -1;
+}
+
+// Like send_error, but for failures of a syscall or libdrm call that just set
+// errno: capture it first (before send_all can overwrite it) and append it.
+static int send_error_errno(int sock, const char *reason) {
+    int saved = errno;
+    fprintf(stderr, "drmtap-helper: %s: %s\n", reason, strerror(saved));
+    struct grab_metadata meta = {0};  /* data_size=0 signals error */
+    send_all(sock, &meta, sizeof(meta));
+    return -1;
 }
 
 /* Cursor metadata sent before the cursor pixels — must match
@@ -396,7 +422,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     /* Refresh plane state on persistent fd */
     drmModePlaneRes *planes = drmModeGetPlaneResources(drm_fd);
     if (!planes) {
-        return send_error(sock, "drmModeGetPlaneResources failed");
+        return send_error_errno(sock, "drmModeGetPlaneResources failed");
     }
 
     /* Search for the plane currently bound to the target CRTC */
@@ -460,7 +486,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     /* GetFB2 on persistent fd */
     drmModeFB2 *fb2 = drmModeGetFB2(drm_fd, fb_id);
     if (!fb2) {
-        return send_error(sock, "drmModeGetFB2 failed");
+        return send_error_errno(sock, "drmModeGetFB2 failed");
     }
 
     if (fb2->handles[0] == 0) {
@@ -577,12 +603,12 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     struct drm_mode_map_dumb map = {0};
     map.handle = gem_handle;
     if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
-        return send_error(sock, "MODE_MAP_DUMB failed");
+        return send_error_errno(sock, "MODE_MAP_DUMB failed");
     }
     mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
                   drm_fd, map.offset);
     if (mapped == MAP_FAILED) {
-        return send_error(sock, "mmap failed");
+        return send_error_errno(sock, "mmap failed");
     }
     meta.flags = 0;
     meta.data_size = (uint32_t)mapped_size;

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -25,9 +25,13 @@ extern "C" {
 /* Version                                                                   */
 /* ========================================================================= */
 
+/* Version of the C library. Kept equal to the libdrmtap-sys crate version
+ * (the C sources packaged for Rust are the same code) and to the meson
+ * project version; the unit tests cross-check all three. The higher-level
+ * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
-#define DRMTAP_VERSION_MINOR 1
-#define DRMTAP_VERSION_PATCH 0
+#define DRMTAP_VERSION_MINOR 4
+#define DRMTAP_VERSION_PATCH 3
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap-sys/src/lib.rs
+++ b/bindings/rust/libdrmtap-sys/src/lib.rs
@@ -146,8 +146,15 @@ mod tests {
 
     #[test]
     fn test_version() {
+        // The C library version (DRMTAP_VERSION_* in csrc/drmtap.h) is kept
+        // equal to this crate's version. Derive the expected packed value from
+        // CARGO_PKG_VERSION so the two can never silently drift apart.
+        let major: i32 = env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap();
+        let minor: i32 = env!("CARGO_PKG_VERSION_MINOR").parse().unwrap();
+        let patch: i32 = env!("CARGO_PKG_VERSION_PATCH").parse().unwrap();
+        let expected = (major << 16) | (minor << 8) | patch;
         let v = unsafe { drmtap_version() };
-        assert_eq!(v, 0x000100); // 0.1.0
+        assert_eq!(v, expected);
     }
 
     #[test]

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -182,23 +182,29 @@ static int send_fd(int sock, int fd, const void *meta, size_t meta_len) {
 static int drop_caps(void) {
     cap_t caps = cap_init();
     if (!caps) {
-        perror("cap_set_proc failed"); return -1;
+        perror("drmtap-helper: cap_init failed"); return -1;
     }
 
     cap_value_t keep[] = { CAP_SYS_ADMIN };
     if (cap_set_flag(caps, CAP_PERMITTED, 1, keep, CAP_SET) != 0 ||
         cap_set_flag(caps, CAP_EFFECTIVE, 1, keep, CAP_SET) != 0) {
+        int saved = errno;       /* cap_free() may clobber errno */
         cap_free(caps);
-        perror("cap_set_proc failed"); return -1;
+        errno = saved;
+        perror("drmtap-helper: cap_set_flag failed"); return -1;
     }
 
     int ret = cap_set_proc(caps);
+    int saved = errno;           /* preserve before cap_free() touches errno */
     cap_free(caps);
 
-    if (ret == 0) {
-        fprintf(stderr, "drmtap-helper: dropped caps, keeping CAP_SYS_ADMIN\n");
+    if (ret != 0) {
+        errno = saved;
+        perror("drmtap-helper: cap_set_proc failed");
+        return -1;
     }
-    return ret;
+    fprintf(stderr, "drmtap-helper: dropped caps, keeping CAP_SYS_ADMIN\n");
+    return 0;
 }
 #endif
 
@@ -207,7 +213,8 @@ static int drop_caps(void) {
 static int install_seccomp(void) {
     scmp_filter_ctx ctx = seccomp_init(SCMP_ACT_KILL_PROCESS);
     if (!ctx) {
-        perror("cap_set_proc failed"); return -1;
+        /* seccomp_init does not set errno; perror would print a stale value. */
+        fprintf(stderr, "drmtap-helper: seccomp_init failed\n"); return -1;
     }
 
     /* NOTE: open/openat are deliberately NOT allowed. The DRM device is opened
@@ -232,19 +239,27 @@ static int install_seccomp(void) {
     };
 
     for (size_t i = 0; i < sizeof(allowed) / sizeof(allowed[0]); i++) {
-        if (seccomp_rule_add(ctx, SCMP_ACT_ALLOW, allowed[i], 0) != 0) {
+        /* seccomp_rule_add returns -errno (it does not set errno itself). */
+        int rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, allowed[i], 0);
+        if (rc != 0) {
             seccomp_release(ctx);
-            perror("cap_set_proc failed"); return -1;
+            fprintf(stderr, "drmtap-helper: seccomp_rule_add failed: %s\n",
+                    strerror(-rc));
+            return -1;
         }
     }
 
     int ret = seccomp_load(ctx);
     seccomp_release(ctx);
 
-    if (ret == 0) {
-        fprintf(stderr, "drmtap-helper: seccomp filter installed\n");
+    if (ret != 0) {
+        /* seccomp_load also returns -errno. */
+        fprintf(stderr, "drmtap-helper: seccomp_load failed: %s\n",
+                strerror(-ret));
+        return -1;
     }
-    return ret;
+    fprintf(stderr, "drmtap-helper: seccomp filter installed\n");
+    return 0;
 }
 #endif
 
@@ -259,19 +274,30 @@ static int send_all(int sock, const void *buf, size_t len) {
     while (sent < len) {
         ssize_t n = send(sock, p + sent, len - sent, MSG_NOSIGNAL);
         if (n <= 0) {
-            perror("cap_set_proc failed"); return -1;
+            perror("drmtap-helper: send failed"); return -1;
         }
         sent += (size_t)n;
     }
     return 0;
 }
 
-// Send error: metadata with data_size=0
+// Send error: metadata with data_size=0. For logical/validation failures where
+// errno carries no useful information about the cause.
 static int send_error(int sock, const char *reason) {
     fprintf(stderr, "drmtap-helper: %s\n", reason);
     struct grab_metadata meta = {0};  /* data_size=0 signals error */
     send_all(sock, &meta, sizeof(meta));
-    perror("cap_set_proc failed"); return -1;
+    return -1;
+}
+
+// Like send_error, but for failures of a syscall or libdrm call that just set
+// errno: capture it first (before send_all can overwrite it) and append it.
+static int send_error_errno(int sock, const char *reason) {
+    int saved = errno;
+    fprintf(stderr, "drmtap-helper: %s: %s\n", reason, strerror(saved));
+    struct grab_metadata meta = {0};  /* data_size=0 signals error */
+    send_all(sock, &meta, sizeof(meta));
+    return -1;
 }
 
 /* Cursor metadata sent before the cursor pixels — must match
@@ -396,7 +422,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     /* Refresh plane state on persistent fd */
     drmModePlaneRes *planes = drmModeGetPlaneResources(drm_fd);
     if (!planes) {
-        return send_error(sock, "drmModeGetPlaneResources failed");
+        return send_error_errno(sock, "drmModeGetPlaneResources failed");
     }
 
     /* Search for the plane currently bound to the target CRTC */
@@ -460,7 +486,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     /* GetFB2 on persistent fd */
     drmModeFB2 *fb2 = drmModeGetFB2(drm_fd, fb_id);
     if (!fb2) {
-        return send_error(sock, "drmModeGetFB2 failed");
+        return send_error_errno(sock, "drmModeGetFB2 failed");
     }
 
     if (fb2->handles[0] == 0) {
@@ -577,12 +603,12 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     struct drm_mode_map_dumb map = {0};
     map.handle = gem_handle;
     if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
-        return send_error(sock, "MODE_MAP_DUMB failed");
+        return send_error_errno(sock, "MODE_MAP_DUMB failed");
     }
     mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
                   drm_fd, map.offset);
     if (mapped == MAP_FAILED) {
-        return send_error(sock, "mmap failed");
+        return send_error_errno(sock, "mmap failed");
     }
     meta.flags = 0;
     meta.data_size = (uint32_t)mapped_size;

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -25,9 +25,13 @@ extern "C" {
 /* Version                                                                   */
 /* ========================================================================= */
 
+/* Version of the C library. Kept equal to the libdrmtap-sys crate version
+ * (the C sources packaged for Rust are the same code) and to the meson
+ * project version; the unit tests cross-check all three. The higher-level
+ * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
-#define DRMTAP_VERSION_MINOR 1
-#define DRMTAP_VERSION_PATCH 0
+#define DRMTAP_VERSION_MINOR 4
+#define DRMTAP_VERSION_PATCH 3
 
 /**
  * @brief Get the library version as a packed integer.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.1.0',
+    version: '0.4.3',
     license: 'MIT',
     default_options: [
         'c_std=c11',

--- a/meson.build
+++ b/meson.build
@@ -12,6 +12,33 @@ project('libdrmtap', 'c',
 )
 
 # ============================================================================
+# Version coherence
+# ============================================================================
+# The library version lives in three places: this project() version, the
+# DRMTAP_VERSION_* macros in include/drmtap.h (returned by drmtap_version()),
+# and the Rust crate version (cross-checked by the version unit tests). Parse
+# the public header here and fail configuration early if it drifts from the
+# project version, so the sources can never silently diverge.
+fs = import('fs')
+_ver_parts = {'MAJOR': '', 'MINOR': '', 'PATCH': ''}
+foreach _line : fs.read('include/drmtap.h').split('\n')
+    _tokens = _line.split()
+    if _tokens.length() >= 3 and _tokens[0] == '#define'
+        foreach _part : ['MAJOR', 'MINOR', 'PATCH']
+            if _tokens[1] == 'DRMTAP_VERSION_' + _part
+                _ver_parts += {_part: _tokens[2]}
+            endif
+        endforeach
+    endif
+endforeach
+_hdr_version = '@0@.@1@.@2@'.format(
+    _ver_parts['MAJOR'], _ver_parts['MINOR'], _ver_parts['PATCH'])
+assert(_hdr_version == meson.project_version(),
+    'version mismatch: meson project version is ' + meson.project_version() +
+    ' but DRMTAP_VERSION_* in include/drmtap.h is ' + _hdr_version +
+    ' — keep them equal')
+
+# ============================================================================
 # Dependencies
 # ============================================================================
 

--- a/tests/test_enumerate.c
+++ b/tests/test_enumerate.c
@@ -28,7 +28,10 @@
 
 static void test_version(void) {
     int v = drmtap_version();
-    TEST_ASSERT(v == ((0 << 16) | (1 << 8) | 0));
+    /* Track the header macros so this never goes stale on a version bump. */
+    TEST_ASSERT(v == ((DRMTAP_VERSION_MAJOR << 16) |
+                      (DRMTAP_VERSION_MINOR << 8) |
+                      DRMTAP_VERSION_PATCH));
     printf("  PASS: version = 0x%06x\n", v);
 }
 

--- a/tests/test_helper.c
+++ b/tests/test_helper.c
@@ -34,7 +34,10 @@
 
 static void test_version(void) {
     int v = drmtap_version();
-    TEST_ASSERT(v == 0x000100);  /* 0.1.0 */
+    /* Track the header macros so this never goes stale on a version bump. */
+    TEST_ASSERT(v == ((DRMTAP_VERSION_MAJOR << 16) |
+                      (DRMTAP_VERSION_MINOR << 8) |
+                      DRMTAP_VERSION_PATCH));
     printf("  PASS: version = 0x%06x\n", v);
 }
 


### PR DESCRIPTION
Addresses the two code-rigor findings in #5 from the RustDesk maintainer review.

## Misleading diagnostics
The helper printed `perror("cap_set_proc failed")` on six error paths, four of which have nothing to do with capabilities. In a setcap binary a wrong message actively misleads an operator during incident response (a seccomp or socket failure reporting a capability failure). Each path now gets an accurate message, chosen by whether the failing call actually sets `errno`:

| path | was | now |
|---|---|---|
| `cap_init` | cap_set_proc failed | `perror(cap_init failed)` |
| `cap_set_flag` | cap_set_proc failed | `perror(cap_set_flag failed)` |
| `seccomp_init` | cap_set_proc failed | `fprintf(seccomp_init failed)` (does not set errno, so no perror) |
| `seccomp_rule_add` | cap_set_proc failed | `fprintf(... strerror(-rc))` (returns -errno, does not set errno) |
| `send` | cap_set_proc failed | `perror(send failed)` |
| `send_error` | cap_set_proc failed | dropped (the reason is already logged; errno not meaningfully set here) |

On the two cap paths, `errno` is now saved before `cap_free()` and restored before `perror()`, since the cleanup call may clobber it (would have reintroduced the same class of misleading message). The genuine `cap_set_proc` and `seccomp_load` failure paths now log instead of returning silently.

## Coherent version
`drmtap_version()` returned 0.1.0 while the project is well past that, which reads as unmaintained. Set `DRMTAP_VERSION_*` and the meson project version to **0.4.3**, matching the currently published libdrmtap-sys crate (same C sources). The `.so` soversion stays 0 (ABI unchanged); only the full version string moves. The version tests now derive their expected value instead of hardcoding it:
- C tests (`test_helper`, `test_enumerate`): from `DRMTAP_VERSION_*`.
- Rust sys test: from `CARGO_PKG_VERSION`, which also cross-checks that the C header and the crate version stay equal (fails loudly if a future release bumps one without the other).

## Validation (local, x86_64 i915)
- release+werror, debug+asan+ubsan+werror, buildtype=plain+werror (FORTIFY gate): all clean
- meson test: 5/5 (unit + integration)
- cppcheck (warning,portability): clean
- cargo build/test: clean (sys + wrapper)
- real V3 capture through the rebuilt helper: 3840x2160, EGL detile ret=0, happy-path diagnostics print correctly with no spurious cap_set_proc message

Closes #5