### PR TITLE
fix: EGL detile context leak + compositor-managed CRTC resolution (0.4.8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 **Language:** C11  
 **License:** MIT  
 **Tests:** unit (no hardware) + integration via VKMS (Virtual KMS) or a real GPU  
-**Version:** C library `0.4.7` · Rust crates `libdrmtap-sys 0.4.7` / `libdrmtap 0.3.4`  
+**Version:** C library `0.4.8` · Rust crates `libdrmtap-sys 0.4.8` / `libdrmtap 0.3.4`  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ int main() {
 libdrmtap = "0.3"
 ```
 
-> This pulls in `libdrmtap-sys` 0.4.7, which embeds and statically compiles the
+> This pulls in `libdrmtap-sys` 0.4.8, which embeds and statically compiles the
 > C sources (and the privilege helper). No system `libdrmtap` install, no
 > `meson install`, no `pkg-config` to find a shared library.
 
@@ -195,7 +195,7 @@ sudo ./build/vnc_server
 libdrmtap is being upstreamed into [RustDesk](https://github.com/rustdesk/rustdesk)
 via [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420).
 The integration adds a `drm` backend to `scrap` that depends on the
-[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.7 crate, which
+[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.8 crate, which
 embeds and statically compiles the C sources (and the privilege helper) — so
 there is no system `libdrmtap` install and no dynamic `libdrmtap.so` linkage.
 

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.7"
+version = "0.4.8"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/drm_enumerate.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_enumerate.c
@@ -24,6 +24,38 @@
 
 #include "drmtap_internal.h"
 
+/* Resolve the CRTC bound to a connector via the atomic CRTC_ID property.
+ *
+ * The legacy path (drmModeGetEncoder(conn->encoder_id)->crtc_id) reports 0 for a
+ * compositor-managed / atomically-bound connector — a documented weakness of the
+ * legacy encoder API under atomic KMS. A connector that enumerates crtc_id==0 is
+ * then mishandled downstream (open() treats 0 as "auto-select the first CRTC",
+ * silently capturing the wrong monitor). Fall back to the connector's atomic
+ * CRTC_ID property to get the real scanout CRTC. Returns 0 if the connector is
+ * genuinely unbound or the property is unavailable (e.g. no atomic cap). */
+static uint32_t connector_crtc_from_atomic(int fd, uint32_t connector_id) {
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return 0;
+    }
+    uint32_t crtc_id = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        if (strcmp(p->name, "CRTC_ID") == 0) {
+            crtc_id = (uint32_t)props->prop_values[i];
+            drmModeFreeProperty(p);
+            break;
+        }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    return crtc_id;
+}
+
 /* ========================================================================= */
 /* Public API                                                                */
 /* ========================================================================= */
@@ -66,6 +98,15 @@ int drmtap_list_displays(drmtap_ctx *ctx, drmtap_display *out, int max_count) {
                 crtc_id = enc->crtc_id;
                 drmModeFreeEncoder(enc);
             }
+        }
+        /* The legacy encoder link is 0 for compositor-managed / atomically-bound
+         * connectors; fall back to the atomic CRTC_ID property so a lit monitor
+         * gets its real CRTC instead of enumerating as crtc_id==0 (which
+         * open(None,0) mis-handles as "auto-select the first/primary CRTC",
+         * silently capturing the wrong monitor). */
+        if (crtc_id == 0) {
+            crtc_id = connector_crtc_from_atomic(ctx->drm_fd,
+                                                 conn->connector_id);
         }
 
         /* Fill output entry */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -253,6 +253,17 @@ drmtap_ctx *drmtap_open(const drmtap_config *config) {
                          "warning: DRM_CLIENT_CAP_UNIVERSAL_PLANES not supported");
     }
 
+    /* Enable atomic modesetting uAPI — best-effort, read-only. This exposes the
+     * connector CRTC_ID property (atomic-flagged, hidden from non-atomic
+     * clients) so enumeration can resolve the real scanout CRTC of a
+     * compositor-managed connector whose legacy encoder link reports 0. We never
+     * commit; the cap only widens property visibility. Harmless if unsupported. */
+    if (drmSetClientCap(ctx->drm_fd, DRM_CLIENT_CAP_ATOMIC, 1) < 0) {
+        drmtap_debug_log(ctx,
+                         "warning: DRM_CLIENT_CAP_ATOMIC not supported "
+                         "(connector CRTC_ID fallback unavailable)");
+    }
+
     drmtap_debug_log(ctx, "context opened: %s (%s)",
                      ctx->device_path, ctx->driver_name);
 
@@ -277,6 +288,13 @@ void drmtap_close(drmtap_ctx *ctx) {
 
     /* Clean up persistent fast-grab state */
     drmtap_fast_cleanup(ctx);
+
+    /* Release this thread's EGL detile context (context + shader + FBO + linear
+     * texture). drmtap_close runs on the capture thread that built it, and C
+     * thread-local storage has no destructor, so without this every open/close on
+     * a fresh capture thread leaks a full EGL context (~tens of MB). No-op if this
+     * thread never used the EGL path. */
+    drmtap_gpu_egl_thread_cleanup();
 
     /* Stop helper if running */
     drmtap_helper_stop(ctx);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 7
+#define DRMTAP_VERSION_PATCH 8
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -214,6 +214,13 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             uint64_t modifier,
                             void **out_data, size_t *out_size);
 
+/* Release the calling thread's lazily-built EGL detile context + GL resources.
+ * Must be called on the capture thread (drmtap_close does this) — C thread-local
+ * storage has no destructor, so without it every open/close on a fresh thread
+ * leaks a whole EGL context + linear texture. No-op if this thread never detiled
+ * or the library was built without EGL. Never terminates the shared display. */
+void drmtap_gpu_egl_thread_cleanup(void);
+
 /* Convert a 16-bit/channel scanout (XR48/AR48/XB48/AB48) to XRGB8888.
  * bgr selects channel order (0 = XR48/AR48, 1 = XB48/AB48). When eotf is
  * DRMTAP_EOTF_PQ the 16-bit values are PQ-decoded and tone-mapped to SDR;

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -66,7 +66,6 @@ typedef struct {
     uint32_t tex_width;
     uint32_t tex_height;
     int initialized;
-    pthread_t owner_thread;  /* thread that created this context */
 } egl_state_t;
 
 /* The per-thread EGL context + GL resources.
@@ -89,6 +88,7 @@ static _Thread_local egl_state_t state = {0};
  * thread exit, while its context can still be made current. The shared
  * g_egl_display is never terminated, so this is safe. */
 static pthread_key_t g_egl_tsd_key;
+static int g_egl_tsd_key_ok = 0;   /* set once the key is created successfully */
 static pthread_once_t g_egl_tsd_once = PTHREAD_ONCE_INIT;
 static void egl_cleanup(egl_state_t *st);
 static void egl_tsd_destructor(void *unused) {
@@ -96,7 +96,11 @@ static void egl_tsd_destructor(void *unused) {
     egl_cleanup(&state);
 }
 static void egl_tsd_key_init(void) {
-    pthread_key_create(&g_egl_tsd_key, egl_tsd_destructor);
+    /* Only mark the key usable if creation succeeds; otherwise g_egl_tsd_key is
+     * indeterminate and must never be passed to pthread_setspecific. */
+    if (pthread_key_create(&g_egl_tsd_key, egl_tsd_destructor) == 0) {
+        g_egl_tsd_key_ok = 1;
+    }
 }
 
 /* EGL function pointers (loaded dynamically) */
@@ -377,14 +381,17 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     state->tex_width = 0;
     state->tex_height = 0;
     state->initialized = 1;
-    state->owner_thread = pthread_self();
     /* Register the thread-exit backstop so a capture thread that dies without
-     * drmtap_close() still frees this context (value must be non-NULL to arm
-     * the destructor; the destructor frees the thread-local `state` directly). */
+     * drmtap_close() still frees this context (value must be non-NULL to arm the
+     * destructor; the destructor frees the thread-local `state` directly). Skip
+     * arming it if the key could not be created (indeterminate key => no UB). */
     pthread_once(&g_egl_tsd_once, egl_tsd_key_init);
-    pthread_setspecific(g_egl_tsd_key, state);
-    drmtap_debug_log(NULL, "EGL: init OK: display=%p ctx=%p program=%u fbo=%u (tid=%ld)",
-            (void*)state->display, (void*)state->context, state->program, state->fbo, (long)(long)0);
+    if (g_egl_tsd_key_ok) {
+        pthread_setspecific(g_egl_tsd_key, state);
+    }
+    drmtap_debug_log(NULL, "EGL: init OK: display=%p ctx=%p program=%u fbo=%u (tid=%lu)",
+            (void*)state->display, (void*)state->context, state->program, state->fbo,
+            (unsigned long)pthread_self());
 
     drmtap_debug_log(ctx, "egl: GPU-universal backend initialized");
     return 0;
@@ -819,8 +826,9 @@ cleanup:
     glDeleteTextures(1, &ext_texture);
     pfn_eglDestroyImageKHR(state.display, image);
 
-    /* Release EGL context from current thread so it can be
-     * claimed by a different thread on the next call */
+    /* The context stays current on this (capture) thread and is reused across
+     * calls — each thread owns its own thread-local context. It is released by
+     * drmtap_gpu_egl_thread_cleanup() at drmtap_close() / thread exit. */
     return ret;
 }
 

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -69,6 +69,36 @@ typedef struct {
     pthread_t owner_thread;  /* thread that created this context */
 } egl_state_t;
 
+/* The per-thread EGL context + GL resources.
+ *
+ * MUST be thread-local: an EGL/GL context is current in at most one thread, and
+ * each capture (e.g. one per monitor in a multi-display session) runs on its own
+ * thread. A single process-global state shared across threads would race on the
+ * FBO/program/textures, producing corrupted/garbage frames under concurrent
+ * capture. Thread-local storage gives each capture thread its own EGL context
+ * over the shared EGLDisplay — the correct EGL threading model.
+ *
+ * It lives at FILE scope (not inside egl_convert_impl) so drmtap_gpu_egl_thread_cleanup()
+ * can release it on drmtap_close(): C thread-local storage has no destructor, so
+ * without an explicit teardown every open/close cycle on a fresh capture thread
+ * leaked a whole EGL context + a w*h*4 linear texture (~33 MB at 4K). */
+static _Thread_local egl_state_t state = {0};
+
+/* Backstop for a capture thread that exits WITHOUT calling drmtap_close (an
+ * error/panic path): a pthread TSD destructor frees this thread's EGL context at
+ * thread exit, while its context can still be made current. The shared
+ * g_egl_display is never terminated, so this is safe. */
+static pthread_key_t g_egl_tsd_key;
+static pthread_once_t g_egl_tsd_once = PTHREAD_ONCE_INIT;
+static void egl_cleanup(egl_state_t *st);
+static void egl_tsd_destructor(void *unused) {
+    (void)unused;
+    egl_cleanup(&state);
+}
+static void egl_tsd_key_init(void) {
+    pthread_key_create(&g_egl_tsd_key, egl_tsd_destructor);
+}
+
 /* EGL function pointers (loaded dynamically) */
 static PFNEGLQUERYDEVICESEXTPROC pfn_eglQueryDevicesEXT;
 static PFNEGLQUERYDEVICESTRINGEXTPROC pfn_eglQueryDeviceStringEXT;
@@ -348,6 +378,11 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     state->tex_height = 0;
     state->initialized = 1;
     state->owner_thread = pthread_self();
+    /* Register the thread-exit backstop so a capture thread that dies without
+     * drmtap_close() still frees this context (value must be non-NULL to arm
+     * the destructor; the destructor frees the thread-local `state` directly). */
+    pthread_once(&g_egl_tsd_once, egl_tsd_key_init);
+    pthread_setspecific(g_egl_tsd_key, state);
     drmtap_debug_log(NULL, "EGL: init OK: display=%p ctx=%p program=%u fbo=%u (tid=%ld)",
             (void*)state->display, (void*)state->context, state->program, state->fbo, (long)(long)0);
 
@@ -355,24 +390,42 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     return 0;
 }
 
-static void __attribute__((unused)) egl_cleanup(egl_state_t *state) {
-    if (!state->initialized) {
+static void egl_cleanup(egl_state_t *st) {
+    if (!st->initialized) {
         return;
     }
-    eglMakeCurrent(state->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                   state->context);
-    if (state->linear_texture) {
-        glDeleteTextures(1, &state->linear_texture);
+    eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                   st->context);
+    if (st->linear_texture) {
+        glDeleteTextures(1, &st->linear_texture);
     }
-    if (state->fbo) {
-        glDeleteFramebuffers(1, &state->fbo);
+    if (st->fbo) {
+        glDeleteFramebuffers(1, &st->fbo);
     }
-    if (state->program) {
-        glDeleteProgram(state->program);
+    if (st->program) {
+        glDeleteProgram(st->program);
     }
-    eglDestroyContext(state->display, state->context);
-    eglTerminate(state->display);
-    state->initialized = 0;
+    /* Release the context from this thread before destroying it. MUST NOT
+     * eglTerminate(st->display): g_egl_display is shared across all capture
+     * threads; terminating it invalidates other threads' live detile contexts
+     * (see the CRITICAL note in drmtap_gpu_egl_available). */
+    eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                   EGL_NO_CONTEXT);
+    eglDestroyContext(st->display, st->context);
+    st->context = EGL_NO_CONTEXT;
+    st->program = 0;
+    st->fbo = 0;
+    st->linear_texture = 0;
+    st->tex_width = 0;
+    st->tex_height = 0;
+    st->initialized = 0;
+}
+
+/* Release THIS thread's EGL context + GL resources. Safe no-op if this thread
+ * never built a context. Called from drmtap_close() on the capture thread (and
+ * by the TSD backstop at thread exit); idempotent. */
+void drmtap_gpu_egl_thread_cleanup(void) {
+    egl_cleanup(&state);
 }
 
 /* Ensure the linear output texture matches the capture dimensions */
@@ -493,36 +546,13 @@ static int egl_convert_impl(drmtap_ctx *ctx,
         return -EINVAL;
     }
 
-    /* Lazy-init EGL state, one per thread.
-     *
-     * MUST be thread-local: an EGL/GL context is current in at most one thread,
-     * and each capture (e.g. one per monitor in a multi-display session) runs on
-     * its own thread. A single process-global state shared across threads would
-     * race on the FBO/program/textures and thrash the context (via the
-     * owner-thread re-creation below), producing corrupted/garbage frames under
-     * concurrent capture. Thread-local storage gives each capture thread its own
-     * EGL context over the shared EGLDisplay — the correct EGL threading model. */
-    static _Thread_local egl_state_t state = {0};
+    /* Lazy-init this thread's EGL context. `state` is the file-scope
+     * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
+     * on close. (A `_Thread_local` is per-thread, so there is no cross-thread
+     * owner check to do here — each thread only ever sees its own instance.) */
     int ret;
 
     drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
-    if (state.initialized && state.owner_thread != pthread_self()) {
-        drmtap_debug_log(NULL, "EGL: thread changed! old=%lu new=%lu, re-creating context",
-                (unsigned long)state.owner_thread, (unsigned long)pthread_self());
-        /* Destroy old context — it belongs to a different thread */
-        eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                       EGL_NO_CONTEXT);
-        if (state.program) glDeleteProgram(state.program);
-        if (state.fbo) glDeleteFramebuffers(1, &state.fbo);
-        if (state.linear_texture) glDeleteTextures(1, &state.linear_texture);
-        eglDestroyContext(state.display, state.context);
-        state.initialized = 0;
-        state.program = 0;
-        state.fbo = 0;
-        state.linear_texture = 0;
-        state.tex_width = 0;
-        state.tex_height = 0;
-    }
     if (!state.initialized) {
         ret = egl_init(ctx, &state);
         drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);
@@ -814,6 +844,10 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
     (void)out_data; (void)out_size;
     drmtap_set_error(ctx, "EGL backend not available (built without EGL)");
     return -ENOTSUP;
+}
+
+void drmtap_gpu_egl_thread_cleanup(void) {
+    /* No EGL backend compiled in — nothing to release. */
 }
 
 #endif /* HAVE_EGL */

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.7", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.4.8", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/bindings/rust/libdrmtap/README.md
+++ b/bindings/rust/libdrmtap/README.md
@@ -25,7 +25,7 @@ reports HDR (`P010` overlay-video and HLG excepted).
 libdrmtap = "0.3"
 ```
 
-This pulls in `libdrmtap-sys` 0.4.7, which embeds and statically compiles the C
+This pulls in `libdrmtap-sys` 0.4.8, which embeds and statically compiles the C
 sources (and the privilege helper) — no system `libdrmtap` install needed.
 
 ## Example

--- a/contrib/integrations/rustdesk/README.md
+++ b/contrib/integrations/rustdesk/README.md
@@ -7,7 +7,7 @@ crate.
 > The upstream integration PR
 > [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420)
 > is **under maintainer review** (in progress — not yet merged). It adds a `drm`
-> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.7. The files here are a
+> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.8. The files here are a
 > self-contained reference for the same crate-based backend.
 
 ## Status
@@ -42,7 +42,7 @@ capture. This means:
 1. Add the crate to `libs/scrap/Cargo.toml`:
 
    ```toml
-   libdrmtap-sys = { version = "0.4.7", optional = true }
+   libdrmtap-sys = { version = "0.4.8", optional = true }
    ```
 
    It embeds and statically compiles the C sources **and** builds the

--- a/contrib/integrations/rustdesk/drm/mod.rs
+++ b/contrib/integrations/rustdesk/drm/mod.rs
@@ -13,7 +13,7 @@
 // Integration (tested on Ubuntu 24.04; uses the static libdrmtap-sys crate):
 //
 //   1. Add the crate to libs/scrap/Cargo.toml:
-//        libdrmtap-sys = { version = "0.4.7", optional = true }
+//        libdrmtap-sys = { version = "0.4.8", optional = true }
 //      It statically embeds and compiles the C sources and builds the
 //      drmtap-helper binary — no system libdrmtap install, no meson install,
 //      no apt package, and no rustc-link-search.

--- a/contrib/integrations/rustdesk/drm/recorder.rs
+++ b/contrib/integrations/rustdesk/drm/recorder.rs
@@ -9,7 +9,7 @@
 // captured 1920x1017 @ BGRA, 7,810,560 bytes — pixel-perfect.
 //
 // To use in RustDesk:
-//   Add `libdrmtap-sys = { version = "0.4.7", optional = true }` to
+//   Add `libdrmtap-sys = { version = "0.4.8", optional = true }` to
 //   libs/scrap/Cargo.toml, place this file at libs/scrap/src/common/drm.rs,
 //   and see mod.rs in this directory for the wiring. The canonical, current
 //   backend is in the upstream PR rustdesk/rustdesk#15420.

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -450,7 +450,7 @@ Three layers, published on crates.io:
 └─────────────────────────────────────────────────┘
 ```
 
-> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.7,
+> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.8,
 > libdrmtap 0.3.4) and verified to build/test in CI on Ubuntu 22.04/24.04.
 > Capture is verified on Intel i915/xe (dual-4K Meteor Lake), Nvidia/Tegra
 > (Jetson Orin Nano, aarch64), virtio-gpu, and AMD amdgpu (RX Vega 64, gfx9,
@@ -514,8 +514,8 @@ Adding `libdrmtap-sys` is standard practice for them. They `cargo add libdrmtap`
 
 | Area | What shipped | Status |
 |---|---|---|
-| Core | `libdrmtap` C library 0.4.7 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
-| Rust | `libdrmtap-sys` 0.4.7 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
+| Core | `libdrmtap` C library 0.4.8 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
+| Rust | `libdrmtap-sys` 0.4.8 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
 | Rust | `libdrmtap` 0.3.4 (safe wrapper) | ✅ Published on crates.io |
 | GPU | EGL/GLES2 GPU-universal detiling backend | ✅ Implemented |
 | HW | Intel i915/xe + Nvidia/Tegra + virtio-gpu + AMD amdgpu validation | ✅ Verified (AMD on RX Vega 64, gfx9) |

--- a/docs/research/07_potential_adopters.md
+++ b/docs/research/07_potential_adopters.md
@@ -16,7 +16,7 @@
 
 ### Integration path for each:
 
-**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.7 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
+**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.8 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
 
 **Sunshine**: Replace internal KMS code with `#include <drmtap.h>`. They already use DMA-BUF → VAAPI pipeline, so `drmtap_grab()` (zero-copy) slots in directly.
 

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 7
+#define DRMTAP_VERSION_PATCH 8
 
 /**
  * @brief Get the library version as a packed integer.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.7',
+    version: '0.4.8',
     license: 'MIT',
     default_options: [
         'c_std=c11',

--- a/patches/rustdesk/README.md
+++ b/patches/rustdesk/README.md
@@ -31,7 +31,7 @@ cargo build --release
 ## Based on
 
 - RustDesk v1.4.6
-- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.7"`
+- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.8"`
 
 ## Upstream status
 

--- a/patches/rustdesk/scrap_Cargo.toml
+++ b/patches/rustdesk/scrap_Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-libdrmtap-sys = { version = "0.4.7", optional = true }
+libdrmtap-sys = { version = "0.4.8", optional = true }
 webm = { git = "https://github.com/rustdesk-org/rust-webm" }
 serde = {version="1.0", features=["derive"]}
 

--- a/src/drm_enumerate.c
+++ b/src/drm_enumerate.c
@@ -24,6 +24,38 @@
 
 #include "drmtap_internal.h"
 
+/* Resolve the CRTC bound to a connector via the atomic CRTC_ID property.
+ *
+ * The legacy path (drmModeGetEncoder(conn->encoder_id)->crtc_id) reports 0 for a
+ * compositor-managed / atomically-bound connector — a documented weakness of the
+ * legacy encoder API under atomic KMS. A connector that enumerates crtc_id==0 is
+ * then mishandled downstream (open() treats 0 as "auto-select the first CRTC",
+ * silently capturing the wrong monitor). Fall back to the connector's atomic
+ * CRTC_ID property to get the real scanout CRTC. Returns 0 if the connector is
+ * genuinely unbound or the property is unavailable (e.g. no atomic cap). */
+static uint32_t connector_crtc_from_atomic(int fd, uint32_t connector_id) {
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return 0;
+    }
+    uint32_t crtc_id = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        if (strcmp(p->name, "CRTC_ID") == 0) {
+            crtc_id = (uint32_t)props->prop_values[i];
+            drmModeFreeProperty(p);
+            break;
+        }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    return crtc_id;
+}
+
 /* ========================================================================= */
 /* Public API                                                                */
 /* ========================================================================= */
@@ -66,6 +98,15 @@ int drmtap_list_displays(drmtap_ctx *ctx, drmtap_display *out, int max_count) {
                 crtc_id = enc->crtc_id;
                 drmModeFreeEncoder(enc);
             }
+        }
+        /* The legacy encoder link is 0 for compositor-managed / atomically-bound
+         * connectors; fall back to the atomic CRTC_ID property so a lit monitor
+         * gets its real CRTC instead of enumerating as crtc_id==0 (which
+         * open(None,0) mis-handles as "auto-select the first/primary CRTC",
+         * silently capturing the wrong monitor). */
+        if (crtc_id == 0) {
+            crtc_id = connector_crtc_from_atomic(ctx->drm_fd,
+                                                 conn->connector_id);
         }
 
         /* Fill output entry */

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -253,6 +253,17 @@ drmtap_ctx *drmtap_open(const drmtap_config *config) {
                          "warning: DRM_CLIENT_CAP_UNIVERSAL_PLANES not supported");
     }
 
