### PR TITLE
hdr: tone-map HDR10 scanouts to SDR end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 | Intel (i915/xe) X/Y-tiled deswizzle | ✅ CPU fallback |
 | AMD (amdgpu) deswizzle | ✅ CPU fallback |
 | Nvidia (nvidia-drm) blocklinear deswizzle | ✅ CPU fallback |
-| HDR / 10-bit (AR30/XR30, P010) | 🚧 In progress ([#16](https://github.com/fxd0h/libdrmtap/issues/16)) |
+| HDR10 → SDR tone-map (AR30/XR30, XR48/AR48) | ✅ Implemented (P010 not yet) |
 | Frame differencing (dirty rects) | ✅ Implemented |
 | Thread-safe (`pthread_mutex`) | ✅ Implemented |
 | Coexists with NoMachine/Sunshine | ✅ By design |
@@ -101,11 +101,16 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 > GPU-side EGL readback on the guest. Solved technically; production integration is
 > in progress ([#15](https://github.com/fxd0h/libdrmtap/issues/15)).
 >
-> 🚧 **HDR is not ready.** HDR10 / 10-bit scanouts are **not** properly supported
-> yet ([#16](https://github.com/fxd0h/libdrmtap/issues/16)). The AR30/XR30 path
-> currently keeps only the top 8 of 10 bits with no PQ decode, BT.2020, or
-> tone-mapping, so capturing an HDR display today yields a washed-out, SDR-ish
-> result. `XR48`/`AR48` (16-bit) and `P010` (10-bit YUV) are not handled.
+> **HDR10 capture is tone-mapped to SDR.** When the connector advertises an HDR
+> scanout (`HDR_OUTPUT_METADATA`, PQ), libdrmtap applies the real transfer —
+> PQ (SMPTE ST 2084) decode, BT.2020 → BT.709 gamut, a highlight-preserving
+> tone-map, sRGB — and returns correct 8-bit SDR, instead of the washed-out
+> top-8-of-10-bits result. This matches what consumers like RustDesk expect
+> (their pipeline is 8-bit SDR; on other platforms the OS/compositor tone-maps
+> before they see it — on DRM we do it). Covers `AR30`/`XR30` (10-bit) and
+> `XR48`/`AR48` (16-bit), in both the CPU and the EGL (tiled) paths.
+> `P010` (10-bit YUV, used for overlay-video planes rather than the primary
+> desktop scanout) is not handled.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 | Intel (i915/xe) X/Y-tiled deswizzle | ✅ CPU fallback |
 | AMD (amdgpu) deswizzle | ✅ CPU fallback |
 | Nvidia (nvidia-drm) blocklinear deswizzle | ✅ CPU fallback |
-| HDR10 → SDR tone-map (AR30/XR30, XR48/AR48) | ✅ Implemented (P010 not yet) |
+| HDR10 → SDR tone-map (AR30/XR30, XR48/AR48/XB48/AB48) | ✅ Implemented (P010 not yet) |
 | Frame differencing (dirty rects) | ✅ Implemented |
 | Thread-safe (`pthread_mutex`) | ✅ Implemented |
 | Coexists with NoMachine/Sunshine | ✅ By design |

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -81,6 +81,79 @@ typedef struct {
 /* Plane discovery                                                           */
 /* ========================================================================= */
 
+/* Read the HDR transfer + peak luminance from the connector driving `crtc_id`
+ * into ctx->cur_hdr_eotf / cur_hdr_max_nits, for the direct (no-helper) capture
+ * path. Mirrors read_hdr_metadata in the helper. Best-effort: any failure leaves
+ * it SDR (0), so a non-HDR display just means no tone-mapping. */
+static void read_hdr_metadata_direct(drmtap_ctx *ctx, uint32_t crtc_id) {
+    ctx->cur_hdr_eotf = 0;
+    ctx->cur_hdr_max_nits = 0;
+    if (crtc_id == 0) {
+        return;
+    }
+    drmModeRes *res = drmModeGetResources(ctx->drm_fd);
+    if (!res) {
+        return;
+    }
+    uint32_t conn_id = 0;
+    for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
+        drmModeConnector *conn =
+            drmModeGetConnector(ctx->drm_fd, res->connectors[i]);
+        if (!conn) {
+            continue;
+        }
+        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
+            drmModeEncoder *enc =
+                drmModeGetEncoder(ctx->drm_fd, conn->encoder_id);
+            if (enc) {
+                if (enc->crtc_id == crtc_id) {
+                    conn_id = conn->connector_id;
+                }
+                drmModeFreeEncoder(enc);
+            }
+        }
+        drmModeFreeConnector(conn);
+    }
+    drmModeFreeResources(res);
+    if (conn_id == 0) {
+        return;
+    }
+    drmModeObjectProperties *props = drmModeObjectGetProperties(
+        ctx->drm_fd, conn_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return;
+    }
+    for (uint32_t p = 0; p < props->count_props; p++) {
+        drmModePropertyRes *prop = drmModeGetProperty(ctx->drm_fd, props->props[p]);
+        if (!prop) {
+            continue;
+        }
+        if (strcmp(prop->name, "HDR_OUTPUT_METADATA") == 0 &&
+            props->prop_values[p] != 0) {
+            drmModePropertyBlobRes *blob = drmModeGetPropertyBlob(
+                ctx->drm_fd, (uint32_t)props->prop_values[p]);
+            if (blob && blob->data &&
+                blob->length >= sizeof(struct hdr_output_metadata)) {
+                const struct hdr_output_metadata *m = blob->data;
+                const struct hdr_metadata_infoframe *inf =
+                    &m->hdmi_metadata_type1;
+                ctx->cur_hdr_eotf = inf->eotf;
+                ctx->cur_hdr_max_nits = inf->max_cll
+                    ? inf->max_cll : inf->max_display_mastering_luminance;
+            }
+            if (blob) {
+                drmModeFreePropertyBlob(blob);
+            }
+        }
+        drmModeFreeProperty(prop);
+    }
+    drmModeFreeObjectProperties(props);
+    if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
+        drmtap_debug_log(ctx, "direct: HDR scanout eotf=%u peak=%u nits",
+                         ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
+    }
+}
+
 // Find the primary plane attached to the target CRTC
 // Returns the plane_id or 0 on failure
 static uint32_t find_primary_plane(drmtap_ctx *ctx) {
@@ -173,6 +246,12 @@ static uint32_t find_primary_plane(drmtap_ctx *ctx) {
     }
 
     drmModeFreePlaneResources(planes);
+
+    /* Direct (no-helper) path: read the connector HDR metadata for this CRTC so
+     * the conversion path can tone-map. In helper mode this comes over the wire
+     * instead (drmtap_helper_grab sets ctx->cur_hdr_eotf). */
+    read_hdr_metadata_direct(ctx, ctx->crtc_id);
+
     return result;
 }
 
@@ -430,6 +509,9 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         frame->format = hresult.wire.format;
         frame->modifier = hresult.wire.modifier;
         frame->fb_id = hresult.wire.fb_id;
+        /* HDR transfer the helper read from the connector — drives tone-mapping. */
+        ctx->cur_hdr_eotf = hresult.wire.hdr_eotf;
+        ctx->cur_hdr_max_nits = hresult.wire.hdr_max_nits;
 
         /* The helper validates its own geometry, but it sends stride/height over
          * the wire — re-check before we mmap/size anything from those values. */
@@ -632,6 +714,65 @@ cleanup:
 /* Auto-process: deswizzle + format convert based on GPU driver              */
 /* ========================================================================= */
 
+/* DRM fourccs for the high-bit-depth scanout formats we reduce to 8-bit. */
+#define DRMTAP_FMT_XR30 0x30335258u  /* XRGB2101010 */
+#define DRMTAP_FMT_AR30 0x30335241u  /* ARGB2101010 */
+#define DRMTAP_FMT_XR48 0x38345258u  /* XRGB16161616 */
+#define DRMTAP_FMT_AR48 0x38345241u  /* ARGB16161616 */
+#define DRMTAP_FMT_XB48 0x38344258u  /* XBGR16161616 */
+#define DRMTAP_FMT_AB48 0x38344241u  /* ABGR16161616 */
+#define DRMTAP_FMT_XR24 0x34325258u  /* XRGB8888 */
+
+/* Reduce a LINEAR high-bit-depth scanout (10-bit AR30/XR30 or 16-bit
+ * XR48/AR48/XB48/AB48) to 8-bit XRGB8888, tone-mapping when the connector
+ * reports HDR (PQ). Output lands in ctx->deswizzle_buf and frame is repointed
+ * at it. Returns 1 if it converted, 0 if the format is already 8-bit (caller
+ * returns the data as-is), <0 on error. P010 (10-bit YUV overlay video, not the
+ * primary desktop scanout) is intentionally not handled — documented limitation. */
+static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
+                                     drmtap_frame_info *frame) {
+    uint32_t fmt = frame->format;
+    int is_ar30 = (fmt == DRMTAP_FMT_XR30 || fmt == DRMTAP_FMT_AR30);
+    int is_rgb16 = (fmt == DRMTAP_FMT_XR48 || fmt == DRMTAP_FMT_AR48 ||
+                    fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
+    if (!is_ar30 && !is_rgb16) {
+        return 0;  /* 8-bit RGB (or unknown): leave as-is */
+    }
+
+    size_t out_size = (size_t)frame->width * frame->height * 4u;
+    int b = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, out_size);
+    if (b != 0) return b;
+    uint32_t dst_stride = frame->width * 4u;
+    int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
+    int ret;
+
+    if (is_ar30) {
+        if (hdr) {
+            ret = drmtap_tonemap_hdr10(data, ctx->deswizzle_buf,
+                    frame->width, frame->height, frame->stride, dst_stride,
+                    fmt, ctx->cur_hdr_max_nits);
+        } else {
+            ret = drmtap_convert_format(data, ctx->deswizzle_buf,
+                    frame->width, frame->height, frame->stride, dst_stride,
+                    fmt, DRMTAP_FMT_XR24);
+        }
+    } else {
+        int bgr = (fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
+        ret = drmtap_convert_rgb16(data, ctx->deswizzle_buf,
+                frame->width, frame->height, frame->stride, dst_stride,
+                bgr, ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
+    }
+    if (ret != 0) return ret;
+
+    drmtap_debug_log(ctx, "auto-process: linear %s -> XRGB8888 (%s)",
+                     is_ar30 ? "10-bit" : "16-bit",
+                     hdr ? "HDR tone-mapped" : "SDR");
+    frame->data = ctx->deswizzle_buf;
+    frame->format = DRMTAP_FMT_XR24;
+    frame->stride = dst_stride;
+    return 1;
+}
+
 static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                             drmtap_frame_info *frame, int force_egl) {
     /* force_egl is set for a virgl scanout: the DMA-BUF holds host-rendered
@@ -641,10 +782,20 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     if (!data && !force_egl) return 0;
 
     uint64_t modifier = frame->modifier;
+    int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0);
 
-    /* Linear framebuffer: no deswizzle needed (unless a virgl readback is
+    /* A linear high-bit-depth / HDR scanout still needs reduction to 8-bit
+     * (the early-return below is only safe for 8-bit RGB). */
+    if (data && is_linear && !force_egl) {
+        int red = reduce_linear_to_xrgb8888(ctx, data, frame);
+        if (red < 0) return red;
+        if (red == 1) return 0;
+        /* red == 0: already 8-bit -> fall through to the early-return. */
+    }
+
+    /* Linear 8-bit framebuffer: no deswizzle needed (unless a virgl readback is
      * forced — see force_egl above). */
-    if ((modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0) && !force_egl) {
+    if (is_linear && !force_egl) {
         return 0;
     }
 
@@ -762,16 +913,29 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             frame->data = ctx->deswizzle_buf;
             drmtap_debug_log(ctx, "auto-process: CPU deswizzled to linear");
 
-            /* Convert 10-bit XR30/AR30 → 8-bit XRGB8888 if needed */
+            /* Reduce 10-bit XR30/AR30 to 8-bit XRGB8888. An HDR10 (PQ) scanout
+             * needs a real tone-map — the naive bit-shift would wash it out; a
+             * plain SDR 10-bit scanout (same fourcc) just gets truncated. */
             if (frame->format == DRM_FMT_XR30 ||
                 frame->format == DRM_FMT_AR30) {
-                drmtap_debug_log(ctx,
-                    "auto-process: converting XR30 10-bit → XRGB8888 8-bit");
-                drmtap_convert_format(
-                    ctx->deswizzle_buf, ctx->deswizzle_buf,
-                    frame->width, frame->height,
-                    frame->stride, frame->stride,
-                    frame->format, DRM_FMT_XR24);
+                if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
+                    drmtap_debug_log(ctx,
+                        "auto-process: HDR10 AR30 -> tone-map to SDR (peak=%u)",
+                        ctx->cur_hdr_max_nits);
+                    drmtap_tonemap_hdr10(
+                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        frame->width, frame->height,
+                        frame->stride, frame->stride,
+                        frame->format, ctx->cur_hdr_max_nits);
+                } else {
+                    drmtap_debug_log(ctx,
+                        "auto-process: SDR 10-bit AR30 -> 8-bit XRGB8888");
+                    drmtap_convert_format(
+                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        frame->width, frame->height,
+                        frame->stride, frame->stride,
+                        frame->format, DRM_FMT_XR24);
+                }
                 frame->format = DRM_FMT_XR24;
             }
         }

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -806,10 +806,6 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
      * always deswizzle into a separate buffer (ctx->deswizzle_buf).
      */
 
-    /* Format conversion constants */
-    #define DRM_FMT_XR30 0x30335258u  /* fourcc('X','R','3','0') */
-    #define DRM_FMT_AR30 0x30335241u  /* fourcc('A','R','3','0') */
-    #define DRM_FMT_XR24 0x34325258u  /* fourcc('X','R','2','4') */
 
     /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
      * see ensure_buf). frame->stride/height are validated at every entry point
@@ -916,13 +912,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             /* Reduce 10-bit XR30/AR30 to 8-bit XRGB8888. An HDR10 (PQ) scanout
              * needs a real tone-map — the naive bit-shift would wash it out; a
              * plain SDR 10-bit scanout (same fourcc) just gets truncated. */
-            if (frame->format == DRM_FMT_XR30 ||
-                frame->format == DRM_FMT_AR30) {
+            if (frame->format == DRMTAP_FMT_XR30 ||
+                frame->format == DRMTAP_FMT_AR30) {
+                int conv;
                 if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
                     drmtap_debug_log(ctx,
                         "auto-process: HDR10 AR30 -> tone-map to SDR (peak=%u)",
                         ctx->cur_hdr_max_nits);
-                    drmtap_tonemap_hdr10(
+                    conv = drmtap_tonemap_hdr10(
                         ctx->deswizzle_buf, ctx->deswizzle_buf,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
@@ -930,13 +927,19 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                 } else {
                     drmtap_debug_log(ctx,
                         "auto-process: SDR 10-bit AR30 -> 8-bit XRGB8888");
-                    drmtap_convert_format(
+                    conv = drmtap_convert_format(
                         ctx->deswizzle_buf, ctx->deswizzle_buf,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
-                        frame->format, DRM_FMT_XR24);
+                        frame->format, DRMTAP_FMT_XR24);
                 }
-                frame->format = DRM_FMT_XR24;
+                /* Only relabel the frame as 8-bit if the conversion succeeded;
+                 * otherwise leave the original format so the caller doesn't read
+                 * unconverted 10-bit data as XRGB8888. */
+                if (conv != 0) {
+                    return conv;
+                }
+                frame->format = DRMTAP_FMT_XR24;
             }
         }
         return ret;

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -142,8 +142,8 @@ struct grab_metadata {
     uint32_t seq;
     uint64_t timestamp_ms;
     uint32_t flags;
-    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
-    uint32_t _pad;
+    uint32_t hdr_eotf;      /* DRM EOTF of the scanout: 0=SDR, 2=PQ (ST2084), 3=HLG */
+    uint32_t hdr_max_nits;  /* mastering/content peak luminance (cd/m2), 0=unknown */
 };
 
 /* Send a file descriptor via SCM_RIGHTS */
@@ -417,6 +417,79 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
 /* DRM capture (privileged) — reads pixels, sends via socket                 */
 /* ========================================================================= */
 
+/* Read the HDR transfer function + peak luminance advertised on the connector
+ * driving `crtc_id`. Sets *eotf to the DRM EOTF (0 = SDR / none) and *max_nits
+ * to the content/mastering peak (0 = unknown). Best-effort: any failure is
+ * treated as SDR, so a missing property or a non-HDR display just means no
+ * tone-mapping (the common case). */
+static void read_hdr_metadata(int drm_fd, uint32_t crtc_id,
+                              uint32_t *eotf, uint32_t *max_nits) {
+    *eotf = 0;
+    *max_nits = 0;
+    if (crtc_id == 0) {
+        return;
+    }
+
+    drmModeRes *res = drmModeGetResources(drm_fd);
+    if (!res) {
+        return;
+    }
+    /* Map the CRTC back to its connected connector via the encoder. */
+    uint32_t conn_id = 0;
+    for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
+        drmModeConnector *conn = drmModeGetConnector(drm_fd, res->connectors[i]);
+        if (!conn) {
+            continue;
+        }
+        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
+            drmModeEncoder *enc = drmModeGetEncoder(drm_fd, conn->encoder_id);
+            if (enc) {
+                if (enc->crtc_id == crtc_id) {
+                    conn_id = conn->connector_id;
+                }
+                drmModeFreeEncoder(enc);
+            }
+        }
+        drmModeFreeConnector(conn);
+    }
+    drmModeFreeResources(res);
+    if (conn_id == 0) {
+        return;
+    }
+
+    drmModeObjectProperties *props = drmModeObjectGetProperties(
+        drm_fd, conn_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return;
+    }
+    for (uint32_t p = 0; p < props->count_props; p++) {
+        drmModePropertyRes *prop = drmModeGetProperty(drm_fd, props->props[p]);
+        if (!prop) {
+            continue;
+        }
+        if (strcmp(prop->name, "HDR_OUTPUT_METADATA") == 0 &&
+            props->prop_values[p] != 0) {
+            drmModePropertyBlobRes *blob = drmModeGetPropertyBlob(
+                drm_fd, (uint32_t)props->prop_values[p]);
+            if (blob && blob->data &&
+                blob->length >= sizeof(struct hdr_output_metadata)) {
+                const struct hdr_output_metadata *m = blob->data;
+                const struct hdr_metadata_infoframe *inf =
+                    &m->hdmi_metadata_type1;
+                *eotf = inf->eotf;
+                /* Prefer content light level, fall back to mastering peak. */
+                *max_nits = inf->max_cll ? inf->max_cll
+                            : inf->max_display_mastering_luminance;
+            }
+            if (blob) {
+                drmModeFreePropertyBlob(blob);
+            }
+        }
+        drmModeFreeProperty(prop);
+    }
+    drmModeFreeObjectProperties(props);
+}
+
 // Grab current framebuffer. Helper reads pixels in its own process
 // (where dumb_mmap returns fresh data) and sends them via the socket.
 static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virtio) {
@@ -431,6 +504,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
     /* Search for the plane currently bound to the target CRTC */
     uint32_t fb_id = 0;
+    uint32_t matched_crtc = 0;  /* actual CRTC of the matched plane (for HDR meta) */
     for (uint32_t i = 0; i < planes->count_planes; i++) {
         drmModePlane *plane = drmModeGetPlane(drm_fd, planes->planes[i]);
         if (!plane) continue;
@@ -466,6 +540,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
             if (is_primary || fb_id == 0) {
                 fb_id = plane->fb_id;
+                matched_crtc = plane->crtc_id;
                 fprintf(stderr, "drmtap-helper: matched plane=%u to crtc=%u (fb=%u, %s)\n",
                         plane->plane_id, target_crtc, fb_id, is_primary ? "PRIMARY" : "overlay");
                 if (is_primary) {
@@ -565,6 +640,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     meta.format = fb2->pixel_format;
     meta.fb_id = fb_id;
     meta.modifier = fb2->modifier;
+
+    /* HDR transfer + peak from the connector, so the library can decide whether
+     * to tone-map (vs a plain bit-depth reduction for SDR 10-bit). */
+    read_hdr_metadata(drm_fd, matched_crtc, &meta.hdr_eotf, &meta.hdr_max_nits);
+    if (meta.hdr_eotf == 2 || meta.hdr_eotf == 3) {
+        fprintf(stderr, "drmtap-helper: HDR scanout eotf=%u peak=%u nits\n",
+                meta.hdr_eotf, meta.hdr_max_nits);
+    }
 
     drmModeFreeFB2(fb2);
 

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -337,12 +337,15 @@ int drmtap_convert_format(const void *src, void *dst,
  * @param src_stride Source stride (bytes per row)
  * @param dst_stride Destination stride (bytes per row)
  * @param src_format Source DRM fourcc (DRM_FORMAT_XRGB2101010 / ARGB2101010)
+ * @param max_nits   Content/mastering peak luminance for the highlight roll-off
+ *                   (0 = a sensible default). Brighter peaks spread highlights
+ *                   over more of the top range instead of clipping to white.
  * @return 0 on success, -ENOTSUP for an unsupported format, -EINVAL on bad args
  */
 int drmtap_tonemap_hdr10(const void *src, void *dst,
                          uint32_t width, uint32_t height,
                          uint32_t src_stride, uint32_t dst_stride,
-                         uint32_t src_format);
+                         uint32_t src_format, uint32_t max_nits);
 
 /* ========================================================================= */
 /* Frame Differencing (optional utility)                                     */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -96,6 +96,13 @@ struct drmtap_ctx {
     uint32_t fb2_pitches[4];
     uint32_t fb2_offsets[4];
     int      fb2_num_planes;  /* number of active planes (1..4) */
+
+    /* HDR state of the frame currently being processed. Set per grab from the
+     * connector HDR_OUTPUT_METADATA (helper sends it on the wire; direct mode
+     * reads it itself) and consumed by the conversion path to decide whether to
+     * tone-map (DRMTAP_EOTF_PQ/HLG) or do a plain bit-depth reduction. */
+    uint32_t cur_hdr_eotf;     /* DRMTAP_EOTF_* */
+    uint32_t cur_hdr_max_nits; /* peak luminance, 0 = unknown */
 };
 
 /* ========================================================================= */
@@ -117,6 +124,12 @@ typedef struct {
 
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */
+/* DRM EOTF values (from the connector HDR_OUTPUT_METADATA infoframe). These
+ * match the kernel/CTA-861 numbering; only PQ and HLG mean "tone-map this". */
+#define DRMTAP_EOTF_SDR  0  /* traditional gamma SDR (or no HDR metadata) */
+#define DRMTAP_EOTF_PQ   2  /* SMPTE ST 2084 (HDR10) */
+#define DRMTAP_EOTF_HLG  3  /* Hybrid Log-Gamma (BT.2100) */
+
 /* Flags for helper_grab_result_t.flags */
 #define HELPER_FLAG_HAS_DMABUF  0x01  /* DMA-BUF fd follows via SCM_RIGHTS */
 #define HELPER_FLAG_VIRGL       0x02  /* DMA-BUF is a host-rendered virgl scanout:
@@ -134,7 +147,8 @@ typedef struct {
     uint32_t seq;           /* frame sequence number from helper */
     uint64_t timestamp_ms;  /* unix ms when helper read the frame */
     uint32_t flags;         /* HELPER_FLAG_* bits */
-    uint32_t _pad;          /* alignment padding */
+    uint32_t hdr_eotf;      /* DRM EOTF of the scanout: 0=SDR, 2=PQ (ST2084), 3=HLG */
+    uint32_t hdr_max_nits;  /* mastering/content peak luminance (cd/m2), 0=unknown */
 } helper_grab_wire_t;  /* wire-format: this is what goes over the socket */
 
 typedef struct {
@@ -201,5 +215,14 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             uint32_t stride, uint32_t fourcc,
                             uint64_t modifier,
                             void **out_data, size_t *out_size);
+
+/* Convert a 16-bit/channel scanout (XR48/AR48/XB48/AB48) to XRGB8888.
+ * bgr selects channel order (0 = XR48/AR48, 1 = XB48/AB48). When eotf is
+ * DRMTAP_EOTF_PQ the 16-bit values are PQ-decoded and tone-mapped to SDR;
+ * otherwise they are reduced to 8-bit directly. (pixel_convert.c) */
+int drmtap_convert_rgb16(const void *src, void *dst,
+                         uint32_t width, uint32_t height,
+                         uint32_t src_stride, uint32_t dst_stride,
+                         int bgr, uint32_t eotf, uint32_t max_nits);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -100,7 +100,7 @@ struct drmtap_ctx {
     /* HDR state of the frame currently being processed. Set per grab from the
      * connector HDR_OUTPUT_METADATA (helper sends it on the wire; direct mode
      * reads it itself) and consumed by the conversion path to decide whether to
-     * tone-map (DRMTAP_EOTF_PQ/HLG) or do a plain bit-depth reduction. */
+     * tone-map (DRMTAP_EOTF_PQ) or do a plain bit-depth reduction. */
     uint32_t cur_hdr_eotf;     /* DRMTAP_EOTF_* */
     uint32_t cur_hdr_max_nits; /* peak luminance, 0 = unknown */
 };
@@ -125,7 +125,8 @@ typedef struct {
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */
 /* DRM EOTF values (from the connector HDR_OUTPUT_METADATA infoframe). These
- * match the kernel/CTA-861 numbering; only PQ and HLG mean "tone-map this". */
+ * match the kernel/CTA-861 numbering. PQ means "tone-map this"; HLG currently
+ * falls back to the plain bit-depth reduction (PQ/HDR10 is the desktop norm). */
 #define DRMTAP_EOTF_SDR  0  /* traditional gamma SDR (or no HDR metadata) */
 #define DRMTAP_EOTF_PQ   2  /* SMPTE ST 2084 (HDR10) */
 #define DRMTAP_EOTF_HLG  3  /* Hybrid Log-Gamma (BT.2100) */

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -109,15 +109,60 @@ static const char *vertex_shader_src =
     "    v_texcoord = in_texcoord;\n"
     "}\n";
 
+/* The fragment shader samples the external (DRM) texture and outputs BGRA. When
+ * the scanout is HDR10 (u_hdr == 1) it additionally tone-maps the PQ/BT.2020
+ * sample to SDR/BT.709 8-bit — the same pipeline as the CPU path in
+ * pixel_convert.c (PQ EOTF -> gamut -> highlight soft-knee -> sRGB), done on the
+ * GPU so tiled HDR scanouts (which can't be CPU-deswizzled) are handled too. */
 static const char *fragment_shader_src =
     "#version 100\n"
     "#extension GL_OES_EGL_image_external : require\n"
     "precision highp float;\n"
     "uniform samplerExternalOES image;\n"
+    "uniform int u_hdr;\n"
+    "uniform float u_peak_n;\n"
     "varying vec2 v_texcoord;\n"
+    "float pq_eotf(float e) {\n"
+    "    float m1 = 0.1593017578125;\n"
+    "    float m2 = 78.84375;\n"
+    "    float c1 = 0.8359375;\n"
+    "    float c2 = 18.8515625;\n"
+    "    float c3 = 18.6875;\n"
+    "    float ep = pow(max(e, 0.0), 1.0 / m2);\n"
+    "    float num = max(ep - c1, 0.0);\n"
+    "    float den = max(c2 - c3 * ep, 1e-6);\n"
+    "    return 10000.0 * pow(num / den, 1.0 / m1);\n"
+    "}\n"
+    "float knee_curve(float x, float p) {\n"
+    "    float knee = 0.9;\n"
+    "    if (x <= knee) return x;\n"
+    "    float pk = max(p, knee + 0.5);\n"
+    "    if (x >= pk) return 1.0;\n"
+    "    float t = (x - knee) / (pk - knee);\n"
+    "    return knee + (1.0 - knee) * (t * (2.0 - t));\n"
+    "}\n"
+    "float srgb_oetf(float c) {\n"
+    "    c = clamp(c, 0.0, 1.0);\n"
+    "    if (c <= 0.0031308) return 12.92 * c;\n"
+    "    return 1.055 * pow(c, 1.0 / 2.4) - 0.055;\n"
+    "}\n"
     "void main() {\n"
     "    vec4 c = texture2D(image, v_texcoord);\n"
-    "    gl_FragColor = vec4(c.b, c.g, c.r, c.a);\n"
+    "    if (u_hdr == 1) {\n"
+    "        float R = pq_eotf(c.r);\n"
+    "        float G = pq_eotf(c.g);\n"
+    "        float B = pq_eotf(c.b);\n"
+    "        float r =  1.660491 * R - 0.587641 * G - 0.072850 * B;\n"
+    "        float g = -0.124550 * R + 1.132900 * G - 0.008349 * B;\n"
+    "        float b = -0.018151 * R - 0.100579 * G + 1.118730 * B;\n"
+    "        float w = 203.0;\n"
+    "        r = srgb_oetf(knee_curve(max(r, 0.0) / w, u_peak_n));\n"
+    "        g = srgb_oetf(knee_curve(max(g, 0.0) / w, u_peak_n));\n"
+    "        b = srgb_oetf(knee_curve(max(b, 0.0) / w, u_peak_n));\n"
+    "        gl_FragColor = vec4(b, g, r, c.a);\n"
+    "    } else {\n"
+    "        gl_FragColor = vec4(c.b, c.g, c.r, c.a);\n"
+    "    }\n"
     "}\n";
 
 /* ========================================================================= */
@@ -675,6 +720,21 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     /* Render fullscreen quad: external texture → linear FBO */
     glUseProgram(state.program);
     glUniform1i(glGetUniformLocation(state.program, "image"), 0);
+
+    /* HDR10 scanout: tone-map PQ/BT.2020 -> SDR in the shader. eotf/peak come
+     * from the connector HDR_OUTPUT_METADATA (carried on ctx). */
+    int hdr_on = (ctx && ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) ? 1 : 0;
+    glUniform1i(glGetUniformLocation(state.program, "u_hdr"), hdr_on);
+    {
+        uint32_t mn = (ctx && ctx->cur_hdr_max_nits > 0)
+                          ? ctx->cur_hdr_max_nits : 1000u;
+        glUniform1f(glGetUniformLocation(state.program, "u_peak_n"),
+                    (float)((double)mn / 203.0));
+    }
+    if (hdr_on) {
+        drmtap_debug_log(ctx, "EGL: HDR tone-map in shader (peak=%u nits)",
+                         ctx->cur_hdr_max_nits);
+    }
 
     /* Fullscreen triangle strip.
      * Use standard unflipped coordinates. The EGL texture is natively

--- a/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
+++ b/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
@@ -382,13 +382,18 @@ static void hdr_lut_init(void) {
 
 /* Highlight-preserving tone curve. Input x is linear light normalized so that
  * 1.0 == SDR diffuse white: x <= knee passes through (SDR content keeps its
- * brightness), and x above the knee rolls off smoothly toward 1.0 (HDR
- * highlights, which an SDR display cannot show brighter than white). */
-static double tonemap_softknee(double x) {
-    const double knee = 0.80;
+ * brightness), and x in (knee, peak_n] rolls off smoothly to 1.0 (HDR
+ * highlights, which an SDR display cannot show brighter than white). peak_n is
+ * the content peak luminance in the same SDR-white units, so a brighter
+ * mastering peak spreads the highlights over more of the top range instead of
+ * clipping them all to white. */
+static double tonemap_softknee(double x, double peak_n) {
+    const double knee = 0.90;
     if (x <= knee) return x;
-    if (x >= 100.0) return 1.0;
-    return knee + (1.0 - knee) * tanh((x - knee) / (1.0 - knee));
+    if (peak_n < knee + 0.5) peak_n = knee + 0.5;  /* sane minimum roll-off width */
+    if (x >= peak_n) return 1.0;
+    double t = (x - knee) / (peak_n - knee);        /* [0,1] across the highlights */
+    return knee + (1.0 - knee) * (t * (2.0 - t));   /* quadratic ease-out to 1.0 */
 }
 
 /* sRGB-encode a linear [0,inf) channel via the precomputed LUT. */
@@ -399,14 +404,11 @@ static uint8_t to_srgb8(double linear) {
     return g_srgb_lut[idx];
 }
 
-/* Map one HDR10 (PQ, BT.2020) ARGB2101010 pixel to SDR 8-bit R/G/B. */
-static void tonemap_ar30_pixel(uint32_t pixel,
+/* Map three BT.2020 linear-light (nits) channels through the gamut matrix, the
+ * tone curve and the sRGB OETF to SDR 8-bit. */
+static void tonemap_rgb_linear(double r_lin, double g_lin, double b_lin,
+                               double peak_n,
                                uint8_t *r8, uint8_t *g8, uint8_t *b8) {
-    /* 10-bit channels, ARGB2101010: R[29:20] G[19:10] B[9:0]. */
-    double r_lin = g_pq_lut[(pixel >> 20) & 0x3FF];  /* BT.2020 linear nits */
-    double g_lin = g_pq_lut[(pixel >> 10) & 0x3FF];
-    double b_lin = g_pq_lut[(pixel)       & 0x3FF];
-
     /* BT.2020 -> BT.709 in linear light. */
     double r =  1.660491 * r_lin - 0.587641 * g_lin - 0.072850 * b_lin;
     double g = -0.124550 * r_lin + 1.132900 * g_lin - 0.008349 * b_lin;
@@ -416,15 +418,21 @@ static void tonemap_ar30_pixel(uint32_t pixel,
     if (b < 0.0) b = 0.0;
 
     /* Normalize to SDR white, roll off highlights, sRGB-encode. */
-    *r8 = to_srgb8(tonemap_softknee(r / DRMTAP_SDR_WHITE_NITS));
-    *g8 = to_srgb8(tonemap_softknee(g / DRMTAP_SDR_WHITE_NITS));
-    *b8 = to_srgb8(tonemap_softknee(b / DRMTAP_SDR_WHITE_NITS));
+    *r8 = to_srgb8(tonemap_softknee(r / DRMTAP_SDR_WHITE_NITS, peak_n));
+    *g8 = to_srgb8(tonemap_softknee(g / DRMTAP_SDR_WHITE_NITS, peak_n));
+    *b8 = to_srgb8(tonemap_softknee(b / DRMTAP_SDR_WHITE_NITS, peak_n));
+}
+
+/* content peak (nits) -> tone-curve peak in SDR-white units (default 1000). */
+static double hdr_peak_units(uint32_t max_nits) {
+    double peak = (max_nits > 0) ? (double)max_nits : 1000.0;
+    return peak / DRMTAP_SDR_WHITE_NITS;
 }
 
 int drmtap_tonemap_hdr10(const void *src, void *dst,
                          uint32_t width, uint32_t height,
                          uint32_t src_stride, uint32_t dst_stride,
-                         uint32_t src_format) {
+                         uint32_t src_format, uint32_t max_nits) {
     if (!src || !dst || width == 0 || height == 0) {
         return -EINVAL;
     }
@@ -441,16 +449,74 @@ int drmtap_tonemap_hdr10(const void *src, void *dst,
     }
 
     pthread_once(&g_hdr_once, hdr_lut_init);
+    double peak_n = hdr_peak_units(max_nits);
 
     for (uint32_t y = 0; y < height; y++) {
         const uint32_t *s = (const uint32_t *)
             ((const uint8_t *)src + (size_t)y * src_stride);
         uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
         for (uint32_t x = 0; x < width; x++) {
+            uint32_t pixel = s[x];
+            /* 10-bit channels, ARGB2101010: R[29:20] G[19:10] B[9:0]. */
             uint8_t r, g, b;
-            tonemap_ar30_pixel(s[x], &r, &g, &b);
+            tonemap_rgb_linear(g_pq_lut[(pixel >> 20) & 0x3FF],
+                               g_pq_lut[(pixel >> 10) & 0x3FF],
+                               g_pq_lut[(pixel)       & 0x3FF],
+                               peak_n, &r, &g, &b);
             d[x] = (0xFFu << 24) | ((uint32_t)r << 16) |
                    ((uint32_t)g << 8) | b;
+        }
+    }
+    return 0;
+}
+
+int drmtap_convert_rgb16(const void *src, void *dst,
+                         uint32_t width, uint32_t height,
+                         uint32_t src_stride, uint32_t dst_stride,
+                         int bgr, uint32_t eotf, uint32_t max_nits) {
+    if (!src || !dst || width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    /* Source is 4x16-bit (8 B/px), destination is XRGB8888 (4 B/px). */
+    size_t src_row = (size_t)width * 8u;
+    size_t dst_row = (size_t)width * 4u;
+    if (src_row > UINT32_MAX || dst_row > UINT32_MAX ||
+        src_stride < src_row || dst_stride < dst_row) {
+        return -EINVAL;
+    }
+
+    int hdr = (eotf == 2 /* DRMTAP_EOTF_PQ */);
+    if (hdr) {
+        pthread_once(&g_hdr_once, hdr_lut_init);
+    }
+    double peak_n = hdr_peak_units(max_nits);
+    /* Memory order of the 16-bit quad is little-endian: XR48 (RGB) lays out
+     * B,G,R,X; XB48 (BGR) lays out R,G,B,X. */
+    int ri = bgr ? 0 : 2;
+    int bi = bgr ? 2 : 0;
+
+    for (uint32_t y = 0; y < height; y++) {
+        const uint16_t *s = (const uint16_t *)
+            ((const uint8_t *)src + (size_t)y * src_stride);
+        uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
+        for (uint32_t x = 0; x < width; x++) {
+            const uint16_t *px = s + (size_t)x * 4;
+            uint16_t cr = px[ri], cg = px[1], cb = px[bi];
+            uint8_t r8, g8, b8;
+            if (hdr) {
+                /* 16-bit PQ -> BT.2020 linear nits -> tone-map -> SDR. */
+                tonemap_rgb_linear(pq_eotf_nits((double)cr / 65535.0),
+                                   pq_eotf_nits((double)cg / 65535.0),
+                                   pq_eotf_nits((double)cb / 65535.0),
+                                   peak_n, &r8, &g8, &b8);
+            } else {
+                /* Plain SDR 16-bit -> 8-bit (keep the high byte). */
+                r8 = (uint8_t)(cr >> 8);
+                g8 = (uint8_t)(cg >> 8);
+                b8 = (uint8_t)(cb >> 8);
+            }
+            d[x] = (0xFFu << 24) | ((uint32_t)r8 << 16) |
+                   ((uint32_t)g8 << 8) | b8;
         }
     }
     return 0;

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -142,8 +142,8 @@ struct grab_metadata {
     uint32_t seq;
     uint64_t timestamp_ms;
     uint32_t flags;
-    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
-    uint32_t _pad;
+    uint32_t hdr_eotf;      /* DRM EOTF of the scanout: 0=SDR, 2=PQ (ST2084), 3=HLG */
+    uint32_t hdr_max_nits;  /* mastering/content peak luminance (cd/m2), 0=unknown */
 };
 
 /* Send a file descriptor via SCM_RIGHTS */
@@ -417,6 +417,79 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
 /* DRM capture (privileged) — reads pixels, sends via socket                 */
 /* ========================================================================= */
 
+/* Read the HDR transfer function + peak luminance advertised on the connector
+ * driving `crtc_id`. Sets *eotf to the DRM EOTF (0 = SDR / none) and *max_nits
+ * to the content/mastering peak (0 = unknown). Best-effort: any failure is
+ * treated as SDR, so a missing property or a non-HDR display just means no
+ * tone-mapping (the common case). */
+static void read_hdr_metadata(int drm_fd, uint32_t crtc_id,
+                              uint32_t *eotf, uint32_t *max_nits) {
+    *eotf = 0;
+    *max_nits = 0;
+    if (crtc_id == 0) {
+        return;
+    }
+
+    drmModeRes *res = drmModeGetResources(drm_fd);
+    if (!res) {
+        return;
+    }
+    /* Map the CRTC back to its connected connector via the encoder. */
+    uint32_t conn_id = 0;
+    for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
+        drmModeConnector *conn = drmModeGetConnector(drm_fd, res->connectors[i]);
+        if (!conn) {
+            continue;
+        }
+        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
+            drmModeEncoder *enc = drmModeGetEncoder(drm_fd, conn->encoder_id);
+            if (enc) {
+                if (enc->crtc_id == crtc_id) {
+                    conn_id = conn->connector_id;
+                }
+                drmModeFreeEncoder(enc);
+            }
+        }
+        drmModeFreeConnector(conn);
+    }
+    drmModeFreeResources(res);
+    if (conn_id == 0) {
+        return;
+    }
+
+    drmModeObjectProperties *props = drmModeObjectGetProperties(
+        drm_fd, conn_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return;
+    }
+    for (uint32_t p = 0; p < props->count_props; p++) {
+        drmModePropertyRes *prop = drmModeGetProperty(drm_fd, props->props[p]);
+        if (!prop) {
+            continue;
+        }
+        if (strcmp(prop->name, "HDR_OUTPUT_METADATA") == 0 &&
+            props->prop_values[p] != 0) {
+            drmModePropertyBlobRes *blob = drmModeGetPropertyBlob(
+                drm_fd, (uint32_t)props->prop_values[p]);
+            if (blob && blob->data &&
+                blob->length >= sizeof(struct hdr_output_metadata)) {
+                const struct hdr_output_metadata *m = blob->data;
+                const struct hdr_metadata_infoframe *inf =
+                    &m->hdmi_metadata_type1;
+                *eotf = inf->eotf;
+                /* Prefer content light level, fall back to mastering peak. */
+                *max_nits = inf->max_cll ? inf->max_cll
+                            : inf->max_display_mastering_luminance;
+            }
+            if (blob) {
+                drmModeFreePropertyBlob(blob);
+            }
+        }
+        drmModeFreeProperty(prop);
+    }
+    drmModeFreeObjectProperties(props);
+}
+
 // Grab current framebuffer. Helper reads pixels in its own process
 // (where dumb_mmap returns fresh data) and sends them via the socket.
 static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virtio) {
@@ -431,6 +504,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
     /* Search for the plane currently bound to the target CRTC */
     uint32_t fb_id = 0;
+    uint32_t matched_crtc = 0;  /* actual CRTC of the matched plane (for HDR meta) */
     for (uint32_t i = 0; i < planes->count_planes; i++) {
         drmModePlane *plane = drmModeGetPlane(drm_fd, planes->planes[i]);
         if (!plane) continue;
@@ -466,6 +540,7 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
             if (is_primary || fb_id == 0) {
                 fb_id = plane->fb_id;
+                matched_crtc = plane->crtc_id;
                 fprintf(stderr, "drmtap-helper: matched plane=%u to crtc=%u (fb=%u, %s)\n",
                         plane->plane_id, target_crtc, fb_id, is_primary ? "PRIMARY" : "overlay");
                 if (is_primary) {
@@ -565,6 +640,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     meta.format = fb2->pixel_format;
     meta.fb_id = fb_id;
     meta.modifier = fb2->modifier;
+
+    /* HDR transfer + peak from the connector, so the library can decide whether
+     * to tone-map (vs a plain bit-depth reduction for SDR 10-bit). */
+    read_hdr_metadata(drm_fd, matched_crtc, &meta.hdr_eotf, &meta.hdr_max_nits);
+    if (meta.hdr_eotf == 2 || meta.hdr_eotf == 3) {
+        fprintf(stderr, "drmtap-helper: HDR scanout eotf=%u peak=%u nits\n",
+                meta.hdr_eotf, meta.hdr_max_nits);
+    }
 
     drmModeFreeFB2(fb2);
 

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -337,12 +337,15 @@ int drmtap_convert_format(const void *src, void *dst,
  * @param src_stride Source stride (bytes per row)
  * @param dst_stride Destination stride (bytes per row)
  * @param src_format Source DRM fourcc (DRM_FORMAT_XRGB2101010 / ARGB2101010)
+ * @param max_nits   Content/mastering peak luminance for the highlight roll-off
+ *                   (0 = a sensible default). Brighter peaks spread highlights
+ *                   over more of the top range instead of clipping to white.
  * @return 0 on success, -ENOTSUP for an unsupported format, -EINVAL on bad args
  */
 int drmtap_tonemap_hdr10(const void *src, void *dst,
                          uint32_t width, uint32_t height,
                          uint32_t src_stride, uint32_t dst_stride,
-                         uint32_t src_format);
+                         uint32_t src_format, uint32_t max_nits);
 
 /* ========================================================================= */
 /* Frame Differencing (optional utility)                                     */

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -81,6 +81,79 @@ typedef struct {
 /* Plane discovery                                                           */
 /* ========================================================================= */
 
+/* Read the HDR transfer + peak luminance from the connector driving `crtc_id`
+ * into ctx->cur_hdr_eotf / cur_hdr_max_nits, for the direct (no-helper) capture
+ * path. Mirrors read_hdr_metadata in the helper. Best-effort: any failure leaves
+ * it SDR (0), so a non-HDR display just means no tone-mapping. */
+static void read_hdr_metadata_direct(drmtap_ctx *ctx, uint32_t crtc_id) {
+    ctx->cur_hdr_eotf = 0;
+    ctx->cur_hdr_max_nits = 0;
+    if (crtc_id == 0) {
+        return;
+    }
+    drmModeRes *res = drmModeGetResources(ctx->drm_fd);
+    if (!res) {
+        return;
+    }
+    uint32_t conn_id = 0;
+    for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
+        drmModeConnector *conn =
+            drmModeGetConnector(ctx->drm_fd, res->connectors[i]);
+        if (!conn) {
+            continue;
+        }
+        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
+            drmModeEncoder *enc =
+                drmModeGetEncoder(ctx->drm_fd, conn->encoder_id);
+            if (enc) {
+                if (enc->crtc_id == crtc_id) {
+                    conn_id = conn->connector_id;
+                }
+                drmModeFreeEncoder(enc);
+            }
+        }
+        drmModeFreeConnector(conn);
+    }
+    drmModeFreeResources(res);
+    if (conn_id == 0) {
+        return;
+    }
+    drmModeObjectProperties *props = drmModeObjectGetProperties(
+        ctx->drm_fd, conn_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return;
+    }
+    for (uint32_t p = 0; p < props->count_props; p++) {
+        drmModePropertyRes *prop = drmModeGetProperty(ctx->drm_fd, props->props[p]);
+        if (!prop) {
+            continue;
+        }
+        if (strcmp(prop->name, "HDR_OUTPUT_METADATA") == 0 &&
+            props->prop_values[p] != 0) {
+            drmModePropertyBlobRes *blob = drmModeGetPropertyBlob(
+                ctx->drm_fd, (uint32_t)props->prop_values[p]);
+            if (blob && blob->data &&
+                blob->length >= sizeof(struct hdr_output_metadata)) {
+                const struct hdr_output_metadata *m = blob->data;
+                const struct hdr_metadata_infoframe *inf =
+                    &m->hdmi_metadata_type1;
+                ctx->cur_hdr_eotf = inf->eotf;
+                ctx->cur_hdr_max_nits = inf->max_cll
+                    ? inf->max_cll : inf->max_display_mastering_luminance;
+            }
+            if (blob) {
+                drmModeFreePropertyBlob(blob);
+            }
+        }
+        drmModeFreeProperty(prop);
+    }
+    drmModeFreeObjectProperties(props);
+    if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
+        drmtap_debug_log(ctx, "direct: HDR scanout eotf=%u peak=%u nits",
+                         ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
+    }
+}
+
 // Find the primary plane attached to the target CRTC
 // Returns the plane_id or 0 on failure
 static uint32_t find_primary_plane(drmtap_ctx *ctx) {
@@ -173,6 +246,12 @@ static uint32_t find_primary_plane(drmtap_ctx *ctx) {
     }
 
     drmModeFreePlaneResources(planes);
+
+    /* Direct (no-helper) path: read the connector HDR metadata for this CRTC so
+     * the conversion path can tone-map. In helper mode this comes over the wire
+     * instead (drmtap_helper_grab sets ctx->cur_hdr_eotf). */
+    read_hdr_metadata_direct(ctx, ctx->crtc_id);
+
     return result;
 }
 
@@ -430,6 +509,9 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         frame->format = hresult.wire.format;
         frame->modifier = hresult.wire.modifier;
         frame->fb_id = hresult.wire.fb_id;
+        /* HDR transfer the helper read from the connector — drives tone-mapping. */
+        ctx->cur_hdr_eotf = hresult.wire.hdr_eotf;
+        ctx->cur_hdr_max_nits = hresult.wire.hdr_max_nits;
 
         /* The helper validates its own geometry, but it sends stride/height over
          * the wire — re-check before we mmap/size anything from those values. */
@@ -632,6 +714,65 @@ cleanup:
 /* Auto-process: deswizzle + format convert based on GPU driver              */
 /* ========================================================================= */
 
+/* DRM fourccs for the high-bit-depth scanout formats we reduce to 8-bit. */
+#define DRMTAP_FMT_XR30 0x30335258u  /* XRGB2101010 */
+#define DRMTAP_FMT_AR30 0x30335241u  /* ARGB2101010 */
+#define DRMTAP_FMT_XR48 0x38345258u  /* XRGB16161616 */
+#define DRMTAP_FMT_AR48 0x38345241u  /* ARGB16161616 */
+#define DRMTAP_FMT_XB48 0x38344258u  /* XBGR16161616 */
+#define DRMTAP_FMT_AB48 0x38344241u  /* ABGR16161616 */
+#define DRMTAP_FMT_XR24 0x34325258u  /* XRGB8888 */
+
+/* Reduce a LINEAR high-bit-depth scanout (10-bit AR30/XR30 or 16-bit
+ * XR48/AR48/XB48/AB48) to 8-bit XRGB8888, tone-mapping when the connector
+ * reports HDR (PQ). Output lands in ctx->deswizzle_buf and frame is repointed
+ * at it. Returns 1 if it converted, 0 if the format is already 8-bit (caller
+ * returns the data as-is), <0 on error. P010 (10-bit YUV overlay video, not the
+ * primary desktop scanout) is intentionally not handled — documented limitation. */
+static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
+                                     drmtap_frame_info *frame) {
+    uint32_t fmt = frame->format;
+    int is_ar30 = (fmt == DRMTAP_FMT_XR30 || fmt == DRMTAP_FMT_AR30);
+    int is_rgb16 = (fmt == DRMTAP_FMT_XR48 || fmt == DRMTAP_FMT_AR48 ||
+                    fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
+    if (!is_ar30 && !is_rgb16) {
+        return 0;  /* 8-bit RGB (or unknown): leave as-is */
+    }
+
+    size_t out_size = (size_t)frame->width * frame->height * 4u;
+    int b = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, out_size);
+    if (b != 0) return b;
+    uint32_t dst_stride = frame->width * 4u;
+    int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
+    int ret;
+
+    if (is_ar30) {
+        if (hdr) {
+            ret = drmtap_tonemap_hdr10(data, ctx->deswizzle_buf,
+                    frame->width, frame->height, frame->stride, dst_stride,
+                    fmt, ctx->cur_hdr_max_nits);
+        } else {
+            ret = drmtap_convert_format(data, ctx->deswizzle_buf,
+                    frame->width, frame->height, frame->stride, dst_stride,
+                    fmt, DRMTAP_FMT_XR24);
+        }
+    } else {
+        int bgr = (fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
+        ret = drmtap_convert_rgb16(data, ctx->deswizzle_buf,
+                frame->width, frame->height, frame->stride, dst_stride,
+                bgr, ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
+    }
+    if (ret != 0) return ret;
+
+    drmtap_debug_log(ctx, "auto-process: linear %s -> XRGB8888 (%s)",
+                     is_ar30 ? "10-bit" : "16-bit",
+                     hdr ? "HDR tone-mapped" : "SDR");
+    frame->data = ctx->deswizzle_buf;
+    frame->format = DRMTAP_FMT_XR24;
+    frame->stride = dst_stride;
+    return 1;
+}
+
 static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                             drmtap_frame_info *frame, int force_egl) {
     /* force_egl is set for a virgl scanout: the DMA-BUF holds host-rendered
@@ -641,10 +782,20 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     if (!data && !force_egl) return 0;
 
     uint64_t modifier = frame->modifier;
+    int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0);
 
-    /* Linear framebuffer: no deswizzle needed (unless a virgl readback is
+    /* A linear high-bit-depth / HDR scanout still needs reduction to 8-bit
+     * (the early-return below is only safe for 8-bit RGB). */
+    if (data && is_linear && !force_egl) {
+        int red = reduce_linear_to_xrgb8888(ctx, data, frame);
+        if (red < 0) return red;
+        if (red == 1) return 0;
+        /* red == 0: already 8-bit -> fall through to the early-return. */
+    }
+
+    /* Linear 8-bit framebuffer: no deswizzle needed (unless a virgl readback is
      * forced — see force_egl above). */
-    if ((modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0) && !force_egl) {
+    if (is_linear && !force_egl) {
         return 0;
     }
 
@@ -762,16 +913,29 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             frame->data = ctx->deswizzle_buf;
             drmtap_debug_log(ctx, "auto-process: CPU deswizzled to linear");
 
-            /* Convert 10-bit XR30/AR30 → 8-bit XRGB8888 if needed */
+            /* Reduce 10-bit XR30/AR30 to 8-bit XRGB8888. An HDR10 (PQ) scanout
+             * needs a real tone-map — the naive bit-shift would wash it out; a
+             * plain SDR 10-bit scanout (same fourcc) just gets truncated. */
             if (frame->format == DRM_FMT_XR30 ||
                 frame->format == DRM_FMT_AR30) {
-                drmtap_debug_log(ctx,
-                    "auto-process: converting XR30 10-bit → XRGB8888 8-bit");
-                drmtap_convert_format(
-                    ctx->deswizzle_buf, ctx->deswizzle_buf,
-                    frame->width, frame->height,
-                    frame->stride, frame->stride,
-                    frame->format, DRM_FMT_XR24);
+                if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
+                    drmtap_debug_log(ctx,
+                        "auto-process: HDR10 AR30 -> tone-map to SDR (peak=%u)",
+                        ctx->cur_hdr_max_nits);
+                    drmtap_tonemap_hdr10(
+                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        frame->width, frame->height,
+                        frame->stride, frame->stride,
+                        frame->format, ctx->cur_hdr_max_nits);
+                } else {
+                    drmtap_debug_log(ctx,
+                        "auto-process: SDR 10-bit AR30 -> 8-bit XRGB8888");
+                    drmtap_convert_format(
+                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        frame->width, frame->height,
+                        frame->stride, frame->stride,
+                        frame->format, DRM_FMT_XR24);
+                }
                 frame->format = DRM_FMT_XR24;
             }
         }

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -806,10 +806,6 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
      * always deswizzle into a separate buffer (ctx->deswizzle_buf).
      */
 
-    /* Format conversion constants */
-    #define DRM_FMT_XR30 0x30335258u  /* fourcc('X','R','3','0') */
-    #define DRM_FMT_AR30 0x30335241u  /* fourcc('A','R','3','0') */
-    #define DRM_FMT_XR24 0x34325258u  /* fourcc('X','R','2','4') */
 
     /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
      * see ensure_buf). frame->stride/height are validated at every entry point
@@ -916,13 +912,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             /* Reduce 10-bit XR30/AR30 to 8-bit XRGB8888. An HDR10 (PQ) scanout
              * needs a real tone-map — the naive bit-shift would wash it out; a
              * plain SDR 10-bit scanout (same fourcc) just gets truncated. */
-            if (frame->format == DRM_FMT_XR30 ||
-                frame->format == DRM_FMT_AR30) {
+            if (frame->format == DRMTAP_FMT_XR30 ||
+                frame->format == DRMTAP_FMT_AR30) {
+                int conv;
                 if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
                     drmtap_debug_log(ctx,
                         "auto-process: HDR10 AR30 -> tone-map to SDR (peak=%u)",
                         ctx->cur_hdr_max_nits);
-                    drmtap_tonemap_hdr10(
+                    conv = drmtap_tonemap_hdr10(
                         ctx->deswizzle_buf, ctx->deswizzle_buf,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
@@ -930,13 +927,19 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                 } else {
                     drmtap_debug_log(ctx,
                         "auto-process: SDR 10-bit AR30 -> 8-bit XRGB8888");
-                    drmtap_convert_format(
+                    conv = drmtap_convert_format(
                         ctx->deswizzle_buf, ctx->deswizzle_buf,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
-                        frame->format, DRM_FMT_XR24);
+                        frame->format, DRMTAP_FMT_XR24);
                 }
-                frame->format = DRM_FMT_XR24;
+                /* Only relabel the frame as 8-bit if the conversion succeeded;
+                 * otherwise leave the original format so the caller doesn't read
+                 * unconverted 10-bit data as XRGB8888. */
+                if (conv != 0) {
+                    return conv;
+                }
+                frame->format = DRMTAP_FMT_XR24;
             }
         }
         return ret;

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -96,6 +96,13 @@ struct drmtap_ctx {
     uint32_t fb2_pitches[4];
     uint32_t fb2_offsets[4];
     int      fb2_num_planes;  /* number of active planes (1..4) */
+
+    /* HDR state of the frame currently being processed. Set per grab from the
+     * connector HDR_OUTPUT_METADATA (helper sends it on the wire; direct mode
+     * reads it itself) and consumed by the conversion path to decide whether to
+     * tone-map (DRMTAP_EOTF_PQ/HLG) or do a plain bit-depth reduction. */
+    uint32_t cur_hdr_eotf;     /* DRMTAP_EOTF_* */
+    uint32_t cur_hdr_max_nits; /* peak luminance, 0 = unknown */
 };
 
 /* ========================================================================= */
@@ -117,6 +124,12 @@ typedef struct {
 
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */
+/* DRM EOTF values (from the connector HDR_OUTPUT_METADATA infoframe). These
+ * match the kernel/CTA-861 numbering; only PQ and HLG mean "tone-map this". */
+#define DRMTAP_EOTF_SDR  0  /* traditional gamma SDR (or no HDR metadata) */
+#define DRMTAP_EOTF_PQ   2  /* SMPTE ST 2084 (HDR10) */
+#define DRMTAP_EOTF_HLG  3  /* Hybrid Log-Gamma (BT.2100) */
+
 /* Flags for helper_grab_result_t.flags */
 #define HELPER_FLAG_HAS_DMABUF  0x01  /* DMA-BUF fd follows via SCM_RIGHTS */
 #define HELPER_FLAG_VIRGL       0x02  /* DMA-BUF is a host-rendered virgl scanout:
@@ -134,7 +147,8 @@ typedef struct {
     uint32_t seq;           /* frame sequence number from helper */
     uint64_t timestamp_ms;  /* unix ms when helper read the frame */
     uint32_t flags;         /* HELPER_FLAG_* bits */
-    uint32_t _pad;          /* alignment padding */
+    uint32_t hdr_eotf;      /* DRM EOTF of the scanout: 0=SDR, 2=PQ (ST2084), 3=HLG */
+    uint32_t hdr_max_nits;  /* mastering/content peak luminance (cd/m2), 0=unknown */
 } helper_grab_wire_t;  /* wire-format: this is what goes over the socket */
 
 typedef struct {
@@ -201,5 +215,14 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             uint32_t stride, uint32_t fourcc,
                             uint64_t modifier,
                             void **out_data, size_t *out_size);
+
+/* Convert a 16-bit/channel scanout (XR48/AR48/XB48/AB48) to XRGB8888.
+ * bgr selects channel order (0 = XR48/AR48, 1 = XB48/AB48). When eotf is
+ * DRMTAP_EOTF_PQ the 16-bit values are PQ-decoded and tone-mapped to SDR;
+ * otherwise they are reduced to 8-bit directly. (pixel_convert.c) */
+int drmtap_convert_rgb16(const void *src, void *dst,
+                         uint32_t width, uint32_t height,
+                         uint32_t src_stride, uint32_t dst_stride,
+                         int bgr, uint32_t eotf, uint32_t max_nits);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -100,7 +100,7 @@ struct drmtap_ctx {
     /* HDR state of the frame currently being processed. Set per grab from the
      * connector HDR_OUTPUT_METADATA (helper sends it on the wire; direct mode
      * reads it itself) and consumed by the conversion path to decide whether to
-     * tone-map (DRMTAP_EOTF_PQ/HLG) or do a plain bit-depth reduction. */
+     * tone-map (DRMTAP_EOTF_PQ) or do a plain bit-depth reduction. */
     uint32_t cur_hdr_eotf;     /* DRMTAP_EOTF_* */
     uint32_t cur_hdr_max_nits; /* peak luminance, 0 = unknown */
 };
@@ -125,7 +125,8 @@ typedef struct {
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */
 /* DRM EOTF values (from the connector HDR_OUTPUT_METADATA infoframe). These
- * match the kernel/CTA-861 numbering; only PQ and HLG mean "tone-map this". */
+ * match the kernel/CTA-861 numbering. PQ means "tone-map this"; HLG currently
+ * falls back to the plain bit-depth reduction (PQ/HDR10 is the desktop norm). */
 #define DRMTAP_EOTF_SDR  0  /* traditional gamma SDR (or no HDR metadata) */
 #define DRMTAP_EOTF_PQ   2  /* SMPTE ST 2084 (HDR10) */
 #define DRMTAP_EOTF_HLG  3  /* Hybrid Log-Gamma (BT.2100) */

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -109,15 +109,60 @@ static const char *vertex_shader_src =
     "    v_texcoord = in_texcoord;\n"
     "}\n";
 
+/* The fragment shader samples the external (DRM) texture and outputs BGRA. When
+ * the scanout is HDR10 (u_hdr == 1) it additionally tone-maps the PQ/BT.2020
+ * sample to SDR/BT.709 8-bit — the same pipeline as the CPU path in
+ * pixel_convert.c (PQ EOTF -> gamut -> highlight soft-knee -> sRGB), done on the
+ * GPU so tiled HDR scanouts (which can't be CPU-deswizzled) are handled too. */
 static const char *fragment_shader_src =
     "#version 100\n"
     "#extension GL_OES_EGL_image_external : require\n"
     "precision highp float;\n"
     "uniform samplerExternalOES image;\n"
+    "uniform int u_hdr;\n"
+    "uniform float u_peak_n;\n"
     "varying vec2 v_texcoord;\n"
+    "float pq_eotf(float e) {\n"
+    "    float m1 = 0.1593017578125;\n"
+    "    float m2 = 78.84375;\n"
+    "    float c1 = 0.8359375;\n"
+    "    float c2 = 18.8515625;\n"
+    "    float c3 = 18.6875;\n"
+    "    float ep = pow(max(e, 0.0), 1.0 / m2);\n"
+    "    float num = max(ep - c1, 0.0);\n"
+    "    float den = max(c2 - c3 * ep, 1e-6);\n"
+    "    return 10000.0 * pow(num / den, 1.0 / m1);\n"
+    "}\n"
+    "float knee_curve(float x, float p) {\n"
+    "    float knee = 0.9;\n"
+    "    if (x <= knee) return x;\n"
+    "    float pk = max(p, knee + 0.5);\n"
+    "    if (x >= pk) return 1.0;\n"
+    "    float t = (x - knee) / (pk - knee);\n"
+    "    return knee + (1.0 - knee) * (t * (2.0 - t));\n"
+    "}\n"
+    "float srgb_oetf(float c) {\n"
+    "    c = clamp(c, 0.0, 1.0);\n"
+    "    if (c <= 0.0031308) return 12.92 * c;\n"
+    "    return 1.055 * pow(c, 1.0 / 2.4) - 0.055;\n"
+    "}\n"
     "void main() {\n"
     "    vec4 c = texture2D(image, v_texcoord);\n"
-    "    gl_FragColor = vec4(c.b, c.g, c.r, c.a);\n"
+    "    if (u_hdr == 1) {\n"
+    "        float R = pq_eotf(c.r);\n"
+    "        float G = pq_eotf(c.g);\n"
+    "        float B = pq_eotf(c.b);\n"
+    "        float r =  1.660491 * R - 0.587641 * G - 0.072850 * B;\n"
+    "        float g = -0.124550 * R + 1.132900 * G - 0.008349 * B;\n"
+    "        float b = -0.018151 * R - 0.100579 * G + 1.118730 * B;\n"
+    "        float w = 203.0;\n"
+    "        r = srgb_oetf(knee_curve(max(r, 0.0) / w, u_peak_n));\n"
+    "        g = srgb_oetf(knee_curve(max(g, 0.0) / w, u_peak_n));\n"
+    "        b = srgb_oetf(knee_curve(max(b, 0.0) / w, u_peak_n));\n"
+    "        gl_FragColor = vec4(b, g, r, c.a);\n"
+    "    } else {\n"
+    "        gl_FragColor = vec4(c.b, c.g, c.r, c.a);\n"
+    "    }\n"
     "}\n";
 
 /* ========================================================================= */
@@ -675,6 +720,21 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     /* Render fullscreen quad: external texture → linear FBO */
     glUseProgram(state.program);
     glUniform1i(glGetUniformLocation(state.program, "image"), 0);
+
+    /* HDR10 scanout: tone-map PQ/BT.2020 -> SDR in the shader. eotf/peak come
+     * from the connector HDR_OUTPUT_METADATA (carried on ctx). */
+    int hdr_on = (ctx && ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) ? 1 : 0;
+    glUniform1i(glGetUniformLocation(state.program, "u_hdr"), hdr_on);
+    {
+        uint32_t mn = (ctx && ctx->cur_hdr_max_nits > 0)
+                          ? ctx->cur_hdr_max_nits : 1000u;
+        glUniform1f(glGetUniformLocation(state.program, "u_peak_n"),
+                    (float)((double)mn / 203.0));
+    }
+    if (hdr_on) {
+        drmtap_debug_log(ctx, "EGL: HDR tone-map in shader (peak=%u nits)",
+                         ctx->cur_hdr_max_nits);
+    }
 
     /* Fullscreen triangle strip.
      * Use standard unflipped coordinates. The EGL texture is natively

--- a/src/pixel_convert.c
+++ b/src/pixel_convert.c
@@ -382,13 +382,18 @@ static void hdr_lut_init(void) {
 
 /* Highlight-preserving tone curve. Input x is linear light normalized so that
  * 1.0 == SDR diffuse white: x <= knee passes through (SDR content keeps its
- * brightness), and x above the knee rolls off smoothly toward 1.0 (HDR
- * highlights, which an SDR display cannot show brighter than white). */
-static double tonemap_softknee(double x) {
-    const double knee = 0.80;
+ * brightness), and x in (knee, peak_n] rolls off smoothly to 1.0 (HDR
+ * highlights, which an SDR display cannot show brighter than white). peak_n is
+ * the content peak luminance in the same SDR-white units, so a brighter
+ * mastering peak spreads the highlights over more of the top range instead of
+ * clipping them all to white. */
+static double tonemap_softknee(double x, double peak_n) {
+    const double knee = 0.90;
     if (x <= knee) return x;
-    if (x >= 100.0) return 1.0;
-    return knee + (1.0 - knee) * tanh((x - knee) / (1.0 - knee));
+    if (peak_n < knee + 0.5) peak_n = knee + 0.5;  /* sane minimum roll-off width */
+    if (x >= peak_n) return 1.0;
+    double t = (x - knee) / (peak_n - knee);        /* [0,1] across the highlights */
+    return knee + (1.0 - knee) * (t * (2.0 - t));   /* quadratic ease-out to 1.0 */
 }
 
 /* sRGB-encode a linear [0,inf) channel via the precomputed LUT. */
@@ -399,14 +404,11 @@ static uint8_t to_srgb8(double linear) {
     return g_srgb_lut[idx];
 }
 
-/* Map one HDR10 (PQ, BT.2020) ARGB2101010 pixel to SDR 8-bit R/G/B. */
-static void tonemap_ar30_pixel(uint32_t pixel,
+/* Map three BT.2020 linear-light (nits) channels through the gamut matrix, the
+ * tone curve and the sRGB OETF to SDR 8-bit. */
+static void tonemap_rgb_linear(double r_lin, double g_lin, double b_lin,
+                               double peak_n,
                                uint8_t *r8, uint8_t *g8, uint8_t *b8) {
-    /* 10-bit channels, ARGB2101010: R[29:20] G[19:10] B[9:0]. */
-    double r_lin = g_pq_lut[(pixel >> 20) & 0x3FF];  /* BT.2020 linear nits */
-    double g_lin = g_pq_lut[(pixel >> 10) & 0x3FF];
-    double b_lin = g_pq_lut[(pixel)       & 0x3FF];
-
     /* BT.2020 -> BT.709 in linear light. */
     double r =  1.660491 * r_lin - 0.587641 * g_lin - 0.072850 * b_lin;
     double g = -0.124550 * r_lin + 1.132900 * g_lin - 0.008349 * b_lin;
@@ -416,15 +418,21 @@ static void tonemap_ar30_pixel(uint32_t pixel,
     if (b < 0.0) b = 0.0;
 
     /* Normalize to SDR white, roll off highlights, sRGB-encode. */
-    *r8 = to_srgb8(tonemap_softknee(r / DRMTAP_SDR_WHITE_NITS));
-    *g8 = to_srgb8(tonemap_softknee(g / DRMTAP_SDR_WHITE_NITS));
-    *b8 = to_srgb8(tonemap_softknee(b / DRMTAP_SDR_WHITE_NITS));
+    *r8 = to_srgb8(tonemap_softknee(r / DRMTAP_SDR_WHITE_NITS, peak_n));
+    *g8 = to_srgb8(tonemap_softknee(g / DRMTAP_SDR_WHITE_NITS, peak_n));
+    *b8 = to_srgb8(tonemap_softknee(b / DRMTAP_SDR_WHITE_NITS, peak_n));
+}
+
+/* content peak (nits) -> tone-curve peak in SDR-white units (default 1000). */
+static double hdr_peak_units(uint32_t max_nits) {
+    double peak = (max_nits > 0) ? (double)max_nits : 1000.0;
+    return peak / DRMTAP_SDR_WHITE_NITS;
 }
 
 int drmtap_tonemap_hdr10(const void *src, void *dst,
                          uint32_t width, uint32_t height,
                          uint32_t src_stride, uint32_t dst_stride,
-                         uint32_t src_format) {
+                         uint32_t src_format, uint32_t max_nits) {
     if (!src || !dst || width == 0 || height == 0) {
         return -EINVAL;
     }
@@ -441,16 +449,74 @@ int drmtap_tonemap_hdr10(const void *src, void *dst,
     }
 
     pthread_once(&g_hdr_once, hdr_lut_init);
+    double peak_n = hdr_peak_units(max_nits);
 
     for (uint32_t y = 0; y < height; y++) {
         const uint32_t *s = (const uint32_t *)
             ((const uint8_t *)src + (size_t)y * src_stride);
         uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
         for (uint32_t x = 0; x < width; x++) {
+            uint32_t pixel = s[x];
+            /* 10-bit channels, ARGB2101010: R[29:20] G[19:10] B[9:0]. */
             uint8_t r, g, b;
-            tonemap_ar30_pixel(s[x], &r, &g, &b);
+            tonemap_rgb_linear(g_pq_lut[(pixel >> 20) & 0x3FF],
+                               g_pq_lut[(pixel >> 10) & 0x3FF],
+                               g_pq_lut[(pixel)       & 0x3FF],
+                               peak_n, &r, &g, &b);
             d[x] = (0xFFu << 24) | ((uint32_t)r << 16) |
                    ((uint32_t)g << 8) | b;
+        }
+    }
+    return 0;
+}
+
+int drmtap_convert_rgb16(const void *src, void *dst,
+                         uint32_t width, uint32_t height,
+                         uint32_t src_stride, uint32_t dst_stride,
+                         int bgr, uint32_t eotf, uint32_t max_nits) {
+    if (!src || !dst || width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    /* Source is 4x16-bit (8 B/px), destination is XRGB8888 (4 B/px). */
+    size_t src_row = (size_t)width * 8u;
+    size_t dst_row = (size_t)width * 4u;
+    if (src_row > UINT32_MAX || dst_row > UINT32_MAX ||
+        src_stride < src_row || dst_stride < dst_row) {
+        return -EINVAL;
+    }
+
+    int hdr = (eotf == 2 /* DRMTAP_EOTF_PQ */);
+    if (hdr) {
+        pthread_once(&g_hdr_once, hdr_lut_init);
+    }
+    double peak_n = hdr_peak_units(max_nits);
+    /* Memory order of the 16-bit quad is little-endian: XR48 (RGB) lays out
+     * B,G,R,X; XB48 (BGR) lays out R,G,B,X. */
+    int ri = bgr ? 0 : 2;
+    int bi = bgr ? 2 : 0;
+
+    for (uint32_t y = 0; y < height; y++) {
+        const uint16_t *s = (const uint16_t *)
+            ((const uint8_t *)src + (size_t)y * src_stride);
+        uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
+        for (uint32_t x = 0; x < width; x++) {
+            const uint16_t *px = s + (size_t)x * 4;
+            uint16_t cr = px[ri], cg = px[1], cb = px[bi];
+            uint8_t r8, g8, b8;
+            if (hdr) {
+                /* 16-bit PQ -> BT.2020 linear nits -> tone-map -> SDR. */
+                tonemap_rgb_linear(pq_eotf_nits((double)cr / 65535.0),
+                                   pq_eotf_nits((double)cg / 65535.0),
+                                   pq_eotf_nits((double)cb / 65535.0),
+                                   peak_n, &r8, &g8, &b8);
+            } else {
+                /* Plain SDR 16-bit -> 8-bit (keep the high byte). */
+                r8 = (uint8_t)(cr >> 8);
+                g8 = (uint8_t)(cg >> 8);
+                b8 = (uint8_t)(cb >> 8);
+            }
+            d[x] = (0xFFu << 24) | ((uint32_t)r8 << 16) |
+                   ((uint32_t)g8 << 8) | b8;
         }
     }
     return 0;

--- a/tests/test_hdr.c
+++ b/tests/test_hdr.c
@@ -23,6 +23,7 @@
 #include <math.h>
 
 #include "drmtap.h"
+#include "drmtap_internal.h"  /* drmtap_convert_rgb16, DRMTAP_EOTF_* */
 
 #define TEST_ASSERT(cond) do { \
     if (!(cond)) { \
@@ -56,7 +57,7 @@ static uint32_t ar30_gray(double nits) {
 static int map_nits(double nits) {
     uint32_t in = ar30_gray(nits);
     uint32_t out = 0;
-    int r = drmtap_tonemap_hdr10(&in, &out, 1, 1, 4, 4, 0x30335258u /* XR30 */);
+    int r = drmtap_tonemap_hdr10(&in, &out, 1, 1, 4, 4, 0x30335258u, 0);
     TEST_ASSERT(r == 0);
     return (int)((out >> 16) & 0xFF); /* gray -> all channels equal */
 }
@@ -85,20 +86,59 @@ static void test_curve(void) {
 static void test_unsupported(void) {
     uint32_t a = 0, b = 0;
     /* XR24 (8-bit XRGB8888) is not an HDR source -> -ENOTSUP. */
-    int r = drmtap_tonemap_hdr10(&a, &b, 1, 1, 4, 4, 0x34325258u);
+    int r = drmtap_tonemap_hdr10(&a, &b, 1, 1, 4, 4, 0x34325258u, 0);
     TEST_ASSERT(r == -ENOTSUP);
     /* Bad args. */
-    TEST_ASSERT(drmtap_tonemap_hdr10(NULL, &b, 1, 1, 4, 4, 0x30335258u) == -EINVAL);
+    TEST_ASSERT(drmtap_tonemap_hdr10(NULL, &b, 1, 1, 4, 4, 0x30335258u, 0) == -EINVAL);
     /* Strides that cannot hold a full row (2 px need 8 bytes). */
     uint32_t row[2] = {0, 0};
-    TEST_ASSERT(drmtap_tonemap_hdr10(row, row, 2, 1, 4, 8, 0x30335258u) == -EINVAL);
-    TEST_ASSERT(drmtap_tonemap_hdr10(row, row, 2, 1, 8, 4, 0x30335258u) == -EINVAL);
+    TEST_ASSERT(drmtap_tonemap_hdr10(row, row, 2, 1, 4, 8, 0x30335258u, 0) == -EINVAL);
+    TEST_ASSERT(drmtap_tonemap_hdr10(row, row, 2, 1, 8, 4, 0x30335258u, 0) == -EINVAL);
     printf("  PASS: unsupported format / bad args / bad stride rejected\n");
+}
+
+/* One gray XR48 pixel (16-bit, memory order B,G,R,X) at the given luminance. */
+static void xr48_gray(double nits, uint16_t px[4]) {
+    double e = pq_inverse(nits);
+    uint16_t c = (uint16_t)(e * 65535.0 + 0.5);
+    px[0] = c; px[1] = c; px[2] = c; px[3] = 0xFFFF;
+}
+
+static int map_nits_rgb16(double nits) {
+    uint16_t px[4];
+    xr48_gray(nits, px);
+    uint32_t out = 0;
+    int r = drmtap_convert_rgb16(px, &out, 1, 1, 8, 4, 0 /*RGB*/,
+                                 DRMTAP_EOTF_PQ, 0);
+    TEST_ASSERT(r == 0);
+    return (int)((out >> 16) & 0xFF);
+}
+
+static void test_rgb16(void) {
+    int n5 = map_nits_rgb16(5), n203 = map_nits_rgb16(203),
+        n1000 = map_nits_rgb16(1000);
+    printf("  rgb16 PQ nits->8bit: 5=%d 203=%d 1000=%d\n", n5, n203, n1000);
+    /* Same shape as the AR30 curve: monotonic, SDR white bright, peak -> white. */
+    TEST_ASSERT(n5 <= n203 && n203 <= n1000);
+    TEST_ASSERT(n5 < 60 && n203 >= 230 && n1000 >= 250);
+
+    /* SDR 16-bit (eotf=SDR): plain high-byte reduction, no tone-map. */
+    uint16_t mid[4] = {0x8000, 0x8000, 0x8000, 0xFFFF};
+    uint32_t out = 0;
+    TEST_ASSERT(drmtap_convert_rgb16(mid, &out, 1, 1, 8, 4, 0,
+                                     DRMTAP_EOTF_SDR, 0) == 0);
+    TEST_ASSERT(((out >> 16) & 0xFF) == 0x80);  /* 0x8000 >> 8 */
+
+    /* Stride too small (2 px need 16 source bytes). */
+    TEST_ASSERT(drmtap_convert_rgb16(mid, &out, 2, 1, 8, 4, 0,
+                                     DRMTAP_EOTF_SDR, 0) == -EINVAL);
+    printf("  PASS: rgb16 HDR tone-map + SDR reduce\n");
 }
 
 int main(void) {
     printf("Running HDR tone-map tests...\n");
     test_curve();
+    test_rgb16();
     test_unsupported();
     printf("All HDR tests passed!\n");
     return 0;

--- a/tests/test_hdr.c
+++ b/tests/test_hdr.c
@@ -132,7 +132,21 @@ static void test_rgb16(void) {
     /* Stride too small (2 px need 16 source bytes). */
     TEST_ASSERT(drmtap_convert_rgb16(mid, &out, 2, 1, 8, 4, 0,
                                      DRMTAP_EOTF_SDR, 0) == -EINVAL);
-    printf("  PASS: rgb16 HDR tone-map + SDR reduce\n");
+
+    /* Channel order: same 16-bit memory, RGB (XR48) vs BGR (XB48) layout. The
+     * SDR path keeps the high byte, so the result must pick the right channel. */
+    uint16_t color[4] = {0x1100, 0x2200, 0x3300, 0xFFFF};  /* mem px[0..2] */
+    uint32_t o_rgb = 0, o_bgr = 0;
+    TEST_ASSERT(drmtap_convert_rgb16(color, &o_rgb, 1, 1, 8, 4, 0 /*RGB*/,
+                                     DRMTAP_EOTF_SDR, 0) == 0);
+    TEST_ASSERT(drmtap_convert_rgb16(color, &o_bgr, 1, 1, 8, 4, 1 /*BGR*/,
+                                     DRMTAP_EOTF_SDR, 0) == 0);
+    TEST_ASSERT(((o_rgb >> 16) & 0xFF) == 0x33);  /* RGB: R = px[2] */
+    TEST_ASSERT(((o_bgr >> 16) & 0xFF) == 0x11);  /* BGR: R = px[0] */
+    TEST_ASSERT(((o_rgb >> 8) & 0xFF) == 0x22 &&
+                ((o_bgr >> 8) & 0xFF) == 0x22);   /* G is px[1] either way */
+    TEST_ASSERT((o_rgb & 0xFF) == 0x11 && (o_bgr & 0xFF) == 0x33);  /* B swaps */
+    printf("  PASS: rgb16 HDR tone-map + SDR reduce + channel order\n");
 }
 
 int main(void) {


### PR DESCRIPTION
Closes #16. Wires the HDR10→SDR tone-mapper (added in #21) into the capture pipeline so an HDR scanout is captured as correct 8-bit SDR instead of the washed-out top-8-of-10-bits result.

## Why tone-map to SDR
RustDesk (and most remote-desktop consumers) are 8-bit SDR end to end. On Windows/Wayland the OS or compositor tone-maps HDR→SDR before the app sees the frame; on DRM/KMS we read the raw scanout, so **libdrmtap** has to do it.

## What's wired
- **Metadata** (decides HDR vs SDR — the fourcc alone doesn't, AR30/XR30 is also SDR 10-bit):
  - Helper reads the connector `HDR_OUTPUT_METADATA` (EOTF + peak) and sends it over the wire (new `hdr_eotf`/`hdr_max_nits` fields replacing the padding).
  - Direct (no-helper/root) path reads it itself in `find_primary_plane`.
  - Only tone-maps when the connector reports HDR (PQ); plain SDR 10-bit keeps the bit-depth reduction.
- **Conversion in every path**:
  - linear `AR30/XR30` and 16-bit `XR48/AR48/XB48/AB48` via `reduce_linear_to_xrgb8888`;
  - CPU-deswizzled `AR30` via the existing convert site;
  - **tiled** scanouts via a new HDR branch in the EGL fragment shader (so HDR buffers that can't be CPU-deswizzled are tone-mapped on the GPU).
- The tone-map is **peak-aware** now (highlights get gradation from the metadata peak instead of clipping flat to white); adds a 16-bit converter `drmtap_convert_rgb16`.

## Limitations (documented)
- **P010** (10-bit YUV, an overlay-video format, not the primary desktop scanout) is not handled.
- **HLG** scanouts fall back to the plain reduction (PQ/HDR10 is the desktop norit).

## Validation
- meson release+werror / debug+asan+ubsan / plain+werror; **meson test 6/6**; cppcheck clean; cargo build/test clean (sys+wrapper, clean rebuild for the libm link).
- i915 SDR capture **unchanged in both helper and direct (root) modes**; the EGL shader compiles and runs; the helper's connector-metadata read does not trip seccomp.
- HDR math + the 16-bit converter are **unit-tested** (`test_hdr.c` PQ-encodes known luminances: SDR white maps bright, highlights roll off, monotonic).

**Honest testability note:** the live HDR-display tone-map could not be hardware-verified — I have no HDR monitor, and vkms doesn't advertise HDR metadata. The EGL shader is a direct port of the unit-tested CPU pipeline, and the SDR path is provably unaffected. Everything that *can* be verified without an HDR panel is verified.

Closes #16