### PR TITLE
security: clear CodeQL alerts (CI token least-privilege + test overflow cast)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege GITHUB_TOKEN: these jobs only check out and build/test.
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     name: Build & Test (Ubuntu ${{ matrix.ubuntu }})

--- a/tests/test_deswizzle.c
+++ b/tests/test_deswizzle.c
@@ -145,7 +145,7 @@ static void test_deswizzle_nvidia_x_tiled_roundtrip(void) {
 
     uint8_t *linear = calloc(1, stride * h);
     /* Tiled size: tiles_x tiles × (tile_w_bytes × tile_h) bytes */
-    size_t tiled_size = tiles_x * tile_w_bytes * tile_h;
+    size_t tiled_size = (size_t)tiles_x * tile_w_bytes * tile_h;
     uint8_t *tiled = calloc(1, tiled_size);
     uint8_t *result = calloc(1, stride * h);
     TEST_ASSERT(linear && tiled && result);


### PR DESCRIPTION
Clears the 4 open CodeQL code-scanning alerts. None were in the shipped library or the privileged helper (those already had zero alerts), they were CI hygiene plus one test.

- **3x medium, actions/missing-workflow-permissions** (ci.yml jobs): the workflow declared no `permissions:` block, so GITHUB_TOKEN ran with the default broad scope. Added a top-level least-privilege `permissions: contents: read`. The jobs only check out and build/test, so that is all they need. Closes all three.
- **1x high, cpp/integer-multiplication-cast-to-long** (tests/test_deswizzle.c:148): the tiled-size multiply was done in uint32_t and then assigned to size_t, so it could overflow in 32-bit before widening. Cast the first operand to size_t so the whole product is 64-bit. Test only and the values are tiny so there was no real risk, but the pattern is worth not having flagged.

No functional change to the library or helper.