+    /* Enable atomic modesetting uAPI — best-effort, read-only. This exposes the
+     * connector CRTC_ID property (atomic-flagged, hidden from non-atomic
+     * clients) so enumeration can resolve the real scanout CRTC of a
+     * compositor-managed connector whose legacy encoder link reports 0. We never
+     * commit; the cap only widens property visibility. Harmless if unsupported. */
+    if (drmSetClientCap(ctx->drm_fd, DRM_CLIENT_CAP_ATOMIC, 1) < 0) {
+        drmtap_debug_log(ctx,
+                         "warning: DRM_CLIENT_CAP_ATOMIC not supported "
+                         "(connector CRTC_ID fallback unavailable)");
+    }
+
     drmtap_debug_log(ctx, "context opened: %s (%s)",
                      ctx->device_path, ctx->driver_name);
 
@@ -277,6 +288,13 @@ void drmtap_close(drmtap_ctx *ctx) {
 
     /* Clean up persistent fast-grab state */
     drmtap_fast_cleanup(ctx);
+
+    /* Release this thread's EGL detile context (context + shader + FBO + linear
+     * texture). drmtap_close runs on the capture thread that built it, and C
+     * thread-local storage has no destructor, so without this every open/close on
+     * a fresh capture thread leaks a full EGL context (~tens of MB). No-op if this
+     * thread never used the EGL path. */
+    drmtap_gpu_egl_thread_cleanup();
 
     /* Stop helper if running */
     drmtap_helper_stop(ctx);

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -214,6 +214,13 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             uint64_t modifier,
                             void **out_data, size_t *out_size);
 
+/* Release the calling thread's lazily-built EGL detile context + GL resources.
+ * Must be called on the capture thread (drmtap_close does this) — C thread-local
+ * storage has no destructor, so without it every open/close on a fresh thread
+ * leaks a whole EGL context + linear texture. No-op if this thread never detiled
+ * or the library was built without EGL. Never terminates the shared display. */
+void drmtap_gpu_egl_thread_cleanup(void);
+
 /* Convert a 16-bit/channel scanout (XR48/AR48/XB48/AB48) to XRGB8888.
  * bgr selects channel order (0 = XR48/AR48, 1 = XB48/AB48). When eotf is
  * DRMTAP_EOTF_PQ the 16-bit values are PQ-decoded and tone-mapped to SDR;

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -66,7 +66,6 @@ typedef struct {
     uint32_t tex_width;
     uint32_t tex_height;
     int initialized;
-    pthread_t owner_thread;  /* thread that created this context */
 } egl_state_t;
 
 /* The per-thread EGL context + GL resources.
@@ -89,6 +88,7 @@ static _Thread_local egl_state_t state = {0};
  * thread exit, while its context can still be made current. The shared
  * g_egl_display is never terminated, so this is safe. */
 static pthread_key_t g_egl_tsd_key;
+static int g_egl_tsd_key_ok = 0;   /* set once the key is created successfully */
 static pthread_once_t g_egl_tsd_once = PTHREAD_ONCE_INIT;
 static void egl_cleanup(egl_state_t *st);
 static void egl_tsd_destructor(void *unused) {
@@ -96,7 +96,11 @@ static void egl_tsd_destructor(void *unused) {
     egl_cleanup(&state);
 }
 static void egl_tsd_key_init(void) {
-    pthread_key_create(&g_egl_tsd_key, egl_tsd_destructor);
+    /* Only mark the key usable if creation succeeds; otherwise g_egl_tsd_key is
+     * indeterminate and must never be passed to pthread_setspecific. */
+    if (pthread_key_create(&g_egl_tsd_key, egl_tsd_destructor) == 0) {
+        g_egl_tsd_key_ok = 1;
+    }
 }
 
 /* EGL function pointers (loaded dynamically) */
@@ -377,14 +381,17 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     state->tex_width = 0;
     state->tex_height = 0;
     state->initialized = 1;
-    state->owner_thread = pthread_self();
     /* Register the thread-exit backstop so a capture thread that dies without
-     * drmtap_close() still frees this context (value must be non-NULL to arm
-     * the destructor; the destructor frees the thread-local `state` directly). */
+     * drmtap_close() still frees this context (value must be non-NULL to arm the
+     * destructor; the destructor frees the thread-local `state` directly). Skip
+     * arming it if the key could not be created (indeterminate key => no UB). */
     pthread_once(&g_egl_tsd_once, egl_tsd_key_init);
-    pthread_setspecific(g_egl_tsd_key, state);
-    drmtap_debug_log(NULL, "EGL: init OK: display=%p ctx=%p program=%u fbo=%u (tid=%ld)",
-            (void*)state->display, (void*)state->context, state->program, state->fbo, (long)(long)0);
+    if (g_egl_tsd_key_ok) {
+        pthread_setspecific(g_egl_tsd_key, state);
+    }
+    drmtap_debug_log(NULL, "EGL: init OK: display=%p ctx=%p program=%u fbo=%u (tid=%lu)",
+            (void*)state->display, (void*)state->context, state->program, state->fbo,
+            (unsigned long)pthread_self());
 
     drmtap_debug_log(ctx, "egl: GPU-universal backend initialized");
     return 0;

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -69,6 +69,36 @@ typedef struct {
     pthread_t owner_thread;  /* thread that created this context */
 } egl_state_t;
 
+/* The per-thread EGL context + GL resources.
+ *
+ * MUST be thread-local: an EGL/GL context is current in at most one thread, and
+ * each capture (e.g. one per monitor in a multi-display session) runs on its own
+ * thread. A single process-global state shared across threads would race on the
+ * FBO/program/textures, producing corrupted/garbage frames under concurrent
+ * capture. Thread-local storage gives each capture thread its own EGL context
+ * over the shared EGLDisplay — the correct EGL threading model.
+ *
+ * It lives at FILE scope (not inside egl_convert_impl) so drmtap_gpu_egl_thread_cleanup()
+ * can release it on drmtap_close(): C thread-local storage has no destructor, so
+ * without an explicit teardown every open/close cycle on a fresh capture thread
+ * leaked a whole EGL context + a w*h*4 linear texture (~33 MB at 4K). */
+static _Thread_local egl_state_t state = {0};
+
+/* Backstop for a capture thread that exits WITHOUT calling drmtap_close (an
+ * error/panic path): a pthread TSD destructor frees this thread's EGL context at
+ * thread exit, while its context can still be made current. The shared
+ * g_egl_display is never terminated, so this is safe. */
+static pthread_key_t g_egl_tsd_key;
+static pthread_once_t g_egl_tsd_once = PTHREAD_ONCE_INIT;
+static void egl_cleanup(egl_state_t *st);
+static void egl_tsd_destructor(void *unused) {
+    (void)unused;
+    egl_cleanup(&state);
+}
+static void egl_tsd_key_init(void) {
+    pthread_key_create(&g_egl_tsd_key, egl_tsd_destructor);
+}
+
 /* EGL function pointers (loaded dynamically) */
 static PFNEGLQUERYDEVICESEXTPROC pfn_eglQueryDevicesEXT;
 static PFNEGLQUERYDEVICESTRINGEXTPROC pfn_eglQueryDeviceStringEXT;
@@ -348,6 +378,11 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     state->tex_height = 0;
     state->initialized = 1;
     state->owner_thread = pthread_self();
+    /* Register the thread-exit backstop so a capture thread that dies without
+     * drmtap_close() still frees this context (value must be non-NULL to arm
+     * the destructor; the destructor frees the thread-local `state` directly). */
+    pthread_once(&g_egl_tsd_once, egl_tsd_key_init);
+    pthread_setspecific(g_egl_tsd_key, state);
     drmtap_debug_log(NULL, "EGL: init OK: display=%p ctx=%p program=%u fbo=%u (tid=%ld)",
             (void*)state->display, (void*)state->context, state->program, state->fbo, (long)(long)0);
 
@@ -355,24 +390,42 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     return 0;
 }
 
-static void __attribute__((unused)) egl_cleanup(egl_state_t *state) {
-    if (!state->initialized) {
+static void egl_cleanup(egl_state_t *st) {
+    if (!st->initialized) {
         return;
     }
-    eglMakeCurrent(state->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                   state->context);
-    if (state->linear_texture) {
-        glDeleteTextures(1, &state->linear_texture);
+    eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                   st->context);
+    if (st->linear_texture) {
+        glDeleteTextures(1, &st->linear_texture);
     }
-    if (state->fbo) {
-        glDeleteFramebuffers(1, &state->fbo);
+    if (st->fbo) {
+        glDeleteFramebuffers(1, &st->fbo);
     }
-    if (state->program) {
-        glDeleteProgram(state->program);
+    if (st->program) {
+        glDeleteProgram(st->program);
     }
-    eglDestroyContext(state->display, state->context);
-    eglTerminate(state->display);
-    state->initialized = 0;
+    /* Release the context from this thread before destroying it. MUST NOT
+     * eglTerminate(st->display): g_egl_display is shared across all capture
+     * threads; terminating it invalidates other threads' live detile contexts
+     * (see the CRITICAL note in drmtap_gpu_egl_available). */
+    eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                   EGL_NO_CONTEXT);
+    eglDestroyContext(st->display, st->context);
+    st->context = EGL_NO_CONTEXT;
+    st->program = 0;
+    st->fbo = 0;
+    st->linear_texture = 0;
+    st->tex_width = 0;
+    st->tex_height = 0;
+    st->initialized = 0;
+}
+
+/* Release THIS thread's EGL context + GL resources. Safe no-op if this thread
+ * never built a context. Called from drmtap_close() on the capture thread (and
+ * by the TSD backstop at thread exit); idempotent. */
+void drmtap_gpu_egl_thread_cleanup(void) {
+    egl_cleanup(&state);
 }
 
 /* Ensure the linear output texture matches the capture dimensions */
@@ -493,36 +546,13 @@ static int egl_convert_impl(drmtap_ctx *ctx,
         return -EINVAL;
     }
 
-    /* Lazy-init EGL state, one per thread.
-     *
-     * MUST be thread-local: an EGL/GL context is current in at most one thread,
-     * and each capture (e.g. one per monitor in a multi-display session) runs on
-     * its own thread. A single process-global state shared across threads would
-     * race on the FBO/program/textures and thrash the context (via the
-     * owner-thread re-creation below), producing corrupted/garbage frames under
-     * concurrent capture. Thread-local storage gives each capture thread its own
-     * EGL context over the shared EGLDisplay — the correct EGL threading model. */
-    static _Thread_local egl_state_t state = {0};
+    /* Lazy-init this thread's EGL context. `state` is the file-scope
+     * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
+     * on close. (A `_Thread_local` is per-thread, so there is no cross-thread
+     * owner check to do here — each thread only ever sees its own instance.) */
     int ret;
 
     drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
-    if (state.initialized && state.owner_thread != pthread_self()) {
-        drmtap_debug_log(NULL, "EGL: thread changed! old=%lu new=%lu, re-creating context",
-                (unsigned long)state.owner_thread, (unsigned long)pthread_self());
-        /* Destroy old context — it belongs to a different thread */
-        eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                       EGL_NO_CONTEXT);
-        if (state.program) glDeleteProgram(state.program);
-        if (state.fbo) glDeleteFramebuffers(1, &state.fbo);
-        if (state.linear_texture) glDeleteTextures(1, &state.linear_texture);
-        eglDestroyContext(state.display, state.context);
-        state.initialized = 0;
-        state.program = 0;
-        state.fbo = 0;
-        state.linear_texture = 0;
-        state.tex_width = 0;
-        state.tex_height = 0;
-    }
     if (!state.initialized) {
         ret = egl_init(ctx, &state);
         drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);
@@ -789,8 +819,9 @@ cleanup:
     glDeleteTextures(1, &ext_texture);
     pfn_eglDestroyImageKHR(state.display, image);
 
-    /* Release EGL context from current thread so it can be
-     * claimed by a different thread on the next call */
+    /* The context stays current on this (capture) thread and is reused across
+     * calls — each thread owns its own thread-local context. It is released by
+     * drmtap_gpu_egl_thread_cleanup() at drmtap_close() / thread exit. */
     return ret;
 }
 
@@ -814,6 +845,10 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
     (void)out_data; (void)out_size;
     drmtap_set_error(ctx, "EGL backend not available (built without EGL)");
     return -ENOTSUP;
+}
+
+void drmtap_gpu_egl_thread_cleanup(void) {
+    /* No EGL backend compiled in — nothing to release. */
 }
 
 #endif /* HAVE_EGL */

--- a/tools/README.md
+++ b/tools/README.md
@@ -29,9 +29,14 @@ a breaking ABI change (see `DRMTAP_ABI_MAJOR` in the rustdesk loader).
 | --- | --- |
 | `set-version.sh X.Y.Z` | Stamps the 5 code sites (C header, csrc header, meson, `libdrmtap-sys` crate, and the wrapper's dependency on it). Leaves the wrapper crate's own separate version line and prose in docs untouched. |
 | `sync-crate.sh [--check]` | Regenerates `bindings/rust/libdrmtap-sys/csrc/` from the library sources (with the one packaging include-path fixup). `--check` fails on drift instead of writing — used by CI. |
-| `check-version.sh` | Fails if any version site disagrees with the canonical header, or if `csrc/` has drifted from the library. Also prints a non-fatal advisory listing doc version strings for manual review. Wired into CI as the `version-coherence` job. |
+| `check-version.sh` | Fails if any version site disagrees with the canonical header, or if `csrc/` has drifted from the library. Also prints a non-fatal advisory listing every libdrmtap version string **across the whole repo** (`*.md`/`*.toml`/`*.rs` under `docs/`, `contrib/`, `patches/`, and the READMEs — not just the top-level ones) that is not the canonical version, for manual review. Wired into CI as the `version-coherence` job. |
 
 Docs and READMEs carry version numbers in prose (both "current" pointers and
-historical statements). Those are intentionally not machine-stamped; the
-`check-version.sh` advisory lists them so a human can update the current ones and
-leave the historical ones alone.
+historical statements), and so do integration snippets under `contrib/` and the
+`patches/` bundle and the `docs/research/` corpus. Those are intentionally not
+machine-stamped; the `check-version.sh` advisory scans the whole repo (scoped to
+lines that mention libdrmtap, so unrelated dep versions are not flagged) and lists
+them so a human can update the current ones and leave the historical ones alone.
+The scan is repo-wide on purpose: a stale `libdrmtap-sys = "…"` pin in a `contrib/`
+snippet or a "published on crates.io" line in `docs/research/` once shipped stale
+because the advisory only looked at the top-level READMEs.

--- a/tools/check-version.sh
+++ b/tools/check-version.sh
@@ -48,15 +48,29 @@ if ! "$root/tools/sync-crate.sh" --check; then
     fail=1
 fi
 
-# Advisory only (never fails the build): surface version-looking strings in the
-# user-facing docs that are not the canonical version, so a human can decide
-# whether they are stale current-pointers or intentional history.
-echo "advisory: doc version strings that are not $ver (review manually):"
-grep -rnoE "$sem" \
-    "$root/README.md" "$root/AGENTS.md" \
-    "$root/bindings/rust/libdrmtap-sys/README.md" \
-    "$root/bindings/rust/libdrmtap/README.md" 2>/dev/null \
-    | grep -vE ":$ver$" | grep -vE "0\.3\.[0-9]+$" | sed 's/^/    /' || echo "    (none)"
+# Advisory only (never fails the build): surface version-looking strings that are
+# not the canonical version so a human can decide whether each is a stale
+# current-pointer (bump it) or intentional history ("shipped in X.Y.Z" — leave
+# it). Scans the WHOLE repo's docs + config (every *.md, *.toml, *.rs — the
+# top-level READMEs, AGENTS.md, docs/, contrib/, patches/, and the crates), NOT
+# just the top-level READMEs: contrib/ + patches/ + docs/research/ carry
+# current-pointer versions (integration snippets, "published on crates.io" status
+# lines, scrap dependency pins) that a 4-file scan silently missed and let ship
+# stale. Build artifacts are excluded. The wrapper's own 0.3.x line is filtered
+# out (its version is intentionally a separate track).
+echo "advisory: libdrmtap version strings that are not $ver (review: stale current-pointer vs intentional history):"
+# Scan with RELATIVE paths (cd "$root") so the repo dir name ("libdrmtap") is not
+# in the path — otherwise the drmtap scope filter below would match every line.
+# Keep only lines whose CONTENT mentions drmtap (a libdrmtap version reference),
+# dropping unrelated deps (rustdesk 1.x, tokio, etc.); drop the canonical version
+# and the wrapper's separate 0.3.x line.
+( cd "$root" && grep -rnE "$sem" . \
+    --include='*.md' --include='*.toml' --include='*.rs' \
+    --exclude-dir='.git' --exclude-dir='build' --exclude-dir='build-pkg' --exclude-dir='target' \
+    2>/dev/null ) \
+    | grep -iE 'drmtap' \
+    | grep -vF "$ver" | grep -vE "0\.3\.[0-9]+" \
+    | sed 's/^/    /' || echo "    (none)"
 
 if [ $fail -ne 0 ]; then
     echo "version coherence FAILED" >&2


### PR DESCRIPTION
two fixes surfaced while testing rustdesk DRM/KMS capture on an intel i915 host with 4-tiled MTL RC CCS scanouts.

1- BUG-1 (memory leak to OOM): the per-thread EGL detile context had no teardown. egl_cleanup was marked unused and also called eglTerminate on the process-shared display. so every capture worker thread that detiled a tiled/CCS scanout and then exited orphaned a whole EGL context plus a ~33 MB linear texture at 4K, and a reconnect loop climbed to tens of GB and got OOM-killed. fix: move the thread-local state to file scope, add drmtap_gpu_egl_thread_cleanup that frees the context/program/fbo/texture without eglTerminate (idempotent), call it from drmtap_close on the capture thread, plus a pthread_key backstop for a thread that exits without close. removed the dead cross-thread re-creation branch.

2- BUG-3 (wrong-CRTC): a compositor-managed connector reports crtc_id 0 via the legacy encoder link, and open(crtc=0) auto-selects the first active CRTC, so selecting that display captured the wrong monitor. fix: set DRM_CLIENT_CAP_ATOMIC best-effort (read-only) and fall back to the connector CRTC_ID property to resolve the real scanout CRTC. a genuinely unbound connector still resolves to 0.

verification:
1- werror build, 7/7 unit tests pass
2- screenshot example still detiles the 4K CCS scanout via EGL unchanged (atomic cap does not regress capture)
3- a 60-iteration open/grab/close churn test (fresh thread each, EGL detile of the 4K scanout) holds RSS flat at ~109 MB where the pre-fix leak would have been ~2 GB
4- version bumped to 0.4.8 across all sites, check-version coherent