### PR TITLE
split capture into privileged export + unprivileged convert (0.4.9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,14 @@ bindings/rust/target/
 
 # Library workspace lockfile (not tracked for a published lib)
 bindings/rust/Cargo.lock
+
+# Secrets — never commit API keys / tokens / credentials (e.g. CodeRabbit cr-*)
+.env
+.env.*
+*.key
+*.pem
+*.p12
+*secret*
+*credential*
+*.token
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 **Language:** C11  
 **License:** MIT  
 **Tests:** unit (no hardware) + integration via VKMS (Virtual KMS) or a real GPU  
-**Version:** C library `0.4.8` · Rust crates `libdrmtap-sys 0.4.8` / `libdrmtap 0.3.4`  
+**Version:** C library `0.4.9` · Rust crates `libdrmtap-sys 0.4.9` / `libdrmtap 0.3.4`  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ int main() {
 libdrmtap = "0.3"
 ```
 
-> This pulls in `libdrmtap-sys` 0.4.8, which embeds and statically compiles the
+> This pulls in `libdrmtap-sys` 0.4.9, which embeds and statically compiles the
 > C sources (and the privilege helper). No system `libdrmtap` install, no
 > `meson install`, no `pkg-config` to find a shared library.
 
@@ -195,7 +195,7 @@ sudo ./build/vnc_server
 libdrmtap is being upstreamed into [RustDesk](https://github.com/rustdesk/rustdesk)
 via [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420).
 The integration adds a `drm` backend to `scrap` that depends on the
-[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.8 crate, which
+[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.9 crate, which
 embeds and statically compiles the C sources (and the privilege helper) — so
 there is no system `libdrmtap` install and no dynamic `libdrmtap.so` linkage.
 

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.8"
+version = "0.4.9"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/build.rs
+++ b/bindings/rust/libdrmtap-sys/build.rs
@@ -60,14 +60,17 @@ fn main() {
 
     build.compile("drmtap");
 
-    // System dependencies.
+    // System dependencies. EGL/GLESv2 are intentionally NOT linked: gpu_egl.c
+    // dlopen()s them lazily on first convert so a privileged process that
+    // never converts never maps the GPU stack (their headers are still needed
+    // at compile time).
     println!("cargo:rustc-link-lib=drm");
-    println!("cargo:rustc-link-lib=EGL");
-    println!("cargo:rustc-link-lib=GLESv2");
     println!("cargo:rustc-link-lib=seccomp");
     println!("cargo:rustc-link-lib=cap");
     // libm: HDR tone-mapping in pixel_convert.c uses pow()/tanh().
     println!("cargo:rustc-link-lib=m");
+    // libdl: only a real library pre-glibc-2.34; harmless (a stub) after.
+    println!("cargo:rustc-link-lib=dl");
 
     // Compile drmtap-helper as a standalone executable.
     // It inherits a socketpair fd from the parent, opens the DRM device with

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -294,8 +294,9 @@ static int dmabuf_sync_end(int fd) {
  * Caps the allocation at DRMTAP_MAX_FB_BYTES as a guard against a bogus/hostile
  * framebuffer geometry forcing an unbounded request. Contents are not preserved
  * across a grow. Returns 0, -EINVAL (zero size), -EFBIG (over the cap), or
- * -ENOMEM. */
-static int ensure_buf(void **buf, size_t *cap, size_t size) {
+ * -ENOMEM. Shared across modules (gpu_egl.c reads back into the same ctx
+ * buffer), hence not static. */
+int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
     if (size == 0) {
         return -EINVAL;
     }
@@ -400,6 +401,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     drmModeFB2 *fb2 = NULL;
     int prime_fd = -1;
 
+    if (ctx->is_render_only) {
+        drmtap_set_error(ctx, "context is render-only (drmtap_open_render); "
+                         "grab needs a KMS context from drmtap_open");
+        return -ENOTSUP;
+    }
+
     /* Step 1: Find the primary plane */
     uint32_t plane_id = find_primary_plane(ctx);
     if (plane_id == 0) {
@@ -474,10 +481,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             "No CAP_SYS_ADMIN (needs helper), trying helper...");
 
         /* Receive buffer for the helper to fill. ctx-owned, grow-once and
-         * reused across grabs (never per-frame churn), capped — see ensure_buf.
-         * Freed in drmtap_close(). */
+         * reused across grabs (never per-frame churn), capped — see
+         * drmtap_ensure_buf. Freed in drmtap_close(). */
         size_t buf_size = (size_t)fb2->pitches[0] * fb2->height;
-        ret = ensure_buf(&ctx->pixel_buf, &ctx->pixel_buf_size, buf_size);
+        ret = drmtap_ensure_buf(&ctx->pixel_buf, &ctx->pixel_buf_size, buf_size);
         if (ret != 0) {
             if (ret == -EFBIG) {
                 drmtap_set_error(ctx,
@@ -801,7 +808,8 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     }
 
     size_t out_size = (size_t)frame->width * frame->height * 4u;
-    int b = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, out_size);
+    int b = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                              out_size);
     if (b != 0) return b;
     uint32_t dst_stride = frame->width * 4u;
     int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
@@ -874,13 +882,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
 
 
     /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
-     * see ensure_buf). frame->stride/height are validated at every entry point
+     * see drmtap_ensure_buf). frame->stride/height are validated at every entry point
      * (validate_fb_size), so this multiply cannot overflow. NOTE: this does NOT
      * bound the EGL output, which is always 4-byte RGBA — a sub-4-byte source
      * (e.g. RG16) can expand past stride*height, so the EGL path caps egl_size
      * separately below. */
     size_t size = (size_t)frame->stride * frame->height;
-    int bres = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    int bres = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                                 size);
     if (bres != 0) {
         if (bres == -EFBIG) {
             drmtap_set_error(ctx,
@@ -910,23 +919,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         int ret = drmtap_gpu_egl_convert(ctx, frame->dma_buf_fd,
                                           frame->width, frame->height,
                                           frame->stride, frame->format,
-                                          modifier, &egl_data, &egl_size);
+                                          modifier, frame->fb_id,
+                                          &egl_data, &egl_size);
         drmtap_debug_log(ctx, "EGL convert: ret=%d data=%p", ret, egl_data);
         if (ret == 0 && egl_data) {
-            /* The EGL output is 4-byte RGBA and can exceed the source
-             * stride*height for sub-4-byte formats, so cap it independently
-             * before adopting it as the context buffer. */
-            if (egl_size > DRMTAP_MAX_FB_BYTES) {
-                free(egl_data);
-                drmtap_set_error(ctx, "EGL output too large: %zu bytes (max %zu)",
-                                 egl_size, (size_t)DRMTAP_MAX_FB_BYTES);
-                return -EFBIG;
-            }
-            /* Store in ctx for reuse / cleanup */
-            free(ctx->deswizzle_buf);
-            ctx->deswizzle_buf = egl_data;
-            ctx->deswizzle_buf_size = egl_size;
-            frame->data = ctx->deswizzle_buf;
+            /* egl_data IS ctx->deswizzle_buf: the convert reads back into the
+             * ctx-owned grow-once buffer (size-capped inside), so adopting it
+             * is just repointing the frame — no allocation churn. */
+            frame->data = egl_data;
             /* EGL outputs RGBA/BGRA 8-bit */
             frame->format = DRM_FORMAT_XRGB8888;
             frame->stride = frame->width * 4;
@@ -1138,9 +1138,27 @@ static int find_or_alloc_slot(drmtap_ctx *ctx, uint32_t fb_id) {
     return 0;
 }
 
+/* Restage a cached slot's captured plane layout into ctx->fb2_*. A fast-path
+ * cache HIT skips GetFB2, so without this ctx->fb2_* still describes whichever
+ * fb was last GetFB2'd — and the EGL detile / CCS import (plus the EGLImage
+ * cache's geometry compare) reads ctx->fb2_*. Restaging the slot's own layout
+ * keeps the plane metadata matched to the frame actually being converted. */
+static void fast_slot_restage_planes(drmtap_ctx *ctx, int slot) {
+    ctx->fb2_num_planes = ctx->fast_slots[slot].fb2_num_planes;
+    for (int p = 0; p < 4; p++) {
+        ctx->fb2_pitches[p] = ctx->fast_slots[slot].fb2_pitches[p];
+        ctx->fb2_offsets[p] = ctx->fast_slots[slot].fb2_offsets[p];
+    }
+}
+
 int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     if (!ctx || !frame) {
         return -EINVAL;
+    }
+    if (ctx->is_render_only) {
+        drmtap_set_error(ctx, "context is render-only (drmtap_open_render); "
+                         "grab needs a KMS context from drmtap_open");
+        return -ENOTSUP;
     }
 
     int ret;
@@ -1196,6 +1214,9 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                 frame->modifier = ctx->fast_slots[i].modifier;
                 frame->fb_id = fb_id;
                 frame->_priv = NULL;
+                /* Restage this slot's plane layout before converting (the
+                 * cache HIT skipped GetFB2, so ctx->fb2_* is otherwise stale). */
+                fast_slot_restage_planes(ctx, i);
                 /* Deswizzle/format-convert like the acquire path does — the
                  * cached mmap is the raw scanout, so a tiled buffer must be
                  * detiled here too (no-op for a linear one). Without this the
@@ -1245,6 +1266,9 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         frame->fb_id = fb_id;
         frame->_priv = NULL;
 
+        /* Restage this slot's plane layout before converting (the cache HIT
+         * skipped GetFB2, so ctx->fb2_* is otherwise stale). */
+        fast_slot_restage_planes(ctx, slot);
         /* Auto-deswizzle tiled framebuffers + format convert */
         gpu_auto_process(ctx, frame->data, frame, 0);
 
@@ -1276,6 +1300,18 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);
         return ret;
+    }
+
+    /* Cache multi-plane info for the EGL CCS import. The EGL path reads plane
+     * offsets/pitches from ctx->fb2_*, which otherwise still holds whatever
+     * the last do_grab() left there (stale geometry from another fb). */
+    ctx->fb2_num_planes = 0;
+    for (int p = 0; p < 4; p++) {
+        ctx->fb2_pitches[p] = fb2->pitches[p];
+        ctx->fb2_offsets[p] = fb2->offsets[p];
+        if (fb2->handles[p] || fb2->pitches[p]) {
+            ctx->fb2_num_planes = p + 1;
+        }
     }
 
     /* Export DMA-BUF */
@@ -1325,6 +1361,14 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;
     ctx->fast_slots[slot].modifier = fb2->modifier;
+    /* Capture this fb's plane layout with the slot so a later cache HIT can
+     * restage it into ctx->fb2_* (ctx->fb2_* was set from this same fb2 just
+     * above, at the "Cache multi-plane info" block). */
+    ctx->fast_slots[slot].fb2_num_planes = ctx->fb2_num_planes;
+    for (int p = 0; p < 4; p++) {
+        ctx->fast_slots[slot].fb2_pitches[p] = ctx->fb2_pitches[p];
+        ctx->fast_slots[slot].fb2_offsets[p] = ctx->fb2_offsets[p];
+    }
 
     drmtap_debug_log(ctx, "fast2: cached fb=%u slot=%d gem=%u %ux%u",
                      fb_id, slot, fb2->handles[0], fb2->width, fb2->height);
@@ -1347,4 +1391,171 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     gpu_auto_process(ctx, frame->data, frame, 0);
 
     return 0;   /* new frame */
+}
+
+/* ========================================================================= */
+/* Split capture: unprivileged convert of an externally-supplied DMA-BUF     */
+/* ========================================================================= */
+
+/* Minimum bytes-per-pixel of a scanout fourcc, for the width*bpp <= stride
+ * bound. The CPU deswizzle/reduce paths index the row as pixel[x] for
+ * x < width, so a stride that does not cover width*bpp would read/write past
+ * the row. 8-bit and 10-bit RGB pack into 4 bytes; the 16-bit-per-channel
+ * formats into 8. Unknown fourccs default to 4: a real desktop scanout is
+ * never sub-4-byte, and the tiled deswizzle writes 4-byte pixels, so 4 is the
+ * safe floor to reject a hostile narrow stride. */
+static uint32_t format_min_bpp(uint32_t fourcc) {
+    switch (fourcc) {
+    case DRMTAP_FMT_XR48:
+    case DRMTAP_FMT_AR48:
+    case DRMTAP_FMT_XB48:
+    case DRMTAP_FMT_AB48:
+        return 8;
+    default:
+        return 4;
+    }
+}
+
+int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
+                          drmtap_frame_info *frame) {
+    if (!ctx || !desc || !frame) {
+        return -EINVAL;
+    }
+
+    uint32_t num_planes = desc->num_planes ? desc->num_planes : 1;
+    if (num_planes > 4 || desc->width == 0) {
+        drmtap_set_error(ctx, "convert: invalid descriptor "
+                         "(width=%u num_planes=%u)",
+                         desc->width, desc->num_planes);
+        return -EINVAL;
+    }
+    int ret = validate_fb_size(desc->pitches[0], desc->height);
+    if (ret != 0) {
+        drmtap_set_error(ctx, "convert: rejecting geometry %ux%u stride=%u",
+                         desc->width, desc->height, desc->pitches[0]);
+        return ret;
+    }
+    /* The descriptor comes from the (untrusted) exporter over IPC, unlike the
+     * in-process grab whose width/stride come from drmModeGetFB2. validate_fb_size
+     * bounds stride*height but is independent of width — enforce that the row
+     * stride actually covers width pixels so the per-pixel CPU converters below
+     * (and the EGL import) cannot be driven past the buffer. */
+    if ((uint64_t)desc->width * format_min_bpp(desc->format) > desc->pitches[0]) {
+        drmtap_set_error(ctx, "convert: stride %u too small for width %u "
+                         "(fourcc %.4s)", desc->pitches[0], desc->width,
+                         (const char *)&desc->format);
+        return -EINVAL;
+    }
+
+    /* Stage the plane + HDR metadata exactly where the in-process grab
+     * (drmModeGetFB2 + the connector HDR read) would put it — the conversion
+     * paths below consume both from the context. */
+    ctx->fb2_num_planes = (int)num_planes;
+    for (uint32_t p = 0; p < 4; p++) {
+        ctx->fb2_pitches[p] = (p < num_planes) ? desc->pitches[p] : 0;
+        ctx->fb2_offsets[p] = (p < num_planes) ? desc->offsets[p] : 0;
+    }
+    ctx->cur_hdr_eotf = desc->hdr_eotf;
+    ctx->cur_hdr_max_nits = desc->hdr_max_nits;
+
+    memset(frame, 0, sizeof(*frame));
+    frame->width = desc->width;
+    frame->height = desc->height;
+    frame->stride = desc->pitches[0];
+    frame->format = desc->format;
+    frame->modifier = desc->modifier;
+    frame->fb_id = desc->fb_id;
+    frame->dma_buf_fd = desc->dma_buf_fd;
+
+#ifdef HAVE_EGL
+    /* GPU path first: EGL imports the fd (or reuses the fb_id-cached import)
+     * and hands back linear XRGB8888 — one hop covers every vendor tiling,
+     * the 10/16-bit reductions and the HDR tone-map. */
+    if (drmtap_gpu_egl_available(ctx)) {
+        void *egl_data = NULL;
+        size_t egl_size = 0;
+        ret = drmtap_gpu_egl_convert(ctx, desc->dma_buf_fd,
+                                     desc->width, desc->height,
+                                     desc->pitches[0], desc->format,
+                                     desc->modifier, desc->fb_id,
+                                     &egl_data, &egl_size);
+        if (ret == 0 && egl_data) {
+            frame->data = egl_data;   /* ctx-owned grow-once buffer */
+            frame->format = DRM_FORMAT_XRGB8888;
+            frame->stride = desc->width * 4;
+            frame->modifier = DRM_FORMAT_MOD_LINEAR;
+            return 0;
+        }
+        drmtap_debug_log(ctx, "convert: EGL path failed (%d), CPU fallback",
+                         ret);
+    }
+#endif
+
+    /* CPU fallback: map the DMA-BUF read-only and run the same deswizzle /
+     * format-reduction pipeline the in-process grab uses. */
+    if (desc->dma_buf_fd < 0) {
+        drmtap_set_error(ctx, "convert: fb_id %u is not cached and no "
+                         "dma-buf fd was supplied", desc->fb_id);
+        return -EINVAL;
+    }
+    size_t map_size = (size_t)desc->pitches[0] * desc->height;
+    void *mapped = mmap(NULL, map_size, PROT_READ, MAP_SHARED,
+                        desc->dma_buf_fd, desc->offsets[0]);
+    if (mapped == MAP_FAILED) {
+        int mmap_errno = errno;
+        drmtap_set_error(ctx, "convert: mmap(%zu) failed: %s "
+                         "(and no usable EGL path)",
+                         map_size, strerror(mmap_errno));
+        return mmap_errno ? -mmap_errno : -EIO;
+    }
+    int sync_started = (dmabuf_sync_start(desc->dma_buf_fd) == 0);
+
+    /* Hide the fd for the gpu_auto_process call so it stays off the EGL
+     * branch it would otherwise retry (we just watched EGL fail, or it is
+     * unavailable) and takes the CPU deswizzle/reduce paths on `mapped`. */
+    frame->data = mapped;
+    frame->dma_buf_fd = -1;
+    ret = gpu_auto_process(ctx, mapped, frame, 0);
+    frame->dma_buf_fd = desc->dma_buf_fd;
+
+    if (ret == 0 && frame->data == mapped) {
+        /* Linear 8-bit passthrough (no deswizzle / reduction happened). Copy
+         * into the ctx buffer so the pixels survive the temporary mapping,
+         * AND repack to a tight width*4 stride so the returned frame honors
+         * the documented "stride width*4" output even when the source scanout
+         * carried row padding (pitches[0] > width*4). The width*4 <= pitches[0]
+         * bound checked above keeps every per-row read inside the mapping. */
+        uint32_t out_stride = desc->width * 4u;
+        size_t out_size = (size_t)out_stride * desc->height;
+        ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                                out_size);
+        if (ret == 0) {
+            const uint8_t *src = mapped;
+            uint8_t *dst = ctx->deswizzle_buf;
+            if (desc->pitches[0] == out_stride) {
+                memcpy(dst, src, out_size);
+            } else {
+                for (uint32_t y = 0; y < desc->height; y++) {
+                    memcpy(dst + (size_t)y * out_stride,
+                           src + (size_t)y * desc->pitches[0], out_stride);
+                }
+            }
+            frame->data = ctx->deswizzle_buf;
+            frame->stride = out_stride;
+        }
+    }
+
+    if (sync_started) {
+        dmabuf_sync_end(desc->dma_buf_fd);
+    }
+    munmap(mapped, map_size);
+
+    if (ret == 0 && !frame->data) {
+        drmtap_set_error(ctx, "convert: no conversion path produced pixels");
+        ret = -ENOTSUP;
+    }
+    if (ret != 0) {
+        frame->data = NULL;
+    }
+    return ret;
 }

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -279,6 +279,85 @@ fail:
     return NULL;
 }
 
+drmtap_ctx *drmtap_open_render(const char *render_node) {
+    drmtap_ctx *ctx = calloc(1, sizeof(drmtap_ctx));
+    if (!ctx) {
+        drmtap_set_error(NULL, "Failed to allocate context: %s",
+                         strerror(errno));
+        return NULL;
+    }
+
+    ctx->drm_fd = -1;
+    ctx->helper_pid = -1;
+    ctx->helper_fd = -1;
+    ctx->is_render_only = 1;
+    for (int i = 0; i < DRMTAP_FAST_SLOTS; i++) {
+        ctx->fast_slots[i].prime_fd = -1;
+    }
+
+    const char *dbg_env = getenv("DRMTAP_DEBUG");
+    if (dbg_env && dbg_env[0] == '1') {
+        ctx->debug = 1;
+    }
+
+    drmtap_debug_log(ctx, "drmtap v%d.%d.%d opening render-only (pid=%d uid=%d)",
+                     DRMTAP_VERSION_MAJOR, DRMTAP_VERSION_MINOR,
+                     DRMTAP_VERSION_PATCH, getpid(), getuid());
+
+    if (render_node && render_node[0]) {
+        snprintf(ctx->device_path, sizeof(ctx->device_path), "%s", render_node);
+        ctx->drm_fd = open(render_node, O_RDWR | O_CLOEXEC);
+        if (ctx->drm_fd < 0) {
+            drmtap_set_error(NULL, "Failed to open %s: %s",
+                             render_node, strerror(errno));
+            goto fail;
+        }
+    } else {
+        /* Auto-detect: first openable render node (render minors start at 128).
+         * No KMS probing here on purpose — a render node has no resources. */
+        for (int i = 128; i < 128 + 16; i++) {
+            char path[64];
+            snprintf(path, sizeof(path), "/dev/dri/renderD%d", i);
+            int fd = open(path, O_RDWR | O_CLOEXEC);
+            if (fd >= 0) {
+                snprintf(ctx->device_path, sizeof(ctx->device_path),
+                         "%s", path);
+                ctx->drm_fd = fd;
+                break;
+            }
+        }
+        if (ctx->drm_fd < 0) {
+            drmtap_set_error(NULL,
+                "No DRM render node found (/dev/dri/renderD*)");
+            goto fail;
+        }
+    }
+
+    /* Same low-fd protection as drmtap_open: async runtimes can close/reuse
+     * low-numbered fds. */
+    {
+        int high_fd = fcntl(ctx->drm_fd, F_DUPFD_CLOEXEC, 100);
+        if (high_fd >= 0) {
+            close(ctx->drm_fd);
+            ctx->drm_fd = high_fd;
+        }
+    }
+
+    /* The driver name selects the CPU deswizzle fallback when EGL is out. */
+    detect_driver(ctx);
+
+    drmtap_debug_log(ctx, "render context opened: %s (%s)",
+                     ctx->device_path, ctx->driver_name);
+    return ctx;
+
+fail:
+    if (ctx->drm_fd >= 0) {
+        close(ctx->drm_fd);
+    }
+    free(ctx);
+    return NULL;
+}
+
 void drmtap_close(drmtap_ctx *ctx) {
     if (!ctx) {
         return;

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -313,9 +313,11 @@ drmtap_ctx *drmtap_open_render(const char *render_node) {
             goto fail;
         }
     } else {
-        /* Auto-detect: first openable render node (render minors start at 128).
-         * No KMS probing here on purpose — a render node has no resources. */
-        for (int i = 128; i < 128 + 16; i++) {
+        /* Auto-detect: first openable render node. DRM render minors span the
+         * whole 128..191 range (up to 64 nodes on a multi-GPU box), so scan all
+         * of it — a valid device can sit above renderD143. No KMS probing here
+         * on purpose: a render node has no resources. */
+        for (int i = 128; i < 128 + 64; i++) {
             char path[64];
             snprintf(path, sizeof(path), "/dev/dri/renderD%d", i);
             int fd = open(path, O_RDWR | O_CLOEXEC);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 8
+#define DRMTAP_VERSION_PATCH 9
 
 /**
  * @brief Get the library version as a packed integer.
@@ -200,6 +200,120 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame);
  * @param frame Frame to release
  */
 void drmtap_frame_release(drmtap_ctx *ctx, drmtap_frame_info *frame);
+
+/* ========================================================================= */
+/* Split capture: privileged export + unprivileged convert                   */
+/* ========================================================================= */
+/*
+ * These entry points let a caller that already owns a privilege boundary
+ * (e.g. a root service + an unprivileged worker) run the DRM export and the
+ * GPU detile/convert in DIFFERENT processes, so the EGL/GLES and vendor GPU
+ * driver stack never load into the privileged one.
+ *
+ *   privileged side:   drmtap_open() + drmtap_grab()  -> dma_buf_fd + metadata
+ *                      (minimal DRM ops only; libEGL/libGLESv2 are dlopen'd
+ *                       lazily on first convert, so a process that never
+ *                       converts never maps the GPU stack at all)
+ *   unprivileged side: drmtap_open_render() + drmtap_convert_dmabuf()
+ *                      (imports the fd, EGL-detiles, converts to linear RGBA)
+ *
+ * The fd + metadata are carried between the two processes by the caller
+ * (e.g. over a unix socket with SCM_RIGHTS) — libdrmtap does not impose a
+ * wire format.
+ */
+
+/* Electro-optical transfer function of a scanout, from the connector
+ * HDR_OUTPUT_METADATA infoframe (kernel/CTA-861 numbering). PQ means
+ * "tone-map this"; HLG currently gets the plain bit-depth reduction
+ * (PQ/HDR10 is the desktop norm). */
+#define DRMTAP_EOTF_SDR  0  /**< traditional gamma SDR (or no HDR metadata) */
+#define DRMTAP_EOTF_PQ   2  /**< SMPTE ST 2084 (HDR10) */
+#define DRMTAP_EOTF_HLG  3  /**< Hybrid Log-Gamma (BT.2100) */
+
+/**
+ * @brief Descriptor of an externally-supplied scanout DMA-BUF.
+ *
+ * Filled by the caller from what the privileged exporter produced
+ * (drmtap_grab() frame metadata plus the connector HDR state) and shipped
+ * over IPC. num_planes/offsets/pitches carry the auxiliary planes of
+ * compressed layouts (e.g. Intel CCS: main surface + CCS aux + clear-color);
+ * all planes live inside the one dma_buf_fd, as DRM GetFB2 reports them.
+ */
+typedef struct {
+    int dma_buf_fd;         /**< Scanout DMA-BUF. May be -1 for an fb_id this
+                                 context has already imported (see
+                                 drmtap_convert_dmabuf). */
+    uint32_t width;         /**< Frame width in pixels */
+    uint32_t height;        /**< Frame height in pixels */
+    uint32_t format;        /**< DRM fourcc of the scanout */
+    uint64_t modifier;      /**< DRM format modifier (tiling/compression) */
+    uint32_t fb_id;         /**< KMS framebuffer id — the import-once cache
+                                 key. 0 disables caching for this frame. */
+    uint32_t num_planes;    /**< Used entries in offsets/pitches (1..4);
+                                 0 is treated as 1 */
+    uint32_t offsets[4];    /**< Per-plane byte offsets into the DMA-BUF */
+    uint32_t pitches[4];    /**< Per-plane strides in bytes; pitches[0] is the
+                                 main surface stride */
+    uint32_t hdr_eotf;      /**< DRMTAP_EOTF_*: PQ triggers the HDR->SDR
+                                 tone-map during conversion */
+    uint32_t hdr_max_nits;  /**< Mastering/content peak luminance (cd/m2),
+                                 0 = unknown */
+} drmtap_dmabuf_desc;
+
+/**
+ * @brief Open an UNPRIVILEGED, render-only context for drmtap_convert_dmabuf().
+ *
+ * Opens a DRM render node only. It does NOT open a KMS card, spawn the
+ * privileged helper, or enumerate displays, and it needs no elevated
+ * capability. Grab entry points return -ENOTSUP on this context.
+ *
+ * @param render_node Render node path (e.g. "/dev/dri/renderD128"),
+ *                    or NULL to auto-select the first usable one.
+ * @return Context handle, or NULL on error (call drmtap_error(NULL) for message)
+ */
+drmtap_ctx *drmtap_open_render(const char *render_node);
+
+/**
+ * @brief Convert an externally-supplied scanout frame to linear RGBA.
+ *
+ * On success frame->data points to context-owned pixels valid until the next
+ * convert on this context or drmtap_close(). Do NOT free it and do NOT call
+ * drmtap_frame_release() on it — there is nothing per-frame to release.
+ * ALWAYS read the returned frame->format, ->stride and ->modifier to describe
+ * the buffer:
+ *   - the GPU (EGL) path normalizes every input to XRGB8888, stride width*4,
+ *     modifier LINEAR;
+ *   - the CPU fallback (used only when no EGL backend is available) also
+ *     returns LINEAR width*4 pixels, but may keep the source 8-bit channel
+ *     order (e.g. XBGR8888) in frame->format.
+ * A well-behaved caller reads frame->format/->stride rather than assuming a
+ * fixed layout.
+ *
+ * Import-once: the DMA-BUF import (EGLImage) is cached keyed by desc->fb_id
+ * plus the buffer's identity (its dma-buf inode), so a fb_id the compositor
+ * recycles onto a NEW buffer re-imports instead of serving stale pixels. The
+ * compositor cycles a small pool of framebuffers, so after the first few
+ * frames every convert hits the cache and no per-frame import happens. For a
+ * known fb_id desc->dma_buf_fd may be -1; whenever the fb_id is new — or was
+ * recycled — a valid fd must be supplied. The cached import holds its own
+ * reference on the buffer, so the caller may close its fd right after the
+ * call. DRMTAP_NO_IMAGE_CACHE=1 forces a fresh import per frame (debug aid).
+ *
+ * Threading: call convert AND drmtap_close for a given context from the SAME
+ * thread. The EGL state and its cached imports are thread-local; closing on a
+ * different thread cannot release them and would strand the cached buffers.
+ *
+ * When no GPU path is usable the conversion falls back to a CPU mmap +
+ * deswizzle of the fd (same pipeline as the in-process grab).
+ *
+ * @param ctx   Context from drmtap_open_render() (or any context with a
+ *              usable EGL backend)
+ * @param desc  Input frame descriptor (metadata from the exporter)
+ * @param frame Output frame (data/format/stride/modifier filled on return)
+ * @return 0 on success, negative errno on error
+ */
+int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
+                          drmtap_frame_info *frame);
 
 /* ========================================================================= */
 /* Cursor Capture                                                            */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -42,6 +42,10 @@ struct drmtap_ctx {
     /* Selected display */
     uint32_t crtc_id;
 
+    /* 1 = context from drmtap_open_render(): render node only, no KMS.
+     * Grab entry points reject it; only drmtap_convert_dmabuf() applies. */
+    int is_render_only;
+
     /* Cached resources for hotplug detection */
     uint32_t cached_connector_count;
     uint32_t cached_crtc_count;
@@ -72,6 +76,12 @@ struct drmtap_ctx {
         uint32_t width, height, stride;
         uint32_t format;
         uint64_t modifier;
+        /* Full plane layout captured at cache-miss (GetFB2) time. Restaged
+         * into ctx->fb2_* on every cache HIT so the EGL detile / CCS import
+         * sees THIS fb's planes, not whatever the last GetFB2 left there. */
+        int      fb2_num_planes;
+        uint32_t fb2_pitches[4];
+        uint32_t fb2_offsets[4];
     } fast_slots[4];
     uint32_t fast_plane_id;         /* cached primary plane id */
     uint32_t fast_last_fb_id;       /* fb_id from last capture (change detect) */
@@ -121,12 +131,8 @@ typedef struct {
 
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */
-/* DRM EOTF values (from the connector HDR_OUTPUT_METADATA infoframe). These
- * match the kernel/CTA-861 numbering. PQ means "tone-map this"; HLG currently
- * falls back to the plain bit-depth reduction (PQ/HDR10 is the desktop norm). */
-#define DRMTAP_EOTF_SDR  0  /* traditional gamma SDR (or no HDR metadata) */
-#define DRMTAP_EOTF_PQ   2  /* SMPTE ST 2084 (HDR10) */
-#define DRMTAP_EOTF_HLG  3  /* Hybrid Log-Gamma (BT.2100) */
+/* DRMTAP_EOTF_* moved to the public header (drmtap.h): the split-capture
+ * descriptor carries the scanout EOTF across the process boundary. */
 
 /* Flags for helper_grab_result_t.flags */
 #define HELPER_FLAG_HAS_DMABUF  0x01  /* DMA-BUF fd follows via SCM_RIGHTS */
@@ -205,13 +211,22 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
                               uint32_t stride, uint32_t format,
                               uint64_t modifier);
 
-/* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c) */
+/* Ensure *buf holds at least `size` bytes: grow-once, never shrinks, capped
+ * at DRMTAP_MAX_FB_BYTES. Contents are not preserved across a grow. Returns
+ * 0, -EINVAL (zero size), -EFBIG (over the cap) or -ENOMEM. (drm_grab.c) */
+int drmtap_ensure_buf(void **buf, size_t *cap, size_t size);
+
+/* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
+ * On success *out_data points at ctx->deswizzle_buf (ctx-owned, grow-once,
+ * valid until the next convert or drmtap_close) — the caller must NOT free
+ * it. fb_id keys the import-once EGLImage cache (0 = no caching); for an
+ * fb_id already cached with matching geometry dma_buf_fd may be -1. */
 int drmtap_gpu_egl_available(drmtap_ctx *ctx);
 int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             int dma_buf_fd,
                             uint32_t width, uint32_t height,
                             uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
+                            uint64_t modifier, uint32_t fb_id,
                             void **out_data, size_t *out_size);
 
 /* Release the calling thread's lazily-built EGL detile context + GL resources.

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -29,6 +29,13 @@
  *   - GL_OES_EGL_image_external
  */
 
+/* _GNU_SOURCE: expose POSIX types (ino_t via <sys/stat.h>) and syscall() under
+ * -std=c11 strict mode, matching the other translation units. Guarded because
+ * the Rust cc build passes -D_GNU_SOURCE on the command line. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <pthread.h>
@@ -40,6 +47,9 @@
 
 #ifdef HAVE_EGL
 
+#include <dlfcn.h>
+#include <sys/stat.h>
+
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLES2/gl2.h>
@@ -49,12 +59,202 @@
 #include "drmtap_internal.h"
 
 /* ========================================================================= */
+/* Lazy runtime loading of libEGL / libGLESv2                                */
+/* ========================================================================= */
+/*
+ * libEGL and libGLESv2 are resolved with dlopen() on first use instead of
+ * being linked as DT_NEEDED, so the GPU userspace stack (and everything it
+ * drags in) is only mapped into processes that actually convert frames. In
+ * the split capture model the privileged exporter calls only
+ * drmtap_open()/drmtap_grab(), which never reach this backend, so the GL
+ * stack never loads into the privileged process.
+ *
+ * The handles are never dlclose()d: GL drivers install thread-local state and
+ * worker threads that do not survive an unload, and the per-thread contexts
+ * released by the TSD destructor can still run at thread exit. One-time load,
+ * process lifetime — the same lifetime a DT_NEEDED link had.
+ */
+
+#define DRMTAP_EGL_CORE_SYMBOLS(X) \
+    X(eglBindAPI) \
+    X(eglChooseConfig) \
+    X(eglCreateContext) \
+    X(eglDestroyContext) \
+    X(eglGetDisplay) \
+    X(eglGetError) \
+    X(eglGetProcAddress) \
+    X(eglInitialize) \
+    X(eglMakeCurrent)
+
+#define DRMTAP_GLES_CORE_SYMBOLS(X) \
+    X(glActiveTexture) \
+    X(glAttachShader) \
+    X(glBindAttribLocation) \
+    X(glBindFramebuffer) \
+    X(glBindTexture) \
+    X(glCompileShader) \
+    X(glCreateProgram) \
+    X(glCreateShader) \
+    X(glDeleteFramebuffers) \
+    X(glDeleteProgram) \
+    X(glDeleteShader) \
+    X(glDeleteTextures) \
+    X(glDisableVertexAttribArray) \
+    X(glDrawArrays) \
+    X(glEnableVertexAttribArray) \
+    X(glFinish) \
+    X(glFramebufferTexture2D) \
+    X(glGenFramebuffers) \
+    X(glGenTextures) \
+    X(glGetError) \
+    X(glGetProgramiv) \
+    X(glGetShaderiv) \
+    X(glGetUniformLocation) \
+    X(glLinkProgram) \
+    X(glReadPixels) \
+    X(glShaderSource) \
+    X(glTexImage2D) \
+    X(glTexParameteri) \
+    X(glUniform1f) \
+    X(glUniform1i) \
+    X(glUseProgram) \
+    X(glVertexAttribPointer) \
+    X(glViewport)
+
+/* One function pointer per symbol, typed from the real prototype in the EGL/
+ * GLES headers so a signature drift is a compile error. Declared BEFORE the
+ * name-routing defines below so __typeof__ sees the header declaration. */
+#define DRMTAP_DECLARE_GL_PFN(name) static __typeof__(name) *pfn_##name;
+DRMTAP_EGL_CORE_SYMBOLS(DRMTAP_DECLARE_GL_PFN)
+DRMTAP_GLES_CORE_SYMBOLS(DRMTAP_DECLARE_GL_PFN)
+#undef DRMTAP_DECLARE_GL_PFN
+
+static void *g_libegl_handle;
+static void *g_libgles_handle;
+static int g_gl_libs_state; /* 0 = not attempted, 1 = loaded, -1 = failed */
+
+/* dlopen libEGL + libGLESv2 and resolve every core symbol this file calls.
+ * Returns 0 when everything resolved, -1 otherwise (sticky either way).
+ * Thread-safe. NOTE: the # / ## operators suppress macro expansion of the
+ * symbol names, so this loader is immune to the name-routing defines below,
+ * but it must stay textually ABOVE them so the pfn_ declarations resolve. */
+static int load_gl_libraries(void) {
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&lk);
+    if (g_gl_libs_state == 0) {
+        g_gl_libs_state = -1;
+        g_libegl_handle = dlopen("libEGL.so.1", RTLD_NOW | RTLD_LOCAL);
+        if (!g_libegl_handle) {
+            g_libegl_handle = dlopen("libEGL.so", RTLD_NOW | RTLD_LOCAL);
+        }
+        g_libgles_handle = dlopen("libGLESv2.so.2", RTLD_NOW | RTLD_LOCAL);
+        if (!g_libgles_handle) {
+            g_libgles_handle = dlopen("libGLESv2.so", RTLD_NOW | RTLD_LOCAL);
+        }
+        if (g_libegl_handle && g_libgles_handle) {
+            int ok = 1;
+            /* *(void **)&pfn is the POSIX-documented way to store a dlsym
+             * result into a function pointer without the pedantic
+             * object-to-function pointer conversion warning. */
+#define DRMTAP_LOAD_EGL_SYM(name) \
+            *(void **)&pfn_##name = dlsym(g_libegl_handle, #name); \
+            if (!pfn_##name) ok = 0;
+#define DRMTAP_LOAD_GLES_SYM(name) \
+            *(void **)&pfn_##name = dlsym(g_libgles_handle, #name); \
+            if (!pfn_##name) ok = 0;
+            DRMTAP_EGL_CORE_SYMBOLS(DRMTAP_LOAD_EGL_SYM)
+            DRMTAP_GLES_CORE_SYMBOLS(DRMTAP_LOAD_GLES_SYM)
+#undef DRMTAP_LOAD_EGL_SYM
+#undef DRMTAP_LOAD_GLES_SYM
+            if (ok) {
+                g_gl_libs_state = 1;
+            }
+        }
+    }
+    int ret = g_gl_libs_state;
+    pthread_mutex_unlock(&lk);
+    return (ret == 1) ? 0 : -1;
+}
+
+/* Route every EGL/GLES call in the rest of this file through the loaded
+ * pointers while keeping the standard API names at the call sites (the same
+ * pattern GLAD-style loaders use). Anything below this point that names an
+ * EGL/GLES core function is calling through its pfn_ pointer. */
+#define eglBindAPI pfn_eglBindAPI
+#define eglChooseConfig pfn_eglChooseConfig
+#define eglCreateContext pfn_eglCreateContext
+#define eglDestroyContext pfn_eglDestroyContext
+#define eglGetDisplay pfn_eglGetDisplay
+#define eglGetError pfn_eglGetError
+#define eglGetProcAddress pfn_eglGetProcAddress
+#define eglInitialize pfn_eglInitialize
+#define eglMakeCurrent pfn_eglMakeCurrent
+#define glActiveTexture pfn_glActiveTexture
+#define glAttachShader pfn_glAttachShader
+#define glBindAttribLocation pfn_glBindAttribLocation
+#define glBindFramebuffer pfn_glBindFramebuffer
+#define glBindTexture pfn_glBindTexture
+#define glCompileShader pfn_glCompileShader
+#define glCreateProgram pfn_glCreateProgram
+#define glCreateShader pfn_glCreateShader
+#define glDeleteFramebuffers pfn_glDeleteFramebuffers
+#define glDeleteProgram pfn_glDeleteProgram
+#define glDeleteShader pfn_glDeleteShader
+#define glDeleteTextures pfn_glDeleteTextures
+#define glDisableVertexAttribArray pfn_glDisableVertexAttribArray
+#define glDrawArrays pfn_glDrawArrays
+#define glEnableVertexAttribArray pfn_glEnableVertexAttribArray
+#define glFinish pfn_glFinish
+#define glFramebufferTexture2D pfn_glFramebufferTexture2D
+#define glGenFramebuffers pfn_glGenFramebuffers
+#define glGenTextures pfn_glGenTextures
+#define glGetError pfn_glGetError
+#define glGetProgramiv pfn_glGetProgramiv
+#define glGetShaderiv pfn_glGetShaderiv
+#define glGetUniformLocation pfn_glGetUniformLocation
+#define glLinkProgram pfn_glLinkProgram
+#define glReadPixels pfn_glReadPixels
+#define glShaderSource pfn_glShaderSource
+#define glTexImage2D pfn_glTexImage2D
+#define glTexParameteri pfn_glTexParameteri
+#define glUniform1f pfn_glUniform1f
+#define glUniform1i pfn_glUniform1i
+#define glUseProgram pfn_glUseProgram
+#define glVertexAttribPointer pfn_glVertexAttribPointer
+#define glViewport pfn_glViewport
+
+/* ========================================================================= */
 /* EGL context (lazily initialized per drmtap_ctx)                           */
 /* ========================================================================= */
 
 /* Global EGL display (one per process, shared across threads) */
 static EGLDisplay g_egl_display = EGL_NO_DISPLAY;
 static int g_egl_display_initialized = 0;
+
+/* ── Import-once EGLImage cache (keyed by KMS fb_id) ── */
+/* The compositor scans out of a small pool of framebuffers (double/triple
+ * buffering), so the same fb_ids repeat every frame. Importing the DMA-BUF as
+ * an EGLImage once per fb_id — instead of create+destroy per frame — removes
+ * the biggest per-frame EGL cost. The cached EGLImage aliases the live
+ * scanout memory, so sampling it always reads the current frame content.
+ * Geometry is stored to detect a recycled fb_id (same id, new framebuffer)
+ * and re-import. An EGLImage keeps its underlying buffer alive, so at most
+ * DRMTAP_EGL_IMAGE_SLOTS scanout buffers are pinned per thread — the same
+ * order of pinning the fast-grab mmap slots already do. */
+#define DRMTAP_EGL_IMAGE_SLOTS 4
+typedef struct {
+    const drmtap_ctx *owner;    /* cache entries are per capture context */
+    uint32_t fb_id;             /* 0 = slot unused */
+    uint32_t width, height, stride, fourcc;
+    uint64_t modifier;
+    int      num_planes;
+    uint32_t offsets[4];
+    uint32_t pitches[4];
+    ino_t    buf_inode;         /* dma-buf inode = the real buffer identity;
+                                   0 = unknown (fd was -1 or fstat failed) */
+    EGLImageKHR image;
+    GLuint texture;             /* GL_TEXTURE_EXTERNAL_OES bound to image */
+} egl_image_slot_t;
 
 /* Per-thread EGL context and GL resources */
 typedef struct {
@@ -66,6 +266,9 @@ typedef struct {
     uint32_t tex_width;
     uint32_t tex_height;
     int initialized;
+    egl_image_slot_t image_slots[DRMTAP_EGL_IMAGE_SLOTS];
+    unsigned next_evict;  /* round-robin eviction cursor for image_slots */
+    int cache_disabled;   /* DRMTAP_NO_IMAGE_CACHE=1 */
 } egl_state_t;
 
 /* The per-thread EGL context + GL resources.
@@ -112,6 +315,13 @@ static PFNEGLDESTROYIMAGEKHRPROC pfn_eglDestroyImageKHR;
 static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC pfn_glEGLImageTargetTexture2DOES;
 
 static int load_egl_procs(void) {
+    /* Bring in libEGL/libGLESv2 first — every EGL entry point in this file
+     * funnels through here (egl_init and drmtap_gpu_egl_available) before any
+     * EGL/GL call is made, so this is the single lazy-load chokepoint. */
+    if (load_gl_libraries() < 0) {
+        return -1;
+    }
+
     pfn_eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)
         eglGetProcAddress("eglQueryDevicesEXT");
     pfn_eglQueryDeviceStringEXT = (PFNEGLQUERYDEVICESTRINGEXTPROC)
@@ -251,6 +461,11 @@ static GLuint create_program(void) {
 /* EGL display from DRM card path                                            */
 /* ========================================================================= */
 
+/* From EGL_EXT_device_drm_render_node; missing from older eglext.h. */
+#ifndef EGL_DRM_RENDER_NODE_FILE_EXT
+#define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
+#endif
+
 static EGLDisplay get_egl_display_for_card(const char *card_path) {
     if (!pfn_eglQueryDevicesEXT || !pfn_eglQueryDeviceStringEXT ||
         !pfn_eglGetPlatformDisplayEXT) {
@@ -273,9 +488,16 @@ static EGLDisplay get_egl_display_for_card(const char *card_path) {
 
     EGLDisplay display = EGL_NO_DISPLAY;
     for (int i = 0; i < num_devices; i++) {
+        /* Match either the card path (drmtap_open) or the render node path
+         * (drmtap_open_render) — a render-only context knows its GPU only by
+         * its /dev/dri/renderD* node. The render-node query returns NULL when
+         * the extension is absent, which just skips that comparison. */
         const char *drm_path = pfn_eglQueryDeviceStringEXT(
             devices[i], EGL_DRM_DEVICE_FILE_EXT);
-        if (drm_path && strcmp(drm_path, card_path) == 0) {
+        const char *render_path = pfn_eglQueryDeviceStringEXT(
+            devices[i], EGL_DRM_RENDER_NODE_FILE_EXT);
+        if ((drm_path && strcmp(drm_path, card_path) == 0) ||
+            (render_path && strcmp(render_path, card_path) == 0)) {
             display = pfn_eglGetPlatformDisplayEXT(
                 EGL_PLATFORM_DEVICE_EXT, devices[i], NULL);
             break;
@@ -380,6 +602,10 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     state->linear_texture = 0;
     state->tex_width = 0;
     state->tex_height = 0;
+    /* Escape hatch: DRMTAP_NO_IMAGE_CACHE=1 forces a fresh EGLImage import
+     * per frame (the pre-0.4.9 behaviour) for debugging driver oddities. */
+    const char *nocache = getenv("DRMTAP_NO_IMAGE_CACHE");
+    state->cache_disabled = (nocache && nocache[0] == '1');
     state->initialized = 1;
     /* Register the thread-exit backstop so a capture thread that dies without
      * drmtap_close() still frees this context (value must be non-NULL to arm the
@@ -397,12 +623,30 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     return 0;
 }
 
+/* Release one cached EGLImage slot (external texture + image). The caller
+ * must have the thread's EGL context current. Safe on an empty slot. */
+static void egl_image_slot_release(egl_state_t *st, egl_image_slot_t *slot) {
+    if (slot->texture) {
+        glDeleteTextures(1, &slot->texture);
+    }
+    if (slot->image != EGL_NO_IMAGE_KHR && pfn_eglDestroyImageKHR) {
+        pfn_eglDestroyImageKHR(st->display, slot->image);
+    }
+    memset(slot, 0, sizeof(*slot));
+}
+
 static void egl_cleanup(egl_state_t *st) {
     if (!st->initialized) {
         return;
     }
     eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                    st->context);
+    /* Drop the fb_id EGLImage cache first: the GL textures need the context
+     * current, and the cached EGLImages pin the imported scanout buffers. */
+    for (int i = 0; i < DRMTAP_EGL_IMAGE_SLOTS; i++) {
+        egl_image_slot_release(st, &st->image_slots[i]);
+    }
+    st->next_evict = 0;
     if (st->linear_texture) {
         glDeleteTextures(1, &st->linear_texture);
     }
@@ -454,131 +698,14 @@ static void ensure_linear_texture(egl_state_t *state, uint32_t w, uint32_t h) {
     state->tex_height = h;
 }
 
-/* ========================================================================= */
-/* Public API                                                                */
-/* ========================================================================= */
-
-/**
- * Check if EGL detiling is available on this system.
- * Returns 1 if EGL + GLES are functional, 0 otherwise.
- */
-int drmtap_gpu_egl_available(drmtap_ctx *ctx) {
-    /* EGL availability is a static property of the GPU, but this is called on
-     * every captured frame. Cache it once.
-     *
-     * CRITICAL: this must NOT call eglTerminate() on the display. The display
-     * returned by get_egl_display_for_card() is the SAME shared EGLDisplay used
-     * by the live detile contexts. Terminating it here — while another capture
-     * thread is mid-eglCreateImage — invalidates that thread's display and makes
-     * its detile fail with EGL_NOT_INITIALIZED, so it falls back to returning the
-     * raw tiled/compressed buffer (garbage/color corruption). Concurrent captures
-     * (e.g. two monitors viewed at once) hit this constantly. */
-    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
-    static int cached = -1;
-    pthread_mutex_lock(&lk);
-    if (cached < 0) {
-        if (load_egl_procs() < 0) {
-            cached = 0;
-        } else {
-            EGLDisplay display = get_egl_display_for_card(ctx->device_path);
-            if (display == EGL_NO_DISPLAY) {
-                cached = 0;
-            } else {
-                EGLint major, minor;
-                cached = eglInitialize(display, &major, &minor) ? 1 : 0;
-                /* Intentionally no eglTerminate(display) — see above. */
-            }
-        }
-    }
-    pthread_mutex_unlock(&lk);
-    return cached;
-}
-
-/**
- * Convert a tiled DMA-BUF framebuffer to linear RGBA pixels using EGL/GL.
- *
- * This is the universal GPU detiling path. The GPU driver handles its
- * own tiling format transparently when the DMA-BUF is imported as an
- * EGLImage with the correct modifier.
- *
- * @param ctx       Capture context
- * @param dma_buf_fd  DMA-BUF file descriptor
- * @param width     Framebuffer width
- * @param height    Framebuffer height
- * @param stride    Framebuffer stride (bytes per row)
- * @param fourcc    DRM fourcc format (e.g., DRM_FORMAT_XRGB8888)
- * @param modifier  DRM framebuffer modifier (tiling info)
- * @param out_data  Output: allocated linear RGBA buffer (caller must free)
- * @param out_size  Output: size of the allocated buffer
- * @return 0 on success, negative errno on error
- */
-static int egl_convert_impl(drmtap_ctx *ctx,
-                            int dma_buf_fd,
-                            uint32_t width, uint32_t height,
-                            uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
-                            void **out_data, size_t *out_size);
-
-/* Public entry point: serialize GPU detiles across the whole process.
- *
- * Each capture runs on its own thread with its own thread-local EGL context, but
- * the GPU is the real bottleneck. When two 4K monitors are captured at once,
- * letting both detiles run concurrently makes each take longer (wall-clock) than
- * the compositor's page-flip interval, so the live scanout buffer is recycled
- * mid-read and the CCS-compressed result comes out as garbage/color corruption.
- * A single process-global lock keeps every detile short enough to complete within
- * one flip interval, which eliminates the corruption while each thread still owns
- * its EGL context. */
-int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
-                           int dma_buf_fd,
-                           uint32_t width, uint32_t height,
-                           uint32_t stride, uint32_t fourcc,
-                           uint64_t modifier,
-                           void **out_data, size_t *out_size) {
-    static pthread_mutex_t g_convert_lock = PTHREAD_MUTEX_INITIALIZER;
-    pthread_mutex_lock(&g_convert_lock);
-    int _ret = egl_convert_impl(ctx, dma_buf_fd, width, height, stride, fourcc,
-                                modifier, out_data, out_size);
-    pthread_mutex_unlock(&g_convert_lock);
-    return _ret;
-}
-
-static int egl_convert_impl(drmtap_ctx *ctx,
-                            int dma_buf_fd,
-                            uint32_t width, uint32_t height,
-                            uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
-                            void **out_data, size_t *out_size) {
-    if (!out_data || !out_size) {
-        return -EINVAL;
-    }
-
-    /* Lazy-init this thread's EGL context. `state` is the file-scope
-     * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
-     * on close. (A `_Thread_local` is per-thread, so there is no cross-thread
-     * owner check to do here — each thread only ever sees its own instance.) */
-    int ret;
-
-    drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
-    if (!state.initialized) {
-        ret = egl_init(ctx, &state);
-        drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);
-        if (ret < 0) {
-            return ret;
-        }
-    }
-
-    /* Ensure display is initialized for this thread and context is current */
-    eglBindAPI(EGL_OPENGL_ES_API);
-    {
-        EGLint _maj, _min;
-        eglInitialize(state.display, &_maj, &_min);  /* no-op if already init */
-    }
-    if (!eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                        state.context)) {
-        drmtap_debug_log(NULL, "EGL: eglMakeCurrent in convert failed: 0x%x", eglGetError());
-    }
-
+/* Import a DMA-BUF as an EGLImage, retrying with progressively simpler
+ * attribute sets (XRGB8888 keeping the modifier, then XRGB8888 alone) the way
+ * some drivers need. CCS auxiliary planes come from ctx->fb2_*. Returns
+ * EGL_NO_IMAGE_KHR when every attempt failed. */
+static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
+                                     uint32_t width, uint32_t height,
+                                     uint32_t stride, uint32_t fourcc,
+                                     uint64_t modifier) {
     /* Build EGLImage attributes with DMA-BUF import */
     EGLint image_attribs[64];
     int ai = 0;
@@ -643,8 +770,6 @@ static int egl_convert_impl(drmtap_ctx *ctx,
 
     drmtap_debug_log(NULL, "EGL: tid=%lu creating EGLImage: fd=%d %ux%u stride=%u fourcc=0x%x mod=0x%lx ai=%d",
             (unsigned long)pthread_self(), dma_buf_fd, width, height, stride, fourcc, (unsigned long)modifier, ai);
-
-    /* eglMakeCurrent already done at function entry */
 
     /* Import DMA-BUF as EGLImage */
     EGLImageKHR image = pfn_eglCreateImageKHR(
@@ -716,13 +841,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
             drmtap_debug_log(NULL, "EGL: retry XRGB8888+nomod also FAILED: err=0x%x", eglGetError());
             drmtap_debug_log(ctx, "egl: all retries failed: 0x%x",
                              eglGetError());
-            return -EIO;
+            return EGL_NO_IMAGE_KHR;
         }
         drmtap_debug_log(NULL, "EGL: retry SUCCEEDED");
         drmtap_debug_log(ctx, "egl: retry succeeded");
     }
+    return image;
+}
 
-    /* Bind as GL_TEXTURE_EXTERNAL_OES — GPU handles detiling */
+/* Wrap an EGLImage in a GL_TEXTURE_EXTERNAL_OES texture (the GPU detiles
+ * transparently when sampling it). Leaves the texture bound on unit 0. */
+static int egl_make_external_texture(drmtap_ctx *ctx, EGLImageKHR image,
+                                     GLuint *out_texture) {
     GLuint ext_texture;
     glGenTextures(1, &ext_texture);
     glActiveTexture(GL_TEXTURE0);
@@ -741,8 +871,248 @@ static int egl_convert_impl(drmtap_ctx *ctx,
         drmtap_debug_log(ctx, "egl: glEGLImageTargetTexture2DOES failed: 0x%x",
                          gl_err);
         glDeleteTextures(1, &ext_texture);
-        pfn_eglDestroyImageKHR(state.display, image);
         return -EIO;
+    }
+    *out_texture = ext_texture;
+    return 0;
+}
+
+/* ========================================================================= */
+/* Public API                                                                */
+/* ========================================================================= */
+
+/**
+ * Check if EGL detiling is available on this system.
+ * Returns 1 if EGL + GLES are functional, 0 otherwise.
+ */
+int drmtap_gpu_egl_available(drmtap_ctx *ctx) {
+    /* EGL availability is a static property of the GPU, but this is called on
+     * every captured frame. Cache it once.
+     *
+     * CRITICAL: this must NOT call eglTerminate() on the display. The display
+     * returned by get_egl_display_for_card() is the SAME shared EGLDisplay used
+     * by the live detile contexts. Terminating it here — while another capture
+     * thread is mid-eglCreateImage — invalidates that thread's display and makes
+     * its detile fail with EGL_NOT_INITIALIZED, so it falls back to returning the
+     * raw tiled/compressed buffer (garbage/color corruption). Concurrent captures
+     * (e.g. two monitors viewed at once) hit this constantly. */
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    static int cached = -1;
+    pthread_mutex_lock(&lk);
+    if (cached < 0) {
+        if (load_egl_procs() < 0) {
+            cached = 0;
+        } else {
+            EGLDisplay display = get_egl_display_for_card(ctx->device_path);
+            if (display == EGL_NO_DISPLAY) {
+                cached = 0;
+            } else {
+                EGLint major, minor;
+                cached = eglInitialize(display, &major, &minor) ? 1 : 0;
+                /* Intentionally no eglTerminate(display) — see above. */
+            }
+        }
+    }
+    pthread_mutex_unlock(&lk);
+    return cached;
+}
+
+/**
+ * Convert a tiled DMA-BUF framebuffer to linear RGBA pixels using EGL/GL.
+ *
+ * This is the universal GPU detiling path. The GPU driver handles its
+ * own tiling format transparently when the DMA-BUF is imported as an
+ * EGLImage with the correct modifier.
+ *
+ * @param ctx       Capture context
+ * @param dma_buf_fd  DMA-BUF file descriptor
+ * @param width     Framebuffer width
+ * @param height    Framebuffer height
+ * @param stride    Framebuffer stride (bytes per row)
+ * @param fourcc    DRM fourcc format (e.g., DRM_FORMAT_XRGB8888)
+ * @param modifier  DRM framebuffer modifier (tiling info)
+ * @param out_data  Output: allocated linear RGBA buffer (caller must free)
+ * @param out_size  Output: size of the allocated buffer
+ * @return 0 on success, negative errno on error
+ */
+static int egl_convert_impl(drmtap_ctx *ctx,
+                            int dma_buf_fd,
+                            uint32_t width, uint32_t height,
+                            uint32_t stride, uint32_t fourcc,
+                            uint64_t modifier, uint32_t fb_id,
+                            void **out_data, size_t *out_size);
+
+/* Public entry point: serialize GPU detiles across the whole process.
+ *
+ * Each capture runs on its own thread with its own thread-local EGL context, but
+ * the GPU is the real bottleneck. When two 4K monitors are captured at once,
+ * letting both detiles run concurrently makes each take longer (wall-clock) than
+ * the compositor's page-flip interval, so the live scanout buffer is recycled
+ * mid-read and the CCS-compressed result comes out as garbage/color corruption.
+ * A single process-global lock keeps every detile short enough to complete within
+ * one flip interval, which eliminates the corruption while each thread still owns
+ * its EGL context. */
+int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
+                           int dma_buf_fd,
+                           uint32_t width, uint32_t height,
+                           uint32_t stride, uint32_t fourcc,
+                           uint64_t modifier, uint32_t fb_id,
+                           void **out_data, size_t *out_size) {
+    static pthread_mutex_t g_convert_lock = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&g_convert_lock);
+    int _ret = egl_convert_impl(ctx, dma_buf_fd, width, height, stride, fourcc,
+                                modifier, fb_id, out_data, out_size);
+    pthread_mutex_unlock(&g_convert_lock);
+    return _ret;
+}
+
+static int egl_convert_impl(drmtap_ctx *ctx,
+                            int dma_buf_fd,
+                            uint32_t width, uint32_t height,
+                            uint32_t stride, uint32_t fourcc,
+                            uint64_t modifier, uint32_t fb_id,
+                            void **out_data, size_t *out_size) {
+    if (!ctx || !out_data || !out_size) {
+        return -EINVAL;
+    }
+
+    /* Lazy-init this thread's EGL context. `state` is the file-scope
+     * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
+     * on close. (A `_Thread_local` is per-thread, so there is no cross-thread
+     * owner check to do here — each thread only ever sees its own instance.) */
+    int ret;
+
+    drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
+    if (!state.initialized) {
+        ret = egl_init(ctx, &state);
+        drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    /* Ensure display is initialized for this thread and context is current */
+    eglBindAPI(EGL_OPENGL_ES_API);
+    {
+        EGLint _maj, _min;
+        eglInitialize(state.display, &_maj, &_min);  /* no-op if already init */
+    }
+    if (!eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        state.context)) {
+        drmtap_debug_log(NULL, "EGL: eglMakeCurrent in convert failed: 0x%x", eglGetError());
+    }
+
+    /* ── Import-once: EGLImage cache keyed by fb_id ── */
+    egl_image_slot_t *slot = NULL;
+    egl_image_slot_t *free_slot = NULL;
+    EGLImageKHR image = EGL_NO_IMAGE_KHR;
+    GLuint ext_texture = 0;
+    int use_cache = (fb_id != 0 && !state.cache_disabled);
+
+    /* Real buffer identity: a DMA-BUF has a unique inode that is stable across
+     * re-exports of the same underlying scanout BO and changes when the BO
+     * changes. KMS recycles a freed fb_id onto a brand-new BO that can have
+     * BYTE-IDENTICAL geometry, so geometry alone cannot tell "same fb, live
+     * buffer" from "same id, new buffer" — the inode can. Captured when a real
+     * fd is supplied; 0 (fd == -1, the known-cached contract, or fstat failed)
+     * means "trust fb_id + geometry". */
+    ino_t cur_inode = 0;
+    if (dma_buf_fd >= 0) {
+        struct stat st;
+        if (fstat(dma_buf_fd, &st) == 0) {
+            cur_inode = st.st_ino;
+        }
+    }
+
+    if (use_cache) {
+        for (int i = 0; i < DRMTAP_EGL_IMAGE_SLOTS; i++) {
+            egl_image_slot_t *s = &state.image_slots[i];
+            if (s->fb_id == 0) {
+                if (!free_slot) {
+                    free_slot = s;
+                }
+                continue;
+            }
+            if (s->fb_id != fb_id || s->owner != ctx) {
+                continue;
+            }
+            int geom_match =
+                (s->width == width && s->height == height &&
+                 s->stride == stride && s->fourcc == fourcc &&
+                 s->modifier == modifier &&
+                 s->num_planes == ctx->fb2_num_planes &&
+                 memcmp(s->offsets, ctx->fb2_offsets, sizeof(s->offsets)) == 0 &&
+                 memcmp(s->pitches, ctx->fb2_pitches, sizeof(s->pitches)) == 0);
+            /* Identity holds unless BOTH inodes are known and differ — i.e. a
+             * recycled fb_id on a new buffer. If either is unknown, geometry
+             * is the best signal we have and we trust it. */
+            int ident_match =
+                (cur_inode == 0 || s->buf_inode == 0 ||
+                 s->buf_inode == cur_inode);
+            if (geom_match && ident_match) {
+                slot = s;
+                break;
+            }
+            /* Different geometry, or same geometry but the buffer identity
+             * changed (fb_id recycled onto a new BO) — the cached import is
+             * stale. Drop it and reuse the slot for the fresh import. */
+            egl_image_slot_release(&state, s);
+            if (!free_slot) {
+                free_slot = s;
+            }
+        }
+    }
+
+    if (slot) {
+        /* Cache hit: the EGLImage aliases the live scanout buffer, so binding
+         * the cached external texture samples the CURRENT frame content — no
+         * re-import, no texture churn. */
+        image = slot->image;
+        ext_texture = slot->texture;
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_EXTERNAL_OES, ext_texture);
+    } else {
+        if (dma_buf_fd < 0) {
+            drmtap_set_error(ctx, "egl: fb_id %u is not cached and no "
+                             "dma-buf fd was supplied", fb_id);
+            return -EINVAL;
+        }
+        image = egl_import_dmabuf(ctx, dma_buf_fd, width, height, stride,
+                                  fourcc, modifier);
+        if (image == EGL_NO_IMAGE_KHR) {
+            return -EIO;
+        }
+        ret = egl_make_external_texture(ctx, image, &ext_texture);
+        if (ret != 0) {
+            pfn_eglDestroyImageKHR(state.display, image);
+            return ret;
+        }
+        if (use_cache) {
+            /* Adopt the fresh import into a slot: reuse a free one, else
+             * round-robin evict (compositors cycle 2-3 buffers, so with 4
+             * slots eviction only happens on pathological flip patterns). */
+            egl_image_slot_t *dst = free_slot;
+            if (!dst) {
+                dst = &state.image_slots[state.next_evict %
+                                         DRMTAP_EGL_IMAGE_SLOTS];
+                state.next_evict++;
+                egl_image_slot_release(&state, dst);
+            }
+            dst->owner = ctx;
+            dst->fb_id = fb_id;
+            dst->width = width;
+            dst->height = height;
+            dst->stride = stride;
+            dst->fourcc = fourcc;
+            dst->modifier = modifier;
+            dst->num_planes = ctx->fb2_num_planes;
+            memcpy(dst->offsets, ctx->fb2_offsets, sizeof(dst->offsets));
+            memcpy(dst->pitches, ctx->fb2_pitches, sizeof(dst->pitches));
+            dst->buf_inode = cur_inode;
+            dst->image = image;
+            dst->texture = ext_texture;
+            slot = dst;
+        }
     }
 
     /* Ensure output texture */
@@ -798,14 +1168,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     /* Ensure GPU rendering is complete before reading back */
     glFinish();
 
-    /* Read linear pixels back */
+    /* Read linear pixels straight into the ctx-owned grow-once buffer
+     * (drmtap_ensure_buf caps it at DRMTAP_MAX_FB_BYTES), so steady-state
+     * conversion performs zero per-frame allocations. The buffer belongs to
+     * the context and is freed in drmtap_close(); callers must not free it. */
     size_t rgba_size = (size_t)width * height * 4;
-    void *pixels = malloc(rgba_size);
-    if (!pixels) {
-        ret = -ENOMEM;
+    ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                            rgba_size);
+    if (ret != 0) {
         goto cleanup;
     }
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
+                 ctx->deswizzle_buf);
     drmtap_debug_log(NULL, "EGL: glReadPixels done, gl_err=0x%x", glGetError());
 
     /* NOTE: CPU horizontal flip removed. The EGL DMA-BUF import with
@@ -813,7 +1187,7 @@ static int egl_convert_impl(drmtap_ctx *ctx,
      * orientation. The previous CPU flip was compensating for a shader-
      * based X flip (1.0 - v_texcoord.x) that has since been removed. */
 
-    *out_data = pixels;
+    *out_data = ctx->deswizzle_buf;
     *out_size = rgba_size;
     ret = 0;
 
@@ -823,8 +1197,13 @@ static int egl_convert_impl(drmtap_ctx *ctx,
 cleanup:
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
-    glDeleteTextures(1, &ext_texture);
-    pfn_eglDestroyImageKHR(state.display, image);
+    if (!slot) {
+        /* Uncached import (fb_id 0, or cache disabled): per-call lifetime,
+         * exactly the pre-cache behaviour. A cached import stays alive in its
+         * slot until eviction or egl_cleanup(). */
+        glDeleteTextures(1, &ext_texture);
+        pfn_eglDestroyImageKHR(state.display, image);
+    }
 
     /* The context stays current on this (capture) thread and is reused across
      * calls — each thread owns its own thread-local context. It is released by
@@ -845,10 +1224,10 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             int dma_buf_fd,
                             uint32_t width, uint32_t height,
                             uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
+                            uint64_t modifier, uint32_t fb_id,
                             void **out_data, size_t *out_size) {
     (void)ctx; (void)dma_buf_fd; (void)width; (void)height;
-    (void)stride; (void)fourcc; (void)modifier;
+    (void)stride; (void)fourcc; (void)modifier; (void)fb_id;
     (void)out_data; (void)out_size;
     drmtap_set_error(ctx, "EGL backend not available (built without EGL)");
     return -ENOTSUP;

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -1003,7 +1003,9 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     }
 
     /* ── Import-once: EGLImage cache keyed by fb_id ── */
-    egl_image_slot_t *slot = NULL;
+    /* slot is only ever read through (the writes go through `dst`/`s`), so it
+     * is const; free_slot/dst stay mutable because they populate a slot. */
+    const egl_image_slot_t *slot = NULL;
     egl_image_slot_t *free_slot = NULL;
     EGLImageKHR image = EGL_NO_IMAGE_KHR;
     GLuint ext_texture = 0;

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -1131,11 +1131,12 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     glUniform1i(glGetUniformLocation(state.program, "image"), 0);
 
     /* HDR10 scanout: tone-map PQ/BT.2020 -> SDR in the shader. eotf/peak come
-     * from the connector HDR_OUTPUT_METADATA (carried on ctx). */
-    int hdr_on = (ctx && ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) ? 1 : 0;
+     * from the connector HDR_OUTPUT_METADATA (carried on ctx). ctx is
+     * non-NULL here — the function returns -EINVAL up top otherwise. */
+    int hdr_on = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) ? 1 : 0;
     glUniform1i(glGetUniformLocation(state.program, "u_hdr"), hdr_on);
     {
-        uint32_t mn = (ctx && ctx->cur_hdr_max_nits > 0)
+        uint32_t mn = (ctx->cur_hdr_max_nits > 0)
                           ? ctx->cur_hdr_max_nits : 1000u;
         glUniform1f(glGetUniformLocation(state.program, "u_peak_n"),
                     (float)((double)mn / 203.0));

--- a/bindings/rust/libdrmtap-sys/src/lib.rs
+++ b/bindings/rust/libdrmtap-sys/src/lib.rs
@@ -77,6 +77,29 @@ pub struct drmtap_rect {
     pub h: u32,
 }
 
+/// Scanout EOTF (from the connector HDR_OUTPUT_METADATA, CTA-861 numbering)
+pub const DRMTAP_EOTF_SDR: u32 = 0;
+pub const DRMTAP_EOTF_PQ: u32 = 2;
+pub const DRMTAP_EOTF_HLG: u32 = 3;
+
+/// Descriptor of an externally-supplied scanout DMA-BUF (split capture):
+/// metadata from the privileged exporter shipped over IPC into
+/// drmtap_convert_dmabuf() on the unprivileged side.
+#[repr(C)]
+pub struct drmtap_dmabuf_desc {
+    pub dma_buf_fd: c_int,
+    pub width: u32,
+    pub height: u32,
+    pub format: u32,
+    pub modifier: u64,
+    pub fb_id: u32,
+    pub num_planes: u32,
+    pub offsets: [u32; 4],
+    pub pitches: [u32; 4],
+    pub hdr_eotf: u32,
+    pub hdr_max_nits: u32,
+}
+
 extern "C" {
     // Version
     pub fn drmtap_version() -> c_int;
@@ -84,6 +107,14 @@ extern "C" {
     // Context lifecycle
     pub fn drmtap_open(config: *const drmtap_config) -> *mut drmtap_ctx;
     pub fn drmtap_close(ctx: *mut drmtap_ctx);
+
+    // Split capture (privileged export + unprivileged convert)
+    pub fn drmtap_open_render(render_node: *const c_char) -> *mut drmtap_ctx;
+    pub fn drmtap_convert_dmabuf(
+        ctx: *mut drmtap_ctx,
+        desc: *const drmtap_dmabuf_desc,
+        frame: *mut drmtap_frame_info,
+    ) -> c_int;
 
     // Display enumeration
     pub fn drmtap_list_displays(

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.8", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.4.9", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/bindings/rust/libdrmtap/README.md
+++ b/bindings/rust/libdrmtap/README.md
@@ -25,7 +25,7 @@ reports HDR (`P010` overlay-video and HLG excepted).
 libdrmtap = "0.3"
 ```
 
-This pulls in `libdrmtap-sys` 0.4.8, which embeds and statically compiles the C
+This pulls in `libdrmtap-sys` 0.4.9, which embeds and statically compiles the C
 sources (and the privilege helper) — no system `libdrmtap` install needed.
 
 ## Example

--- a/contrib/integrations/rustdesk/README.md
+++ b/contrib/integrations/rustdesk/README.md
@@ -7,7 +7,7 @@ crate.
 > The upstream integration PR
 > [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420)
 > is **under maintainer review** (in progress — not yet merged). It adds a `drm`
-> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.8. The files here are a
+> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.9. The files here are a
 > self-contained reference for the same crate-based backend.
 
 ## Status
@@ -42,7 +42,7 @@ capture. This means:
 1. Add the crate to `libs/scrap/Cargo.toml`:
 
    ```toml
-   libdrmtap-sys = { version = "0.4.8", optional = true }
+   libdrmtap-sys = { version = "0.4.9", optional = true }
    ```
 
    It embeds and statically compiles the C sources **and** builds the

--- a/contrib/integrations/rustdesk/drm/mod.rs
+++ b/contrib/integrations/rustdesk/drm/mod.rs
@@ -13,7 +13,7 @@
 // Integration (tested on Ubuntu 24.04; uses the static libdrmtap-sys crate):
 //
 //   1. Add the crate to libs/scrap/Cargo.toml:
-//        libdrmtap-sys = { version = "0.4.8", optional = true }
+//        libdrmtap-sys = { version = "0.4.9", optional = true }
 //      It statically embeds and compiles the C sources and builds the
 //      drmtap-helper binary — no system libdrmtap install, no meson install,
 //      no apt package, and no rustc-link-search.

--- a/contrib/integrations/rustdesk/drm/recorder.rs
+++ b/contrib/integrations/rustdesk/drm/recorder.rs
@@ -9,7 +9,7 @@
 // captured 1920x1017 @ BGRA, 7,810,560 bytes — pixel-perfect.
 //
 // To use in RustDesk:
-//   Add `libdrmtap-sys = { version = "0.4.8", optional = true }` to
+//   Add `libdrmtap-sys = { version = "0.4.9", optional = true }` to
 //   libs/scrap/Cargo.toml, place this file at libs/scrap/src/common/drm.rs,
 //   and see mod.rs in this directory for the wiring. The canonical, current
 //   backend is in the upstream PR rustdesk/rustdesk#15420.

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -450,7 +450,7 @@ Three layers, published on crates.io:
 └─────────────────────────────────────────────────┘
 ```
 
-> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.8,
+> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.9,
 > libdrmtap 0.3.4) and verified to build/test in CI on Ubuntu 22.04/24.04.
 > Capture is verified on Intel i915/xe (dual-4K Meteor Lake), Nvidia/Tegra
 > (Jetson Orin Nano, aarch64), virtio-gpu, and AMD amdgpu (RX Vega 64, gfx9,
@@ -514,8 +514,8 @@ Adding `libdrmtap-sys` is standard practice for them. They `cargo add libdrmtap`
 
 | Area | What shipped | Status |
 |---|---|---|
-| Core | `libdrmtap` C library 0.4.8 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
-| Rust | `libdrmtap-sys` 0.4.8 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
+| Core | `libdrmtap` C library 0.4.9 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
+| Rust | `libdrmtap-sys` 0.4.9 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
 | Rust | `libdrmtap` 0.3.4 (safe wrapper) | ✅ Published on crates.io |
 | GPU | EGL/GLES2 GPU-universal detiling backend | ✅ Implemented |
 | HW | Intel i915/xe + Nvidia/Tegra + virtio-gpu + AMD amdgpu validation | ✅ Verified (AMD on RX Vega 64, gfx9) |

--- a/docs/research/07_potential_adopters.md
+++ b/docs/research/07_potential_adopters.md
@@ -16,7 +16,7 @@
 
 ### Integration path for each:
 
-**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.8 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
+**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.9 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
 
 **Sunshine**: Replace internal KMS code with `#include <drmtap.h>`. They already use DMA-BUF → VAAPI pipeline, so `drmtap_grab()` (zero-copy) slots in directly.
 

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 8
+#define DRMTAP_VERSION_PATCH 9
 
 /**
  * @brief Get the library version as a packed integer.
@@ -200,6 +200,120 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame);
  * @param frame Frame to release
  */
 void drmtap_frame_release(drmtap_ctx *ctx, drmtap_frame_info *frame);
+
+/* ========================================================================= */
+/* Split capture: privileged export + unprivileged convert                   */
+/* ========================================================================= */
+/*
+ * These entry points let a caller that already owns a privilege boundary
+ * (e.g. a root service + an unprivileged worker) run the DRM export and the
+ * GPU detile/convert in DIFFERENT processes, so the EGL/GLES and vendor GPU
+ * driver stack never load into the privileged one.
+ *
+ *   privileged side:   drmtap_open() + drmtap_grab()  -> dma_buf_fd + metadata
+ *                      (minimal DRM ops only; libEGL/libGLESv2 are dlopen'd
+ *                       lazily on first convert, so a process that never
+ *                       converts never maps the GPU stack at all)
+ *   unprivileged side: drmtap_open_render() + drmtap_convert_dmabuf()
+ *                      (imports the fd, EGL-detiles, converts to linear RGBA)
+ *
+ * The fd + metadata are carried between the two processes by the caller
+ * (e.g. over a unix socket with SCM_RIGHTS) — libdrmtap does not impose a
+ * wire format.
+ */
+
+/* Electro-optical transfer function of a scanout, from the connector
+ * HDR_OUTPUT_METADATA infoframe (kernel/CTA-861 numbering). PQ means
+ * "tone-map this"; HLG currently gets the plain bit-depth reduction
+ * (PQ/HDR10 is the desktop norm). */
+#define DRMTAP_EOTF_SDR  0  /**< traditional gamma SDR (or no HDR metadata) */
+#define DRMTAP_EOTF_PQ   2  /**< SMPTE ST 2084 (HDR10) */
+#define DRMTAP_EOTF_HLG  3  /**< Hybrid Log-Gamma (BT.2100) */
+
+/**
+ * @brief Descriptor of an externally-supplied scanout DMA-BUF.
+ *
+ * Filled by the caller from what the privileged exporter produced
+ * (drmtap_grab() frame metadata plus the connector HDR state) and shipped
+ * over IPC. num_planes/offsets/pitches carry the auxiliary planes of
+ * compressed layouts (e.g. Intel CCS: main surface + CCS aux + clear-color);
+ * all planes live inside the one dma_buf_fd, as DRM GetFB2 reports them.
+ */
+typedef struct {
+    int dma_buf_fd;         /**< Scanout DMA-BUF. May be -1 for an fb_id this
+                                 context has already imported (see
+                                 drmtap_convert_dmabuf). */
+    uint32_t width;         /**< Frame width in pixels */
+    uint32_t height;        /**< Frame height in pixels */
+    uint32_t format;        /**< DRM fourcc of the scanout */
+    uint64_t modifier;      /**< DRM format modifier (tiling/compression) */
+    uint32_t fb_id;         /**< KMS framebuffer id — the import-once cache
+                                 key. 0 disables caching for this frame. */
+    uint32_t num_planes;    /**< Used entries in offsets/pitches (1..4);
+                                 0 is treated as 1 */
+    uint32_t offsets[4];    /**< Per-plane byte offsets into the DMA-BUF */
+    uint32_t pitches[4];    /**< Per-plane strides in bytes; pitches[0] is the
+                                 main surface stride */
+    uint32_t hdr_eotf;      /**< DRMTAP_EOTF_*: PQ triggers the HDR->SDR
+                                 tone-map during conversion */
+    uint32_t hdr_max_nits;  /**< Mastering/content peak luminance (cd/m2),
+                                 0 = unknown */
+} drmtap_dmabuf_desc;
+
+/**
+ * @brief Open an UNPRIVILEGED, render-only context for drmtap_convert_dmabuf().
+ *
+ * Opens a DRM render node only. It does NOT open a KMS card, spawn the
+ * privileged helper, or enumerate displays, and it needs no elevated
+ * capability. Grab entry points return -ENOTSUP on this context.
+ *
+ * @param render_node Render node path (e.g. "/dev/dri/renderD128"),
+ *                    or NULL to auto-select the first usable one.
+ * @return Context handle, or NULL on error (call drmtap_error(NULL) for message)
+ */
+drmtap_ctx *drmtap_open_render(const char *render_node);
+
+/**
+ * @brief Convert an externally-supplied scanout frame to linear RGBA.
+ *
+ * On success frame->data points to context-owned pixels valid until the next
+ * convert on this context or drmtap_close(). Do NOT free it and do NOT call
+ * drmtap_frame_release() on it — there is nothing per-frame to release.
+ * ALWAYS read the returned frame->format, ->stride and ->modifier to describe
+ * the buffer:
+ *   - the GPU (EGL) path normalizes every input to XRGB8888, stride width*4,
+ *     modifier LINEAR;
+ *   - the CPU fallback (used only when no EGL backend is available) also
+ *     returns LINEAR width*4 pixels, but may keep the source 8-bit channel
+ *     order (e.g. XBGR8888) in frame->format.
+ * A well-behaved caller reads frame->format/->stride rather than assuming a
+ * fixed layout.
+ *
+ * Import-once: the DMA-BUF import (EGLImage) is cached keyed by desc->fb_id
+ * plus the buffer's identity (its dma-buf inode), so a fb_id the compositor
+ * recycles onto a NEW buffer re-imports instead of serving stale pixels. The
+ * compositor cycles a small pool of framebuffers, so after the first few
+ * frames every convert hits the cache and no per-frame import happens. For a
+ * known fb_id desc->dma_buf_fd may be -1; whenever the fb_id is new — or was
+ * recycled — a valid fd must be supplied. The cached import holds its own
+ * reference on the buffer, so the caller may close its fd right after the
+ * call. DRMTAP_NO_IMAGE_CACHE=1 forces a fresh import per frame (debug aid).
+ *
+ * Threading: call convert AND drmtap_close for a given context from the SAME
+ * thread. The EGL state and its cached imports are thread-local; closing on a
+ * different thread cannot release them and would strand the cached buffers.
+ *
+ * When no GPU path is usable the conversion falls back to a CPU mmap +
+ * deswizzle of the fd (same pipeline as the in-process grab).
+ *
+ * @param ctx   Context from drmtap_open_render() (or any context with a
+ *              usable EGL backend)
+ * @param desc  Input frame descriptor (metadata from the exporter)
+ * @param frame Output frame (data/format/stride/modifier filled on return)
+ * @return 0 on success, negative errno on error
+ */
+int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
+                          drmtap_frame_info *frame);
 
 /* ========================================================================= */
 /* Cursor Capture                                                            */

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.8',
+    version: '0.4.9',
     license: 'MIT',
     default_options: [
         'c_std=c11',
@@ -106,12 +106,34 @@ endif
 # Nvidia backend (no extra deps — CPU deswizzle)
 lib_sources += files('src/gpu_nvidia.c')
 
-# EGL/GLES2 GPU-universal detiling backend
+# EGL/GLES2 GPU-universal detiling backend.
+# Compile-time headers ONLY: the backend dlopen()s libEGL/libGLESv2 lazily on
+# first use (see src/gpu_egl.c), so the GPU stack must never appear in the .so
+# DT_NEEDED NOR in libdrmtap.pc Requires.private (a static consumer resolving
+# the .pc would otherwise re-link -lEGL/-lGLESv2 into its own — possibly
+# privileged — binary, defeating the whole split). We therefore do NOT attach
+# egl/glesv2 as dependencies of the library target; we only pull their include
+# dirs in as plain compile args. dl IS a real link dep (dlopen) and stays.
+dl_dep = cc.find_library('dl', required: false)
 lib_sources += files('src/gpu_egl.c')
-if egl_dep.found() and glesv2_dep.found()
-    lib_deps += [egl_dep, glesv2_dep]
+have_egl = egl_dep.found() and glesv2_dep.found() \
+    and cc.has_header('EGL/egl.h') and cc.has_header('EGL/eglext.h') \
+    and cc.has_header('GLES2/gl2.h') and cc.has_header('GLES2/gl2ext.h')
+if have_egl
+    # Add the pkg-config include dirs (if any) as compile args, without making
+    # egl/glesv2 dependencies of the target — so they stay out of the .pc.
+    egl_incs = run_command('pkg-config', '--cflags-only-I', 'egl', 'glesv2',
+                           check: false)
+    if egl_incs.returncode() == 0
+        foreach _inc : egl_incs.stdout().split()
+            add_project_arguments(_inc, language: 'c')
+        endforeach
+    endif
+    if dl_dep.found()
+        lib_deps += dl_dep
+    endif
     add_project_arguments('-DHAVE_EGL=1', language: 'c')
-    message('EGL backend: enabled (GPU-universal detiling)')
+    message('EGL backend: enabled (GPU-universal detiling, lazy dlopen)')
 else
     message('EGL backend: disabled (stub only)')
 endif
@@ -248,6 +270,11 @@ test_hdr = executable('test_hdr',
     dependencies: [libdrmtap_dep, m_dep],
     include_directories: lib_include,
 )
+test_convert = executable('test_convert',
+    'tests/test_convert.c',
+    dependencies: [libdrmtap_dep],
+    include_directories: lib_include,
+)
 # Wire-protocol tests are self-contained (socketpair + fake peer, no DRM, no
 # libdrmtap link): they guard the helper IPC's fd-access-mode / CLOEXEC /
 # ancillary-truncation / fixed-frame-reassembly invariants.
@@ -261,6 +288,7 @@ test('deswizzle', test_deswizzle, suite: 'unit')
 test('helper', test_helper, suite: 'unit')
 test('hdr', test_hdr, suite: 'unit')
 test('wire', test_wire, suite: 'unit')
+test('convert', test_convert, suite: 'unit')
 
 # Integration tests (need vkms or real GPU)
 # LSan: suppress the deliberate process-lifetime EGL/Mesa display allocation

--- a/patches/rustdesk/README.md
+++ b/patches/rustdesk/README.md
@@ -31,7 +31,7 @@ cargo build --release
 ## Based on
 
 - RustDesk v1.4.6
-- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.8"`
+- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.9"`
 
 ## Upstream status
 

--- a/patches/rustdesk/scrap_Cargo.toml
+++ b/patches/rustdesk/scrap_Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-libdrmtap-sys = { version = "0.4.8", optional = true }
+libdrmtap-sys = { version = "0.4.9", optional = true }
 webm = { git = "https://github.com/rustdesk-org/rust-webm" }
 serde = {version="1.0", features=["derive"]}
 

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -294,8 +294,9 @@ static int dmabuf_sync_end(int fd) {
  * Caps the allocation at DRMTAP_MAX_FB_BYTES as a guard against a bogus/hostile
  * framebuffer geometry forcing an unbounded request. Contents are not preserved
  * across a grow. Returns 0, -EINVAL (zero size), -EFBIG (over the cap), or
- * -ENOMEM. */
-static int ensure_buf(void **buf, size_t *cap, size_t size) {
+ * -ENOMEM. Shared across modules (gpu_egl.c reads back into the same ctx
+ * buffer), hence not static. */
+int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
     if (size == 0) {
         return -EINVAL;
     }
@@ -400,6 +401,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     drmModeFB2 *fb2 = NULL;
     int prime_fd = -1;
 
+    if (ctx->is_render_only) {
+        drmtap_set_error(ctx, "context is render-only (drmtap_open_render); "
+                         "grab needs a KMS context from drmtap_open");
+        return -ENOTSUP;
+    }
+
     /* Step 1: Find the primary plane */
     uint32_t plane_id = find_primary_plane(ctx);
     if (plane_id == 0) {
@@ -474,10 +481,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             "No CAP_SYS_ADMIN (needs helper), trying helper...");
 
         /* Receive buffer for the helper to fill. ctx-owned, grow-once and
-         * reused across grabs (never per-frame churn), capped — see ensure_buf.
-         * Freed in drmtap_close(). */
+         * reused across grabs (never per-frame churn), capped — see
+         * drmtap_ensure_buf. Freed in drmtap_close(). */
         size_t buf_size = (size_t)fb2->pitches[0] * fb2->height;
-        ret = ensure_buf(&ctx->pixel_buf, &ctx->pixel_buf_size, buf_size);
+        ret = drmtap_ensure_buf(&ctx->pixel_buf, &ctx->pixel_buf_size, buf_size);
         if (ret != 0) {
             if (ret == -EFBIG) {
                 drmtap_set_error(ctx,
@@ -801,7 +808,8 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     }
 
     size_t out_size = (size_t)frame->width * frame->height * 4u;
-    int b = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, out_size);
+    int b = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                              out_size);
     if (b != 0) return b;
     uint32_t dst_stride = frame->width * 4u;
     int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
@@ -874,13 +882,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
 
 
     /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
-     * see ensure_buf). frame->stride/height are validated at every entry point
+     * see drmtap_ensure_buf). frame->stride/height are validated at every entry point
      * (validate_fb_size), so this multiply cannot overflow. NOTE: this does NOT
      * bound the EGL output, which is always 4-byte RGBA — a sub-4-byte source
      * (e.g. RG16) can expand past stride*height, so the EGL path caps egl_size
      * separately below. */
     size_t size = (size_t)frame->stride * frame->height;
-    int bres = ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    int bres = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                                 size);
     if (bres != 0) {
         if (bres == -EFBIG) {
             drmtap_set_error(ctx,
@@ -910,23 +919,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         int ret = drmtap_gpu_egl_convert(ctx, frame->dma_buf_fd,
                                           frame->width, frame->height,
                                           frame->stride, frame->format,
-                                          modifier, &egl_data, &egl_size);
+                                          modifier, frame->fb_id,
+                                          &egl_data, &egl_size);
         drmtap_debug_log(ctx, "EGL convert: ret=%d data=%p", ret, egl_data);
         if (ret == 0 && egl_data) {
-            /* The EGL output is 4-byte RGBA and can exceed the source
-             * stride*height for sub-4-byte formats, so cap it independently
-             * before adopting it as the context buffer. */
-            if (egl_size > DRMTAP_MAX_FB_BYTES) {
-                free(egl_data);
-                drmtap_set_error(ctx, "EGL output too large: %zu bytes (max %zu)",
-                                 egl_size, (size_t)DRMTAP_MAX_FB_BYTES);
-                return -EFBIG;
-            }
-            /* Store in ctx for reuse / cleanup */
-            free(ctx->deswizzle_buf);
-            ctx->deswizzle_buf = egl_data;
-            ctx->deswizzle_buf_size = egl_size;
-            frame->data = ctx->deswizzle_buf;
+            /* egl_data IS ctx->deswizzle_buf: the convert reads back into the
+             * ctx-owned grow-once buffer (size-capped inside), so adopting it
+             * is just repointing the frame — no allocation churn. */
+            frame->data = egl_data;
             /* EGL outputs RGBA/BGRA 8-bit */
             frame->format = DRM_FORMAT_XRGB8888;
             frame->stride = frame->width * 4;
@@ -1138,9 +1138,27 @@ static int find_or_alloc_slot(drmtap_ctx *ctx, uint32_t fb_id) {
     return 0;
 }
 
+/* Restage a cached slot's captured plane layout into ctx->fb2_*. A fast-path
+ * cache HIT skips GetFB2, so without this ctx->fb2_* still describes whichever
+ * fb was last GetFB2'd — and the EGL detile / CCS import (plus the EGLImage
+ * cache's geometry compare) reads ctx->fb2_*. Restaging the slot's own layout
+ * keeps the plane metadata matched to the frame actually being converted. */
+static void fast_slot_restage_planes(drmtap_ctx *ctx, int slot) {
+    ctx->fb2_num_planes = ctx->fast_slots[slot].fb2_num_planes;
+    for (int p = 0; p < 4; p++) {
+        ctx->fb2_pitches[p] = ctx->fast_slots[slot].fb2_pitches[p];
+        ctx->fb2_offsets[p] = ctx->fast_slots[slot].fb2_offsets[p];
+    }
+}
+
 int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     if (!ctx || !frame) {
         return -EINVAL;
+    }
+    if (ctx->is_render_only) {
+        drmtap_set_error(ctx, "context is render-only (drmtap_open_render); "
+                         "grab needs a KMS context from drmtap_open");
+        return -ENOTSUP;
     }
 
     int ret;
@@ -1196,6 +1214,9 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                 frame->modifier = ctx->fast_slots[i].modifier;
                 frame->fb_id = fb_id;
                 frame->_priv = NULL;
+                /* Restage this slot's plane layout before converting (the
+                 * cache HIT skipped GetFB2, so ctx->fb2_* is otherwise stale). */
+                fast_slot_restage_planes(ctx, i);
                 /* Deswizzle/format-convert like the acquire path does — the
                  * cached mmap is the raw scanout, so a tiled buffer must be
                  * detiled here too (no-op for a linear one). Without this the
@@ -1245,6 +1266,9 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         frame->fb_id = fb_id;
         frame->_priv = NULL;
 
+        /* Restage this slot's plane layout before converting (the cache HIT
+         * skipped GetFB2, so ctx->fb2_* is otherwise stale). */
+        fast_slot_restage_planes(ctx, slot);
         /* Auto-deswizzle tiled framebuffers + format convert */
         gpu_auto_process(ctx, frame->data, frame, 0);
 
@@ -1276,6 +1300,18 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);
         return ret;
+    }
+
+    /* Cache multi-plane info for the EGL CCS import. The EGL path reads plane
+     * offsets/pitches from ctx->fb2_*, which otherwise still holds whatever
+     * the last do_grab() left there (stale geometry from another fb). */
+    ctx->fb2_num_planes = 0;
+    for (int p = 0; p < 4; p++) {
+        ctx->fb2_pitches[p] = fb2->pitches[p];
+        ctx->fb2_offsets[p] = fb2->offsets[p];
+        if (fb2->handles[p] || fb2->pitches[p]) {
+            ctx->fb2_num_planes = p + 1;
+        }
     }
 
     /* Export DMA-BUF */
@@ -1325,6 +1361,14 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;
     ctx->fast_slots[slot].modifier = fb2->modifier;
+    /* Capture this fb's plane layout with the slot so a later cache HIT can
+     * restage it into ctx->fb2_* (ctx->fb2_* was set from this same fb2 just
+     * above, at the "Cache multi-plane info" block). */
+    ctx->fast_slots[slot].fb2_num_planes = ctx->fb2_num_planes;
+    for (int p = 0; p < 4; p++) {
+        ctx->fast_slots[slot].fb2_pitches[p] = ctx->fb2_pitches[p];
+        ctx->fast_slots[slot].fb2_offsets[p] = ctx->fb2_offsets[p];
+    }
 
     drmtap_debug_log(ctx, "fast2: cached fb=%u slot=%d gem=%u %ux%u",
                      fb_id, slot, fb2->handles[0], fb2->width, fb2->height);
@@ -1347,4 +1391,171 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     gpu_auto_process(ctx, frame->data, frame, 0);
 
     return 0;   /* new frame */
+}
+
+/* ========================================================================= */
+/* Split capture: unprivileged convert of an externally-supplied DMA-BUF     */
+/* ========================================================================= */
+
+/* Minimum bytes-per-pixel of a scanout fourcc, for the width*bpp <= stride
+ * bound. The CPU deswizzle/reduce paths index the row as pixel[x] for
+ * x < width, so a stride that does not cover width*bpp would read/write past
+ * the row. 8-bit and 10-bit RGB pack into 4 bytes; the 16-bit-per-channel
+ * formats into 8. Unknown fourccs default to 4: a real desktop scanout is
+ * never sub-4-byte, and the tiled deswizzle writes 4-byte pixels, so 4 is the
+ * safe floor to reject a hostile narrow stride. */
+static uint32_t format_min_bpp(uint32_t fourcc) {
+    switch (fourcc) {
+    case DRMTAP_FMT_XR48:
+    case DRMTAP_FMT_AR48:
+    case DRMTAP_FMT_XB48:
+    case DRMTAP_FMT_AB48:
+        return 8;
+    default:
+        return 4;
+    }
+}
+
+int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
+                          drmtap_frame_info *frame) {
+    if (!ctx || !desc || !frame) {
+        return -EINVAL;
+    }
+
+    uint32_t num_planes = desc->num_planes ? desc->num_planes : 1;
+    if (num_planes > 4 || desc->width == 0) {
+        drmtap_set_error(ctx, "convert: invalid descriptor "
+                         "(width=%u num_planes=%u)",
+                         desc->width, desc->num_planes);
+        return -EINVAL;
+    }
+    int ret = validate_fb_size(desc->pitches[0], desc->height);
+    if (ret != 0) {
+        drmtap_set_error(ctx, "convert: rejecting geometry %ux%u stride=%u",
+                         desc->width, desc->height, desc->pitches[0]);
+        return ret;
+    }
+    /* The descriptor comes from the (untrusted) exporter over IPC, unlike the
+     * in-process grab whose width/stride come from drmModeGetFB2. validate_fb_size
+     * bounds stride*height but is independent of width — enforce that the row
+     * stride actually covers width pixels so the per-pixel CPU converters below
+     * (and the EGL import) cannot be driven past the buffer. */
+    if ((uint64_t)desc->width * format_min_bpp(desc->format) > desc->pitches[0]) {
+        drmtap_set_error(ctx, "convert: stride %u too small for width %u "
+                         "(fourcc %.4s)", desc->pitches[0], desc->width,
+                         (const char *)&desc->format);
+        return -EINVAL;
+    }
+
+    /* Stage the plane + HDR metadata exactly where the in-process grab
+     * (drmModeGetFB2 + the connector HDR read) would put it — the conversion
+     * paths below consume both from the context. */
+    ctx->fb2_num_planes = (int)num_planes;
+    for (uint32_t p = 0; p < 4; p++) {
+        ctx->fb2_pitches[p] = (p < num_planes) ? desc->pitches[p] : 0;
+        ctx->fb2_offsets[p] = (p < num_planes) ? desc->offsets[p] : 0;
+    }
+    ctx->cur_hdr_eotf = desc->hdr_eotf;
+    ctx->cur_hdr_max_nits = desc->hdr_max_nits;
+
+    memset(frame, 0, sizeof(*frame));
+    frame->width = desc->width;
+    frame->height = desc->height;
+    frame->stride = desc->pitches[0];
+    frame->format = desc->format;
+    frame->modifier = desc->modifier;
+    frame->fb_id = desc->fb_id;
+    frame->dma_buf_fd = desc->dma_buf_fd;
+
+#ifdef HAVE_EGL
+    /* GPU path first: EGL imports the fd (or reuses the fb_id-cached import)
+     * and hands back linear XRGB8888 — one hop covers every vendor tiling,
+     * the 10/16-bit reductions and the HDR tone-map. */
+    if (drmtap_gpu_egl_available(ctx)) {
+        void *egl_data = NULL;
+        size_t egl_size = 0;
+        ret = drmtap_gpu_egl_convert(ctx, desc->dma_buf_fd,
+                                     desc->width, desc->height,
+                                     desc->pitches[0], desc->format,
+                                     desc->modifier, desc->fb_id,
+                                     &egl_data, &egl_size);
+        if (ret == 0 && egl_data) {
+            frame->data = egl_data;   /* ctx-owned grow-once buffer */
+            frame->format = DRM_FORMAT_XRGB8888;
+            frame->stride = desc->width * 4;
+            frame->modifier = DRM_FORMAT_MOD_LINEAR;
+            return 0;
+        }
+        drmtap_debug_log(ctx, "convert: EGL path failed (%d), CPU fallback",
+                         ret);
+    }
+#endif
+
+    /* CPU fallback: map the DMA-BUF read-only and run the same deswizzle /
+     * format-reduction pipeline the in-process grab uses. */
+    if (desc->dma_buf_fd < 0) {
+        drmtap_set_error(ctx, "convert: fb_id %u is not cached and no "
+                         "dma-buf fd was supplied", desc->fb_id);
+        return -EINVAL;
+    }
+    size_t map_size = (size_t)desc->pitches[0] * desc->height;
+    void *mapped = mmap(NULL, map_size, PROT_READ, MAP_SHARED,
+                        desc->dma_buf_fd, desc->offsets[0]);
+    if (mapped == MAP_FAILED) {
+        int mmap_errno = errno;
+        drmtap_set_error(ctx, "convert: mmap(%zu) failed: %s "
+                         "(and no usable EGL path)",
+                         map_size, strerror(mmap_errno));
+        return mmap_errno ? -mmap_errno : -EIO;
+    }
+    int sync_started = (dmabuf_sync_start(desc->dma_buf_fd) == 0);
+
+    /* Hide the fd for the gpu_auto_process call so it stays off the EGL
+     * branch it would otherwise retry (we just watched EGL fail, or it is
+     * unavailable) and takes the CPU deswizzle/reduce paths on `mapped`. */
+    frame->data = mapped;
+    frame->dma_buf_fd = -1;
+    ret = gpu_auto_process(ctx, mapped, frame, 0);
+    frame->dma_buf_fd = desc->dma_buf_fd;
+
+    if (ret == 0 && frame->data == mapped) {
+        /* Linear 8-bit passthrough (no deswizzle / reduction happened). Copy
+         * into the ctx buffer so the pixels survive the temporary mapping,
+         * AND repack to a tight width*4 stride so the returned frame honors
+         * the documented "stride width*4" output even when the source scanout
+         * carried row padding (pitches[0] > width*4). The width*4 <= pitches[0]
+         * bound checked above keeps every per-row read inside the mapping. */
+        uint32_t out_stride = desc->width * 4u;
+        size_t out_size = (size_t)out_stride * desc->height;
+        ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                                out_size);
+        if (ret == 0) {
+            const uint8_t *src = mapped;
+            uint8_t *dst = ctx->deswizzle_buf;
+            if (desc->pitches[0] == out_stride) {
+                memcpy(dst, src, out_size);
+            } else {
+                for (uint32_t y = 0; y < desc->height; y++) {
+                    memcpy(dst + (size_t)y * out_stride,
+                           src + (size_t)y * desc->pitches[0], out_stride);
+                }
+            }
+            frame->data = ctx->deswizzle_buf;
+            frame->stride = out_stride;
+        }
+    }
+
+    if (sync_started) {
+        dmabuf_sync_end(desc->dma_buf_fd);
+    }
+    munmap(mapped, map_size);
+
+    if (ret == 0 && !frame->data) {
+        drmtap_set_error(ctx, "convert: no conversion path produced pixels");
+        ret = -ENOTSUP;
+    }
+    if (ret != 0) {
+        frame->data = NULL;
+    }
+    return ret;
 }

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -279,6 +279,85 @@ fail:
     return NULL;
 }
 
+drmtap_ctx *drmtap_open_render(const char *render_node) {
+    drmtap_ctx *ctx = calloc(1, sizeof(drmtap_ctx));
+    if (!ctx) {
+        drmtap_set_error(NULL, "Failed to allocate context: %s",
+                         strerror(errno));
+        return NULL;
+    }
+
+    ctx->drm_fd = -1;
+    ctx->helper_pid = -1;
+    ctx->helper_fd = -1;
+    ctx->is_render_only = 1;
+    for (int i = 0; i < DRMTAP_FAST_SLOTS; i++) {
+        ctx->fast_slots[i].prime_fd = -1;
+    }
+
+    const char *dbg_env = getenv("DRMTAP_DEBUG");
+    if (dbg_env && dbg_env[0] == '1') {
+        ctx->debug = 1;
+    }
+
+    drmtap_debug_log(ctx, "drmtap v%d.%d.%d opening render-only (pid=%d uid=%d)",
+                     DRMTAP_VERSION_MAJOR, DRMTAP_VERSION_MINOR,
+                     DRMTAP_VERSION_PATCH, getpid(), getuid());
+
+    if (render_node && render_node[0]) {
+        snprintf(ctx->device_path, sizeof(ctx->device_path), "%s", render_node);
+        ctx->drm_fd = open(render_node, O_RDWR | O_CLOEXEC);
+        if (ctx->drm_fd < 0) {
+            drmtap_set_error(NULL, "Failed to open %s: %s",
+                             render_node, strerror(errno));
+            goto fail;
+        }
+    } else {
+        /* Auto-detect: first openable render node (render minors start at 128).
+         * No KMS probing here on purpose — a render node has no resources. */
+        for (int i = 128; i < 128 + 16; i++) {
+            char path[64];
+            snprintf(path, sizeof(path), "/dev/dri/renderD%d", i);
+            int fd = open(path, O_RDWR | O_CLOEXEC);
+            if (fd >= 0) {
+                snprintf(ctx->device_path, sizeof(ctx->device_path),
+                         "%s", path);
+                ctx->drm_fd = fd;
+                break;
+            }
+        }
+        if (ctx->drm_fd < 0) {
+            drmtap_set_error(NULL,
+                "No DRM render node found (/dev/dri/renderD*)");
+            goto fail;
+        }
+    }
+
+    /* Same low-fd protection as drmtap_open: async runtimes can close/reuse
+     * low-numbered fds. */
+    {
+        int high_fd = fcntl(ctx->drm_fd, F_DUPFD_CLOEXEC, 100);
+        if (high_fd >= 0) {
+            close(ctx->drm_fd);
+            ctx->drm_fd = high_fd;
+        }
+    }
+
+    /* The driver name selects the CPU deswizzle fallback when EGL is out. */
+    detect_driver(ctx);
+
+    drmtap_debug_log(ctx, "render context opened: %s (%s)",
+                     ctx->device_path, ctx->driver_name);
+    return ctx;
+
+fail:
+    if (ctx->drm_fd >= 0) {
+        close(ctx->drm_fd);
+    }
+    free(ctx);
+    return NULL;
+}
+
 void drmtap_close(drmtap_ctx *ctx) {
     if (!ctx) {
         return;

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -313,9 +313,11 @@ drmtap_ctx *drmtap_open_render(const char *render_node) {
             goto fail;
         }
     } else {
-        /* Auto-detect: first openable render node (render minors start at 128).
-         * No KMS probing here on purpose — a render node has no resources. */
-        for (int i = 128; i < 128 + 16; i++) {
+        /* Auto-detect: first openable render node. DRM render minors span the
+         * whole 128..191 range (up to 64 nodes on a multi-GPU box), so scan all
+         * of it — a valid device can sit above renderD143. No KMS probing here
+         * on purpose: a render node has no resources. */
+        for (int i = 128; i < 128 + 64; i++) {
             char path[64];
             snprintf(path, sizeof(path), "/dev/dri/renderD%d", i);
             int fd = open(path, O_RDWR | O_CLOEXEC);

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -42,6 +42,10 @@ struct drmtap_ctx {
     /* Selected display */
     uint32_t crtc_id;
 
+    /* 1 = context from drmtap_open_render(): render node only, no KMS.
+     * Grab entry points reject it; only drmtap_convert_dmabuf() applies. */
+    int is_render_only;
+
     /* Cached resources for hotplug detection */
     uint32_t cached_connector_count;
     uint32_t cached_crtc_count;
@@ -72,6 +76,12 @@ struct drmtap_ctx {
         uint32_t width, height, stride;
         uint32_t format;
         uint64_t modifier;
+        /* Full plane layout captured at cache-miss (GetFB2) time. Restaged
+         * into ctx->fb2_* on every cache HIT so the EGL detile / CCS import
+         * sees THIS fb's planes, not whatever the last GetFB2 left there. */
+        int      fb2_num_planes;
+        uint32_t fb2_pitches[4];
+        uint32_t fb2_offsets[4];
     } fast_slots[4];
     uint32_t fast_plane_id;         /* cached primary plane id */
     uint32_t fast_last_fb_id;       /* fb_id from last capture (change detect) */
@@ -121,12 +131,8 @@ typedef struct {
 
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */
-/* DRM EOTF values (from the connector HDR_OUTPUT_METADATA infoframe). These
- * match the kernel/CTA-861 numbering. PQ means "tone-map this"; HLG currently
- * falls back to the plain bit-depth reduction (PQ/HDR10 is the desktop norm). */
-#define DRMTAP_EOTF_SDR  0  /* traditional gamma SDR (or no HDR metadata) */
-#define DRMTAP_EOTF_PQ   2  /* SMPTE ST 2084 (HDR10) */
-#define DRMTAP_EOTF_HLG  3  /* Hybrid Log-Gamma (BT.2100) */
+/* DRMTAP_EOTF_* moved to the public header (drmtap.h): the split-capture
+ * descriptor carries the scanout EOTF across the process boundary. */
 
 /* Flags for helper_grab_result_t.flags */
 #define HELPER_FLAG_HAS_DMABUF  0x01  /* DMA-BUF fd follows via SCM_RIGHTS */
@@ -205,13 +211,22 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
                               uint32_t stride, uint32_t format,
                               uint64_t modifier);
 
-/* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c) */
+/* Ensure *buf holds at least `size` bytes: grow-once, never shrinks, capped
+ * at DRMTAP_MAX_FB_BYTES. Contents are not preserved across a grow. Returns
+ * 0, -EINVAL (zero size), -EFBIG (over the cap) or -ENOMEM. (drm_grab.c) */
+int drmtap_ensure_buf(void **buf, size_t *cap, size_t size);
+
+/* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
+ * On success *out_data points at ctx->deswizzle_buf (ctx-owned, grow-once,
+ * valid until the next convert or drmtap_close) — the caller must NOT free
+ * it. fb_id keys the import-once EGLImage cache (0 = no caching); for an
+ * fb_id already cached with matching geometry dma_buf_fd may be -1. */
 int drmtap_gpu_egl_available(drmtap_ctx *ctx);
 int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             int dma_buf_fd,
                             uint32_t width, uint32_t height,
                             uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
+                            uint64_t modifier, uint32_t fb_id,
                             void **out_data, size_t *out_size);
 
 /* Release the calling thread's lazily-built EGL detile context + GL resources.

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -29,6 +29,13 @@
  *   - GL_OES_EGL_image_external
  */
 
+/* _GNU_SOURCE: expose POSIX types (ino_t via <sys/stat.h>) and syscall() under
+ * -std=c11 strict mode, matching the other translation units. Guarded because
+ * the Rust cc build passes -D_GNU_SOURCE on the command line. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <pthread.h>
@@ -40,6 +47,9 @@
 
 #ifdef HAVE_EGL
 
+#include <dlfcn.h>
+#include <sys/stat.h>
+
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #include <GLES2/gl2.h>
@@ -49,12 +59,202 @@
 #include "drmtap_internal.h"
 
 /* ========================================================================= */
+/* Lazy runtime loading of libEGL / libGLESv2                                */
+/* ========================================================================= */
+/*
+ * libEGL and libGLESv2 are resolved with dlopen() on first use instead of
+ * being linked as DT_NEEDED, so the GPU userspace stack (and everything it
+ * drags in) is only mapped into processes that actually convert frames. In
+ * the split capture model the privileged exporter calls only
+ * drmtap_open()/drmtap_grab(), which never reach this backend, so the GL
+ * stack never loads into the privileged process.
+ *
+ * The handles are never dlclose()d: GL drivers install thread-local state and
+ * worker threads that do not survive an unload, and the per-thread contexts
+ * released by the TSD destructor can still run at thread exit. One-time load,
+ * process lifetime — the same lifetime a DT_NEEDED link had.
+ */
+
+#define DRMTAP_EGL_CORE_SYMBOLS(X) \
+    X(eglBindAPI) \
+    X(eglChooseConfig) \
+    X(eglCreateContext) \
+    X(eglDestroyContext) \
+    X(eglGetDisplay) \
+    X(eglGetError) \
+    X(eglGetProcAddress) \
+    X(eglInitialize) \
+    X(eglMakeCurrent)
+
+#define DRMTAP_GLES_CORE_SYMBOLS(X) \
+    X(glActiveTexture) \
+    X(glAttachShader) \
+    X(glBindAttribLocation) \
+    X(glBindFramebuffer) \
+    X(glBindTexture) \
+    X(glCompileShader) \
+    X(glCreateProgram) \
+    X(glCreateShader) \
+    X(glDeleteFramebuffers) \
+    X(glDeleteProgram) \
+    X(glDeleteShader) \
+    X(glDeleteTextures) \
+    X(glDisableVertexAttribArray) \
+    X(glDrawArrays) \
+    X(glEnableVertexAttribArray) \
+    X(glFinish) \
+    X(glFramebufferTexture2D) \
+    X(glGenFramebuffers) \
+    X(glGenTextures) \
+    X(glGetError) \
+    X(glGetProgramiv) \
+    X(glGetShaderiv) \
+    X(glGetUniformLocation) \
+    X(glLinkProgram) \
+    X(glReadPixels) \
+    X(glShaderSource) \
+    X(glTexImage2D) \
+    X(glTexParameteri) \
+    X(glUniform1f) \
+    X(glUniform1i) \
+    X(glUseProgram) \
+    X(glVertexAttribPointer) \
+    X(glViewport)
+
+/* One function pointer per symbol, typed from the real prototype in the EGL/
+ * GLES headers so a signature drift is a compile error. Declared BEFORE the
+ * name-routing defines below so __typeof__ sees the header declaration. */
+#define DRMTAP_DECLARE_GL_PFN(name) static __typeof__(name) *pfn_##name;
+DRMTAP_EGL_CORE_SYMBOLS(DRMTAP_DECLARE_GL_PFN)
+DRMTAP_GLES_CORE_SYMBOLS(DRMTAP_DECLARE_GL_PFN)
+#undef DRMTAP_DECLARE_GL_PFN
+
+static void *g_libegl_handle;
+static void *g_libgles_handle;
+static int g_gl_libs_state; /* 0 = not attempted, 1 = loaded, -1 = failed */
+
+/* dlopen libEGL + libGLESv2 and resolve every core symbol this file calls.
+ * Returns 0 when everything resolved, -1 otherwise (sticky either way).
+ * Thread-safe. NOTE: the # / ## operators suppress macro expansion of the
+ * symbol names, so this loader is immune to the name-routing defines below,
+ * but it must stay textually ABOVE them so the pfn_ declarations resolve. */
+static int load_gl_libraries(void) {
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&lk);
+    if (g_gl_libs_state == 0) {
+        g_gl_libs_state = -1;
+        g_libegl_handle = dlopen("libEGL.so.1", RTLD_NOW | RTLD_LOCAL);
+        if (!g_libegl_handle) {
+            g_libegl_handle = dlopen("libEGL.so", RTLD_NOW | RTLD_LOCAL);
+        }
+        g_libgles_handle = dlopen("libGLESv2.so.2", RTLD_NOW | RTLD_LOCAL);
+        if (!g_libgles_handle) {
+            g_libgles_handle = dlopen("libGLESv2.so", RTLD_NOW | RTLD_LOCAL);
+        }
+        if (g_libegl_handle && g_libgles_handle) {
+            int ok = 1;
+            /* *(void **)&pfn is the POSIX-documented way to store a dlsym
+             * result into a function pointer without the pedantic
+             * object-to-function pointer conversion warning. */
+#define DRMTAP_LOAD_EGL_SYM(name) \
+            *(void **)&pfn_##name = dlsym(g_libegl_handle, #name); \
+            if (!pfn_##name) ok = 0;
+#define DRMTAP_LOAD_GLES_SYM(name) \
+            *(void **)&pfn_##name = dlsym(g_libgles_handle, #name); \
+            if (!pfn_##name) ok = 0;
+            DRMTAP_EGL_CORE_SYMBOLS(DRMTAP_LOAD_EGL_SYM)
+            DRMTAP_GLES_CORE_SYMBOLS(DRMTAP_LOAD_GLES_SYM)
+#undef DRMTAP_LOAD_EGL_SYM
+#undef DRMTAP_LOAD_GLES_SYM
+            if (ok) {
+                g_gl_libs_state = 1;
+            }
+        }
+    }
+    int ret = g_gl_libs_state;
+    pthread_mutex_unlock(&lk);
+    return (ret == 1) ? 0 : -1;
+}
+
+/* Route every EGL/GLES call in the rest of this file through the loaded
+ * pointers while keeping the standard API names at the call sites (the same
+ * pattern GLAD-style loaders use). Anything below this point that names an
+ * EGL/GLES core function is calling through its pfn_ pointer. */
+#define eglBindAPI pfn_eglBindAPI
+#define eglChooseConfig pfn_eglChooseConfig
+#define eglCreateContext pfn_eglCreateContext
+#define eglDestroyContext pfn_eglDestroyContext
+#define eglGetDisplay pfn_eglGetDisplay
+#define eglGetError pfn_eglGetError
+#define eglGetProcAddress pfn_eglGetProcAddress
+#define eglInitialize pfn_eglInitialize
+#define eglMakeCurrent pfn_eglMakeCurrent
+#define glActiveTexture pfn_glActiveTexture
+#define glAttachShader pfn_glAttachShader
+#define glBindAttribLocation pfn_glBindAttribLocation
+#define glBindFramebuffer pfn_glBindFramebuffer
+#define glBindTexture pfn_glBindTexture
+#define glCompileShader pfn_glCompileShader
+#define glCreateProgram pfn_glCreateProgram
+#define glCreateShader pfn_glCreateShader
+#define glDeleteFramebuffers pfn_glDeleteFramebuffers
+#define glDeleteProgram pfn_glDeleteProgram
+#define glDeleteShader pfn_glDeleteShader
+#define glDeleteTextures pfn_glDeleteTextures
+#define glDisableVertexAttribArray pfn_glDisableVertexAttribArray
+#define glDrawArrays pfn_glDrawArrays
+#define glEnableVertexAttribArray pfn_glEnableVertexAttribArray
+#define glFinish pfn_glFinish
+#define glFramebufferTexture2D pfn_glFramebufferTexture2D
+#define glGenFramebuffers pfn_glGenFramebuffers
+#define glGenTextures pfn_glGenTextures
+#define glGetError pfn_glGetError
+#define glGetProgramiv pfn_glGetProgramiv
+#define glGetShaderiv pfn_glGetShaderiv
+#define glGetUniformLocation pfn_glGetUniformLocation
+#define glLinkProgram pfn_glLinkProgram
+#define glReadPixels pfn_glReadPixels
+#define glShaderSource pfn_glShaderSource
+#define glTexImage2D pfn_glTexImage2D
+#define glTexParameteri pfn_glTexParameteri
+#define glUniform1f pfn_glUniform1f
+#define glUniform1i pfn_glUniform1i
+#define glUseProgram pfn_glUseProgram
+#define glVertexAttribPointer pfn_glVertexAttribPointer
+#define glViewport pfn_glViewport
+
+/* ========================================================================= */
 /* EGL context (lazily initialized per drmtap_ctx)                           */
 /* ========================================================================= */
 
 /* Global EGL display (one per process, shared across threads) */
 static EGLDisplay g_egl_display = EGL_NO_DISPLAY;
 static int g_egl_display_initialized = 0;
+
+/* ── Import-once EGLImage cache (keyed by KMS fb_id) ── */
+/* The compositor scans out of a small pool of framebuffers (double/triple
+ * buffering), so the same fb_ids repeat every frame. Importing the DMA-BUF as
+ * an EGLImage once per fb_id — instead of create+destroy per frame — removes
+ * the biggest per-frame EGL cost. The cached EGLImage aliases the live
+ * scanout memory, so sampling it always reads the current frame content.
+ * Geometry is stored to detect a recycled fb_id (same id, new framebuffer)
+ * and re-import. An EGLImage keeps its underlying buffer alive, so at most
+ * DRMTAP_EGL_IMAGE_SLOTS scanout buffers are pinned per thread — the same
+ * order of pinning the fast-grab mmap slots already do. */
+#define DRMTAP_EGL_IMAGE_SLOTS 4
+typedef struct {
+    const drmtap_ctx *owner;    /* cache entries are per capture context */
+    uint32_t fb_id;             /* 0 = slot unused */
+    uint32_t width, height, stride, fourcc;
+    uint64_t modifier;
+    int      num_planes;
+    uint32_t offsets[4];
+    uint32_t pitches[4];
+    ino_t    buf_inode;         /* dma-buf inode = the real buffer identity;
+                                   0 = unknown (fd was -1 or fstat failed) */
+    EGLImageKHR image;
+    GLuint texture;             /* GL_TEXTURE_EXTERNAL_OES bound to image */
+} egl_image_slot_t;
 
 /* Per-thread EGL context and GL resources */
 typedef struct {
@@ -66,6 +266,9 @@ typedef struct {
     uint32_t tex_width;
     uint32_t tex_height;
     int initialized;
+    egl_image_slot_t image_slots[DRMTAP_EGL_IMAGE_SLOTS];
+    unsigned next_evict;  /* round-robin eviction cursor for image_slots */
+    int cache_disabled;   /* DRMTAP_NO_IMAGE_CACHE=1 */
 } egl_state_t;
 
 /* The per-thread EGL context + GL resources.
@@ -112,6 +315,13 @@ static PFNEGLDESTROYIMAGEKHRPROC pfn_eglDestroyImageKHR;
 static PFNGLEGLIMAGETARGETTEXTURE2DOESPROC pfn_glEGLImageTargetTexture2DOES;
 
 static int load_egl_procs(void) {
+    /* Bring in libEGL/libGLESv2 first — every EGL entry point in this file
+     * funnels through here (egl_init and drmtap_gpu_egl_available) before any
+     * EGL/GL call is made, so this is the single lazy-load chokepoint. */
+    if (load_gl_libraries() < 0) {
+        return -1;
+    }
+
     pfn_eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)
         eglGetProcAddress("eglQueryDevicesEXT");
     pfn_eglQueryDeviceStringEXT = (PFNEGLQUERYDEVICESTRINGEXTPROC)
@@ -251,6 +461,11 @@ static GLuint create_program(void) {
 /* EGL display from DRM card path                                            */
 /* ========================================================================= */
 
+/* From EGL_EXT_device_drm_render_node; missing from older eglext.h. */
+#ifndef EGL_DRM_RENDER_NODE_FILE_EXT
+#define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
+#endif
+
 static EGLDisplay get_egl_display_for_card(const char *card_path) {
     if (!pfn_eglQueryDevicesEXT || !pfn_eglQueryDeviceStringEXT ||
         !pfn_eglGetPlatformDisplayEXT) {
@@ -273,9 +488,16 @@ static EGLDisplay get_egl_display_for_card(const char *card_path) {
 
     EGLDisplay display = EGL_NO_DISPLAY;
     for (int i = 0; i < num_devices; i++) {
+        /* Match either the card path (drmtap_open) or the render node path
+         * (drmtap_open_render) — a render-only context knows its GPU only by
+         * its /dev/dri/renderD* node. The render-node query returns NULL when
+         * the extension is absent, which just skips that comparison. */
         const char *drm_path = pfn_eglQueryDeviceStringEXT(
             devices[i], EGL_DRM_DEVICE_FILE_EXT);
-        if (drm_path && strcmp(drm_path, card_path) == 0) {
+        const char *render_path = pfn_eglQueryDeviceStringEXT(
+            devices[i], EGL_DRM_RENDER_NODE_FILE_EXT);
+        if ((drm_path && strcmp(drm_path, card_path) == 0) ||
+            (render_path && strcmp(render_path, card_path) == 0)) {
             display = pfn_eglGetPlatformDisplayEXT(
                 EGL_PLATFORM_DEVICE_EXT, devices[i], NULL);
             break;
@@ -380,6 +602,10 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     state->linear_texture = 0;
     state->tex_width = 0;
     state->tex_height = 0;
+    /* Escape hatch: DRMTAP_NO_IMAGE_CACHE=1 forces a fresh EGLImage import
+     * per frame (the pre-0.4.9 behaviour) for debugging driver oddities. */
+    const char *nocache = getenv("DRMTAP_NO_IMAGE_CACHE");
+    state->cache_disabled = (nocache && nocache[0] == '1');
     state->initialized = 1;
     /* Register the thread-exit backstop so a capture thread that dies without
      * drmtap_close() still frees this context (value must be non-NULL to arm the
@@ -397,12 +623,30 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     return 0;
 }
 
+/* Release one cached EGLImage slot (external texture + image). The caller
+ * must have the thread's EGL context current. Safe on an empty slot. */
+static void egl_image_slot_release(egl_state_t *st, egl_image_slot_t *slot) {
+    if (slot->texture) {
+        glDeleteTextures(1, &slot->texture);
+    }
+    if (slot->image != EGL_NO_IMAGE_KHR && pfn_eglDestroyImageKHR) {
+        pfn_eglDestroyImageKHR(st->display, slot->image);
+    }
+    memset(slot, 0, sizeof(*slot));
+}
+
 static void egl_cleanup(egl_state_t *st) {
     if (!st->initialized) {
         return;
     }
     eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                    st->context);
+    /* Drop the fb_id EGLImage cache first: the GL textures need the context
+     * current, and the cached EGLImages pin the imported scanout buffers. */
+    for (int i = 0; i < DRMTAP_EGL_IMAGE_SLOTS; i++) {
+        egl_image_slot_release(st, &st->image_slots[i]);
+    }
+    st->next_evict = 0;
     if (st->linear_texture) {
         glDeleteTextures(1, &st->linear_texture);
     }
@@ -454,131 +698,14 @@ static void ensure_linear_texture(egl_state_t *state, uint32_t w, uint32_t h) {
     state->tex_height = h;
 }
 
-/* ========================================================================= */
-/* Public API                                                                */
-/* ========================================================================= */
-
-/**
- * Check if EGL detiling is available on this system.
- * Returns 1 if EGL + GLES are functional, 0 otherwise.
- */
-int drmtap_gpu_egl_available(drmtap_ctx *ctx) {
-    /* EGL availability is a static property of the GPU, but this is called on
-     * every captured frame. Cache it once.
-     *
-     * CRITICAL: this must NOT call eglTerminate() on the display. The display
-     * returned by get_egl_display_for_card() is the SAME shared EGLDisplay used
-     * by the live detile contexts. Terminating it here — while another capture
-     * thread is mid-eglCreateImage — invalidates that thread's display and makes
-     * its detile fail with EGL_NOT_INITIALIZED, so it falls back to returning the
-     * raw tiled/compressed buffer (garbage/color corruption). Concurrent captures
-     * (e.g. two monitors viewed at once) hit this constantly. */
-    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
-    static int cached = -1;
-    pthread_mutex_lock(&lk);
-    if (cached < 0) {
-        if (load_egl_procs() < 0) {
-            cached = 0;
-        } else {
-            EGLDisplay display = get_egl_display_for_card(ctx->device_path);
-            if (display == EGL_NO_DISPLAY) {
-                cached = 0;
-            } else {
-                EGLint major, minor;
-                cached = eglInitialize(display, &major, &minor) ? 1 : 0;
-                /* Intentionally no eglTerminate(display) — see above. */
-            }
-        }
-    }
-    pthread_mutex_unlock(&lk);
-    return cached;
-}
-
-/**
- * Convert a tiled DMA-BUF framebuffer to linear RGBA pixels using EGL/GL.
- *
- * This is the universal GPU detiling path. The GPU driver handles its
- * own tiling format transparently when the DMA-BUF is imported as an
- * EGLImage with the correct modifier.
- *
- * @param ctx       Capture context
- * @param dma_buf_fd  DMA-BUF file descriptor
- * @param width     Framebuffer width
- * @param height    Framebuffer height
- * @param stride    Framebuffer stride (bytes per row)
- * @param fourcc    DRM fourcc format (e.g., DRM_FORMAT_XRGB8888)
- * @param modifier  DRM framebuffer modifier (tiling info)
- * @param out_data  Output: allocated linear RGBA buffer (caller must free)
- * @param out_size  Output: size of the allocated buffer
- * @return 0 on success, negative errno on error
- */
-static int egl_convert_impl(drmtap_ctx *ctx,
-                            int dma_buf_fd,
-                            uint32_t width, uint32_t height,
-                            uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
-                            void **out_data, size_t *out_size);
-
-/* Public entry point: serialize GPU detiles across the whole process.
- *
- * Each capture runs on its own thread with its own thread-local EGL context, but
- * the GPU is the real bottleneck. When two 4K monitors are captured at once,
- * letting both detiles run concurrently makes each take longer (wall-clock) than
- * the compositor's page-flip interval, so the live scanout buffer is recycled
- * mid-read and the CCS-compressed result comes out as garbage/color corruption.
- * A single process-global lock keeps every detile short enough to complete within
- * one flip interval, which eliminates the corruption while each thread still owns
- * its EGL context. */
-int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
-                           int dma_buf_fd,
-                           uint32_t width, uint32_t height,
-                           uint32_t stride, uint32_t fourcc,
-                           uint64_t modifier,
-                           void **out_data, size_t *out_size) {
-    static pthread_mutex_t g_convert_lock = PTHREAD_MUTEX_INITIALIZER;
-    pthread_mutex_lock(&g_convert_lock);
-    int _ret = egl_convert_impl(ctx, dma_buf_fd, width, height, stride, fourcc,
-                                modifier, out_data, out_size);
-    pthread_mutex_unlock(&g_convert_lock);
-    return _ret;
-}
-
-static int egl_convert_impl(drmtap_ctx *ctx,
-                            int dma_buf_fd,
-                            uint32_t width, uint32_t height,
-                            uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
-                            void **out_data, size_t *out_size) {
-    if (!out_data || !out_size) {
-        return -EINVAL;
-    }
-
-    /* Lazy-init this thread's EGL context. `state` is the file-scope
-     * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
-     * on close. (A `_Thread_local` is per-thread, so there is no cross-thread
-     * owner check to do here — each thread only ever sees its own instance.) */
-    int ret;
-
-    drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
-    if (!state.initialized) {
-        ret = egl_init(ctx, &state);
-        drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);
-        if (ret < 0) {
-            return ret;
-        }
-    }
-
-    /* Ensure display is initialized for this thread and context is current */
-    eglBindAPI(EGL_OPENGL_ES_API);
-    {
-        EGLint _maj, _min;
-        eglInitialize(state.display, &_maj, &_min);  /* no-op if already init */
-    }
-    if (!eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
-                        state.context)) {
-        drmtap_debug_log(NULL, "EGL: eglMakeCurrent in convert failed: 0x%x", eglGetError());
-    }
-
+/* Import a DMA-BUF as an EGLImage, retrying with progressively simpler
+ * attribute sets (XRGB8888 keeping the modifier, then XRGB8888 alone) the way
+ * some drivers need. CCS auxiliary planes come from ctx->fb2_*. Returns
+ * EGL_NO_IMAGE_KHR when every attempt failed. */
+static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
+                                     uint32_t width, uint32_t height,
+                                     uint32_t stride, uint32_t fourcc,
+                                     uint64_t modifier) {
     /* Build EGLImage attributes with DMA-BUF import */
     EGLint image_attribs[64];
     int ai = 0;
@@ -643,8 +770,6 @@ static int egl_convert_impl(drmtap_ctx *ctx,
 
     drmtap_debug_log(NULL, "EGL: tid=%lu creating EGLImage: fd=%d %ux%u stride=%u fourcc=0x%x mod=0x%lx ai=%d",
             (unsigned long)pthread_self(), dma_buf_fd, width, height, stride, fourcc, (unsigned long)modifier, ai);
-
-    /* eglMakeCurrent already done at function entry */
 
     /* Import DMA-BUF as EGLImage */
     EGLImageKHR image = pfn_eglCreateImageKHR(
@@ -716,13 +841,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
             drmtap_debug_log(NULL, "EGL: retry XRGB8888+nomod also FAILED: err=0x%x", eglGetError());
             drmtap_debug_log(ctx, "egl: all retries failed: 0x%x",
                              eglGetError());
-            return -EIO;
+            return EGL_NO_IMAGE_KHR;
         }
         drmtap_debug_log(NULL, "EGL: retry SUCCEEDED");
         drmtap_debug_log(ctx, "egl: retry succeeded");
     }
+    return image;
+}
 
-    /* Bind as GL_TEXTURE_EXTERNAL_OES — GPU handles detiling */
+/* Wrap an EGLImage in a GL_TEXTURE_EXTERNAL_OES texture (the GPU detiles
+ * transparently when sampling it). Leaves the texture bound on unit 0. */
+static int egl_make_external_texture(drmtap_ctx *ctx, EGLImageKHR image,
+                                     GLuint *out_texture) {
     GLuint ext_texture;
     glGenTextures(1, &ext_texture);
     glActiveTexture(GL_TEXTURE0);
@@ -741,8 +871,248 @@ static int egl_convert_impl(drmtap_ctx *ctx,
         drmtap_debug_log(ctx, "egl: glEGLImageTargetTexture2DOES failed: 0x%x",
                          gl_err);
         glDeleteTextures(1, &ext_texture);
-        pfn_eglDestroyImageKHR(state.display, image);
         return -EIO;
+    }
+    *out_texture = ext_texture;
+    return 0;
+}
+
+/* ========================================================================= */
+/* Public API                                                                */
+/* ========================================================================= */
+
+/**
+ * Check if EGL detiling is available on this system.
+ * Returns 1 if EGL + GLES are functional, 0 otherwise.
+ */
+int drmtap_gpu_egl_available(drmtap_ctx *ctx) {
+    /* EGL availability is a static property of the GPU, but this is called on
+     * every captured frame. Cache it once.
+     *
+     * CRITICAL: this must NOT call eglTerminate() on the display. The display
+     * returned by get_egl_display_for_card() is the SAME shared EGLDisplay used
+     * by the live detile contexts. Terminating it here — while another capture
+     * thread is mid-eglCreateImage — invalidates that thread's display and makes
+     * its detile fail with EGL_NOT_INITIALIZED, so it falls back to returning the
+     * raw tiled/compressed buffer (garbage/color corruption). Concurrent captures
+     * (e.g. two monitors viewed at once) hit this constantly. */
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    static int cached = -1;
+    pthread_mutex_lock(&lk);
+    if (cached < 0) {
+        if (load_egl_procs() < 0) {
+            cached = 0;
+        } else {
+            EGLDisplay display = get_egl_display_for_card(ctx->device_path);
+            if (display == EGL_NO_DISPLAY) {
+                cached = 0;
+            } else {
+                EGLint major, minor;
+                cached = eglInitialize(display, &major, &minor) ? 1 : 0;
+                /* Intentionally no eglTerminate(display) — see above. */
+            }
+        }
+    }
+    pthread_mutex_unlock(&lk);
+    return cached;
+}
+
+/**
+ * Convert a tiled DMA-BUF framebuffer to linear RGBA pixels using EGL/GL.
+ *
+ * This is the universal GPU detiling path. The GPU driver handles its
+ * own tiling format transparently when the DMA-BUF is imported as an
+ * EGLImage with the correct modifier.
+ *
+ * @param ctx       Capture context
+ * @param dma_buf_fd  DMA-BUF file descriptor
+ * @param width     Framebuffer width
+ * @param height    Framebuffer height
+ * @param stride    Framebuffer stride (bytes per row)
+ * @param fourcc    DRM fourcc format (e.g., DRM_FORMAT_XRGB8888)
+ * @param modifier  DRM framebuffer modifier (tiling info)
+ * @param out_data  Output: allocated linear RGBA buffer (caller must free)
+ * @param out_size  Output: size of the allocated buffer
+ * @return 0 on success, negative errno on error
+ */
+static int egl_convert_impl(drmtap_ctx *ctx,
+                            int dma_buf_fd,
+                            uint32_t width, uint32_t height,
+                            uint32_t stride, uint32_t fourcc,
+                            uint64_t modifier, uint32_t fb_id,
+                            void **out_data, size_t *out_size);
+
+/* Public entry point: serialize GPU detiles across the whole process.
+ *
+ * Each capture runs on its own thread with its own thread-local EGL context, but
+ * the GPU is the real bottleneck. When two 4K monitors are captured at once,
+ * letting both detiles run concurrently makes each take longer (wall-clock) than
+ * the compositor's page-flip interval, so the live scanout buffer is recycled
+ * mid-read and the CCS-compressed result comes out as garbage/color corruption.
+ * A single process-global lock keeps every detile short enough to complete within
+ * one flip interval, which eliminates the corruption while each thread still owns
+ * its EGL context. */
+int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
+                           int dma_buf_fd,
+                           uint32_t width, uint32_t height,
+                           uint32_t stride, uint32_t fourcc,
+                           uint64_t modifier, uint32_t fb_id,
+                           void **out_data, size_t *out_size) {
+    static pthread_mutex_t g_convert_lock = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&g_convert_lock);
+    int _ret = egl_convert_impl(ctx, dma_buf_fd, width, height, stride, fourcc,
+                                modifier, fb_id, out_data, out_size);
+    pthread_mutex_unlock(&g_convert_lock);
+    return _ret;
+}
+
+static int egl_convert_impl(drmtap_ctx *ctx,
+                            int dma_buf_fd,
+                            uint32_t width, uint32_t height,
+                            uint32_t stride, uint32_t fourcc,
+                            uint64_t modifier, uint32_t fb_id,
+                            void **out_data, size_t *out_size) {
+    if (!ctx || !out_data || !out_size) {
+        return -EINVAL;
+    }
+
+    /* Lazy-init this thread's EGL context. `state` is the file-scope
+     * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
+     * on close. (A `_Thread_local` is per-thread, so there is no cross-thread
+     * owner check to do here — each thread only ever sees its own instance.) */
+    int ret;
+
+    drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
+    if (!state.initialized) {
+        ret = egl_init(ctx, &state);
+        drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);
+        if (ret < 0) {
+            return ret;
+        }
+    }
+
+    /* Ensure display is initialized for this thread and context is current */
+    eglBindAPI(EGL_OPENGL_ES_API);
+    {
+        EGLint _maj, _min;
+        eglInitialize(state.display, &_maj, &_min);  /* no-op if already init */
+    }
+    if (!eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
+                        state.context)) {
+        drmtap_debug_log(NULL, "EGL: eglMakeCurrent in convert failed: 0x%x", eglGetError());
+    }
+
+    /* ── Import-once: EGLImage cache keyed by fb_id ── */
+    egl_image_slot_t *slot = NULL;
+    egl_image_slot_t *free_slot = NULL;
+    EGLImageKHR image = EGL_NO_IMAGE_KHR;
+    GLuint ext_texture = 0;
+    int use_cache = (fb_id != 0 && !state.cache_disabled);
+
+    /* Real buffer identity: a DMA-BUF has a unique inode that is stable across
+     * re-exports of the same underlying scanout BO and changes when the BO
+     * changes. KMS recycles a freed fb_id onto a brand-new BO that can have
+     * BYTE-IDENTICAL geometry, so geometry alone cannot tell "same fb, live
+     * buffer" from "same id, new buffer" — the inode can. Captured when a real
+     * fd is supplied; 0 (fd == -1, the known-cached contract, or fstat failed)
+     * means "trust fb_id + geometry". */
+    ino_t cur_inode = 0;
+    if (dma_buf_fd >= 0) {
+        struct stat st;
+        if (fstat(dma_buf_fd, &st) == 0) {
+            cur_inode = st.st_ino;
+        }
+    }
+
+    if (use_cache) {
+        for (int i = 0; i < DRMTAP_EGL_IMAGE_SLOTS; i++) {
+            egl_image_slot_t *s = &state.image_slots[i];
+            if (s->fb_id == 0) {
+                if (!free_slot) {
+                    free_slot = s;
+                }
+                continue;
+            }
+            if (s->fb_id != fb_id || s->owner != ctx) {
+                continue;
+            }
+            int geom_match =
+                (s->width == width && s->height == height &&
+                 s->stride == stride && s->fourcc == fourcc &&
+                 s->modifier == modifier &&
+                 s->num_planes == ctx->fb2_num_planes &&
+                 memcmp(s->offsets, ctx->fb2_offsets, sizeof(s->offsets)) == 0 &&
+                 memcmp(s->pitches, ctx->fb2_pitches, sizeof(s->pitches)) == 0);
+            /* Identity holds unless BOTH inodes are known and differ — i.e. a
+             * recycled fb_id on a new buffer. If either is unknown, geometry
+             * is the best signal we have and we trust it. */
+            int ident_match =
+                (cur_inode == 0 || s->buf_inode == 0 ||
+                 s->buf_inode == cur_inode);
+            if (geom_match && ident_match) {
+                slot = s;
+                break;
+            }
+            /* Different geometry, or same geometry but the buffer identity
+             * changed (fb_id recycled onto a new BO) — the cached import is
+             * stale. Drop it and reuse the slot for the fresh import. */
+            egl_image_slot_release(&state, s);
+            if (!free_slot) {
+                free_slot = s;
+            }
+        }
+    }
+
+    if (slot) {
+        /* Cache hit: the EGLImage aliases the live scanout buffer, so binding
+         * the cached external texture samples the CURRENT frame content — no
+         * re-import, no texture churn. */
+        image = slot->image;
+        ext_texture = slot->texture;
+        glActiveTexture(GL_TEXTURE0);
+        glBindTexture(GL_TEXTURE_EXTERNAL_OES, ext_texture);
+    } else {
+        if (dma_buf_fd < 0) {
+            drmtap_set_error(ctx, "egl: fb_id %u is not cached and no "
+                             "dma-buf fd was supplied", fb_id);
+            return -EINVAL;
+        }
+        image = egl_import_dmabuf(ctx, dma_buf_fd, width, height, stride,
+                                  fourcc, modifier);
+        if (image == EGL_NO_IMAGE_KHR) {
+            return -EIO;
+        }
+        ret = egl_make_external_texture(ctx, image, &ext_texture);
+        if (ret != 0) {
+            pfn_eglDestroyImageKHR(state.display, image);
+            return ret;
+        }
+        if (use_cache) {
+            /* Adopt the fresh import into a slot: reuse a free one, else
+             * round-robin evict (compositors cycle 2-3 buffers, so with 4
+             * slots eviction only happens on pathological flip patterns). */
+            egl_image_slot_t *dst = free_slot;
+            if (!dst) {
+                dst = &state.image_slots[state.next_evict %
+                                         DRMTAP_EGL_IMAGE_SLOTS];
+                state.next_evict++;
+                egl_image_slot_release(&state, dst);
+            }
+            dst->owner = ctx;
+            dst->fb_id = fb_id;
+            dst->width = width;
+            dst->height = height;
+            dst->stride = stride;
+            dst->fourcc = fourcc;
+            dst->modifier = modifier;
+            dst->num_planes = ctx->fb2_num_planes;
+            memcpy(dst->offsets, ctx->fb2_offsets, sizeof(dst->offsets));
+            memcpy(dst->pitches, ctx->fb2_pitches, sizeof(dst->pitches));
+            dst->buf_inode = cur_inode;
+            dst->image = image;
+            dst->texture = ext_texture;
+            slot = dst;
+        }
     }
 
     /* Ensure output texture */
@@ -798,14 +1168,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     /* Ensure GPU rendering is complete before reading back */
     glFinish();
 
-    /* Read linear pixels back */
+    /* Read linear pixels straight into the ctx-owned grow-once buffer
+     * (drmtap_ensure_buf caps it at DRMTAP_MAX_FB_BYTES), so steady-state
+     * conversion performs zero per-frame allocations. The buffer belongs to
+     * the context and is freed in drmtap_close(); callers must not free it. */
     size_t rgba_size = (size_t)width * height * 4;
-    void *pixels = malloc(rgba_size);
-    if (!pixels) {
-        ret = -ENOMEM;
+    ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
+                            rgba_size);
+    if (ret != 0) {
         goto cleanup;
     }
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
+                 ctx->deswizzle_buf);
     drmtap_debug_log(NULL, "EGL: glReadPixels done, gl_err=0x%x", glGetError());
 
     /* NOTE: CPU horizontal flip removed. The EGL DMA-BUF import with
@@ -813,7 +1187,7 @@ static int egl_convert_impl(drmtap_ctx *ctx,
      * orientation. The previous CPU flip was compensating for a shader-
      * based X flip (1.0 - v_texcoord.x) that has since been removed. */
 
-    *out_data = pixels;
+    *out_data = ctx->deswizzle_buf;
     *out_size = rgba_size;
     ret = 0;
 
@@ -823,8 +1197,13 @@ static int egl_convert_impl(drmtap_ctx *ctx,
 cleanup:
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glBindTexture(GL_TEXTURE_EXTERNAL_OES, 0);
-    glDeleteTextures(1, &ext_texture);
-    pfn_eglDestroyImageKHR(state.display, image);
+    if (!slot) {
+        /* Uncached import (fb_id 0, or cache disabled): per-call lifetime,
+         * exactly the pre-cache behaviour. A cached import stays alive in its
+         * slot until eviction or egl_cleanup(). */
+        glDeleteTextures(1, &ext_texture);
+        pfn_eglDestroyImageKHR(state.display, image);
+    }
 
     /* The context stays current on this (capture) thread and is reused across
      * calls — each thread owns its own thread-local context. It is released by
@@ -845,10 +1224,10 @@ int drmtap_gpu_egl_convert(drmtap_ctx *ctx,
                             int dma_buf_fd,
                             uint32_t width, uint32_t height,
                             uint32_t stride, uint32_t fourcc,
-                            uint64_t modifier,
+                            uint64_t modifier, uint32_t fb_id,
                             void **out_data, size_t *out_size) {
     (void)ctx; (void)dma_buf_fd; (void)width; (void)height;
-    (void)stride; (void)fourcc; (void)modifier;
+    (void)stride; (void)fourcc; (void)modifier; (void)fb_id;
     (void)out_data; (void)out_size;
     drmtap_set_error(ctx, "EGL backend not available (built without EGL)");
     return -ENOTSUP;

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -1003,7 +1003,9 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     }
 
     /* ── Import-once: EGLImage cache keyed by fb_id ── */
-    egl_image_slot_t *slot = NULL;
+    /* slot is only ever read through (the writes go through `dst`/`s`), so it
+     * is const; free_slot/dst stay mutable because they populate a slot. */
+    const egl_image_slot_t *slot = NULL;
     egl_image_slot_t *free_slot = NULL;
     EGLImageKHR image = EGL_NO_IMAGE_KHR;
     GLuint ext_texture = 0;

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -1131,11 +1131,12 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     glUniform1i(glGetUniformLocation(state.program, "image"), 0);
 
     /* HDR10 scanout: tone-map PQ/BT.2020 -> SDR in the shader. eotf/peak come
-     * from the connector HDR_OUTPUT_METADATA (carried on ctx). */
-    int hdr_on = (ctx && ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) ? 1 : 0;
+     * from the connector HDR_OUTPUT_METADATA (carried on ctx). ctx is
+     * non-NULL here — the function returns -EINVAL up top otherwise. */
+    int hdr_on = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) ? 1 : 0;
     glUniform1i(glGetUniformLocation(state.program, "u_hdr"), hdr_on);
     {
-        uint32_t mn = (ctx && ctx->cur_hdr_max_nits > 0)
+        uint32_t mn = (ctx->cur_hdr_max_nits > 0)
                           ? ctx->cur_hdr_max_nits : 1000u;
         glUniform1f(glGetUniformLocation(state.program, "u_peak_n"),
                     (float)((double)mn / 203.0));

--- a/tests/test_convert.c
+++ b/tests/test_convert.c
@@ -293,11 +293,29 @@ static void test_hdr_pq_xr30(drmtap_ctx *ctx) {
     desc.hdr_eotf = DRMTAP_EOTF_PQ;
     desc.hdr_max_nits = 1000;
 
+    /* Baseline: the SAME 10-bit pixel reduced WITHOUT HDR (plain 10->8). Keep
+     * a copy — the next convert overwrites the ctx-owned output buffer. */
+    desc.hdr_eotf = DRMTAP_EOTF_SDR;
+    desc.hdr_max_nits = 0;
+    int r_sdr = drmtap_convert_dmabuf(ctx, &desc, &frame);
+    uint32_t sdr_px = (r_sdr == 0 && frame.data)
+                          ? (((const uint32_t *)frame.data)[0] & 0x00FFFFFFu) : 0;
+
+    /* HDR10 (PQ) tone-map of the same pixel. */
+    desc.hdr_eotf = DRMTAP_EOTF_PQ;
+    desc.hdr_max_nits = 1000;
     int ret = drmtap_convert_dmabuf(ctx, &desc, &frame);
     check(ret == 0, "HDR10 (PQ) XR30 convert succeeds");
     if (ret == 0) {
         check(frame.format == FMT_XR24, "tone-mapped output is XRGB8888");
         check(frame.data != NULL, "tone-mapped pixels returned");
+        uint32_t pq_px = frame.data
+                             ? (((const uint32_t *)frame.data)[0] & 0x00FFFFFFu) : 0;
+        /* The whole point of the PQ path: it must NOT collapse to the plain
+         * bit-depth reduction. If HDR metadata were ignored, pq_px == sdr_px
+         * and this fails — which is exactly the broken-HDR regression to catch. */
+        check(r_sdr == 0 && pq_px != sdr_px,
+              "PQ tone-map differs from the plain SDR reduction (HDR path engaged)");
     }
     close(fd);
 }

--- a/tests/test_convert.c
+++ b/tests/test_convert.c
@@ -1,0 +1,336 @@
+/*
+ * libdrmtap — DRM/KMS screen capture library for Linux
+ * https://github.com/fxd0h/libdrmtap
+ *
+ * Copyright (c) 2026 Mariano Abad <weimaraner@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file test_convert.c
+ * @brief Unit tests for the split-capture convert API
+ *        (drmtap_open_render + drmtap_convert_dmabuf)
+ *
+ * Runs without scanout hardware: argument validation runs everywhere; the
+ * pixel tests feed a memfd standing in for a linear DMA-BUF, which exercises
+ * the CPU fallback path deterministically (an EGL import of a non-DMA-BUF fd
+ * fails and the conversion falls back, and machines without EGL never try
+ * it). Prints SKIP and exits clean when no render node / DRM device exists.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <unistd.h>
+#include <sys/mman.h>
+
+#include "drmtap.h"
+
+static int failures = 0;
+
+static void check(int cond, const char *what) {
+    if (cond) {
+        printf("  OK: %s\n", what);
+    } else {
+        printf("  FAIL: %s\n", what);
+        failures++;
+    }
+}
+
+/* DRM fourccs (avoid a libdrm header dependency in a unit test) */
+#define FMT_XR24 0x34325258u /* XRGB8888 */
+#define FMT_XR30 0x30335258u /* XRGB2101010 */
+
+/* A memfd filled with `size` bytes of `data` stands in for a linear DMA-BUF:
+ * the library mmaps it PROT_READ/MAP_SHARED exactly like a real fd, and the
+ * DMA_BUF_IOCTL_SYNC calls fail silently (they are best-effort). */
+static int make_pixel_memfd(const void *data, size_t size) {
+    int fd = memfd_create("drmtap-convert-test", MFD_CLOEXEC);
+    if (fd < 0) {
+        return -1;
+    }
+    if (write(fd, data, size) != (ssize_t)size) {
+        close(fd);
+        return -1;
+    }
+    return fd;
+}
+
+static void test_null_args(void) {
+    printf("test_null_args:\n");
+    drmtap_dmabuf_desc desc;
+    drmtap_frame_info frame;
+    memset(&desc, 0, sizeof(desc));
+    check(drmtap_convert_dmabuf(NULL, &desc, &frame) == -EINVAL,
+          "NULL ctx rejected");
+}
+
+static void test_desc_validation(drmtap_ctx *ctx) {
+    printf("test_desc_validation:\n");
+    drmtap_dmabuf_desc desc;
+    drmtap_frame_info frame;
+
+    memset(&desc, 0, sizeof(desc));
+    desc.dma_buf_fd = -1;
+    desc.width = 64;
+    desc.height = 32;
+    /* pitches[0] == 0 */
+    check(drmtap_convert_dmabuf(ctx, &desc, &frame) == -EINVAL,
+          "zero stride rejected");
+
+    desc.pitches[0] = 64 * 4;
+    desc.num_planes = 5;
+    check(drmtap_convert_dmabuf(ctx, &desc, &frame) == -EINVAL,
+          "num_planes > 4 rejected");
+
+    desc.num_planes = 1;
+    desc.height = 0x20000000u; /* stride*height far past DRMTAP's FB cap */
+    check(drmtap_convert_dmabuf(ctx, &desc, &frame) == -EFBIG,
+          "oversized geometry rejected");
+
+    desc.height = 32;
+    desc.fb_id = 12345; /* never imported by this context */
+    desc.dma_buf_fd = -1;
+    check(drmtap_convert_dmabuf(ctx, &desc, &frame) == -EINVAL,
+          "unknown fb_id with fd=-1 rejected");
+
+    /* Untrusted descriptor: a stride that does not cover width*bpp must be
+     * rejected before any per-pixel converter can read/write past the row. */
+    memset(&desc, 0, sizeof(desc));
+    desc.dma_buf_fd = -1;
+    desc.width = 4096;
+    desc.height = 64;
+    desc.format = FMT_XR24;
+    desc.num_planes = 1;
+    desc.pitches[0] = 256; /* only 64 px wide, but width says 4096 */
+    check(drmtap_convert_dmabuf(ctx, &desc, &frame) == -EINVAL,
+          "stride smaller than width*bpp rejected");
+}
+
+static void test_padded_stride_passthrough(drmtap_ctx *ctx) {
+    printf("test_padded_stride_passthrough:\n");
+    enum { W = 32, H = 8, PAD_PX = 16 };
+    const uint32_t src_stride = (W + PAD_PX) * 4; /* padded scanout row */
+    static uint32_t src[(W + PAD_PX) * H];
+    for (uint32_t y = 0; y < H; y++) {
+        for (uint32_t x = 0; x < W + PAD_PX; x++) {
+            /* Distinct value per pixel; padding columns get a sentinel that
+             * must NOT survive into the tight output. */
+            src[y * (W + PAD_PX) + x] =
+                (x < W) ? (0xFF000000u | (y << 8) | x) : 0xDEADBEEFu;
+        }
+    }
+    int fd = make_pixel_memfd(src, sizeof(src));
+    if (fd < 0) {
+        printf("  SKIP: memfd_create failed\n");
+        return;
+    }
+
+    drmtap_dmabuf_desc desc;
+    drmtap_frame_info frame;
+    memset(&desc, 0, sizeof(desc));
+    desc.dma_buf_fd = fd;
+    desc.width = W;
+    desc.height = H;
+    desc.format = FMT_XR24;
+    desc.modifier = 0;
+    desc.fb_id = 0;
+    desc.num_planes = 1;
+    desc.pitches[0] = src_stride;
+
+    int ret = drmtap_convert_dmabuf(ctx, &desc, &frame);
+    check(ret == 0, "padded-stride convert succeeds");
+    if (ret == 0) {
+        check(frame.stride == W * 4,
+              "output stride normalized to width*4 (padding dropped)");
+        /* Every output row must equal the first W pixels of the source row,
+         * with no padding sentinel bleeding in. */
+        int content_ok = 1;
+        const uint32_t *out = frame.data;
+        for (uint32_t y = 0; y < H && content_ok; y++) {
+            for (uint32_t x = 0; x < W; x++) {
+                if (out[y * W + x] != src[y * (W + PAD_PX) + x]) {
+                    content_ok = 0;
+                    break;
+                }
+            }
+        }
+        check(content_ok, "repacked pixels match source (no padding bleed)");
+    }
+    close(fd);
+}
+
+static void test_grab_guard(drmtap_ctx *ctx, int render_only) {
+    printf("test_grab_guard:\n");
+    if (!render_only) {
+        printf("  SKIP: context is not render-only\n");
+        return;
+    }
+    drmtap_frame_info frame;
+    check(drmtap_grab(ctx, &frame) == -ENOTSUP,
+          "grab rejected on render-only context");
+    check(drmtap_grab_mapped_fast(ctx, &frame) == -ENOTSUP,
+          "fast grab rejected on render-only context");
+}
+
+static void test_linear_xrgb8888(drmtap_ctx *ctx) {
+    printf("test_linear_xrgb8888:\n");
+    enum { W = 64, H = 32 };
+    const uint32_t stride = W * 4;
+    static uint32_t src[W * H];
+    for (uint32_t y = 0; y < H; y++) {
+        for (uint32_t x = 0; x < W; x++) {
+            src[y * W + x] = 0xAA000000u | (y << 16) | x;
+        }
+    }
+    int fd = make_pixel_memfd(src, sizeof(src));
+    if (fd < 0) {
+        printf("  SKIP: memfd_create failed\n");
+        return;
+    }
+
+    drmtap_dmabuf_desc desc;
+    drmtap_frame_info frame;
+    memset(&desc, 0, sizeof(desc));
+    desc.dma_buf_fd = fd;
+    desc.width = W;
+    desc.height = H;
+    desc.format = FMT_XR24;
+    desc.modifier = 0; /* linear */
+    desc.fb_id = 0;    /* no caching for a stand-in fd */
+    desc.num_planes = 1;
+    desc.pitches[0] = stride;
+
+    int ret = drmtap_convert_dmabuf(ctx, &desc, &frame);
+    check(ret == 0, "linear XRGB8888 convert succeeds");
+    if (ret == 0) {
+        check(frame.data != NULL, "pixels returned");
+        check(frame.format == FMT_XR24, "format stays XRGB8888");
+        check(frame.stride == stride, "stride preserved");
+        check(frame.width == W && frame.height == H, "geometry preserved");
+        check(frame.data && memcmp(frame.data, src, sizeof(src)) == 0,
+              "pixel content identical");
+
+        /* Second convert on the same context must reuse the grow-once buffer
+         * and still produce correct pixels. */
+        ret = drmtap_convert_dmabuf(ctx, &desc, &frame);
+        check(ret == 0 && frame.data &&
+              memcmp(frame.data, src, sizeof(src)) == 0,
+              "second convert (buffer reuse) identical");
+    }
+    close(fd);
+}
+
+static void test_linear_xr30(drmtap_ctx *ctx) {
+    printf("test_linear_xr30:\n");
+    enum { W = 16, H = 8 };
+    const uint32_t stride = W * 4;
+    /* XRGB2101010: X[31:30] R[29:20] G[19:10] B[9:0]. Full-scale R and B,
+     * zero G — exact under both truncating and rounding 10->8 reductions. */
+    const uint32_t px = (1023u << 20) | (0u << 10) | 1023u;
+    static uint32_t src[W * H];
+    for (int i = 0; i < W * H; i++) {
+        src[i] = px;
+    }
+    int fd = make_pixel_memfd(src, sizeof(src));
+    if (fd < 0) {
+        printf("  SKIP: memfd_create failed\n");
+        return;
+    }
+
+    drmtap_dmabuf_desc desc;
+    drmtap_frame_info frame;
+    memset(&desc, 0, sizeof(desc));
+    desc.dma_buf_fd = fd;
+    desc.width = W;
+    desc.height = H;
+    desc.format = FMT_XR30;
+    desc.modifier = 0;
+    desc.fb_id = 0;
+    desc.num_planes = 1;
+    desc.pitches[0] = stride;
+
+    int ret = drmtap_convert_dmabuf(ctx, &desc, &frame);
+    check(ret == 0, "linear XR30 convert succeeds");
+    if (ret == 0) {
+        check(frame.format == FMT_XR24, "XR30 reduced to XRGB8888");
+        uint32_t out = frame.data ? ((const uint32_t *)frame.data)[0] : 0;
+        check((out & 0x00FFFFFFu) == 0x00FF00FFu,
+              "10-bit magenta reduces to 8-bit magenta");
+    }
+    close(fd);
+}
+
+static void test_hdr_pq_xr30(drmtap_ctx *ctx) {
+    printf("test_hdr_pq_xr30:\n");
+    enum { W = 16, H = 8 };
+    const uint32_t stride = W * 4;
+    const uint32_t px = (512u << 20) | (512u << 10) | 512u;
+    static uint32_t src[W * H];
+    for (int i = 0; i < W * H; i++) {
+        src[i] = px;
+    }
+    int fd = make_pixel_memfd(src, sizeof(src));
+    if (fd < 0) {
+        printf("  SKIP: memfd_create failed\n");
+        return;
+    }
+
+    drmtap_dmabuf_desc desc;
+    drmtap_frame_info frame;
+    memset(&desc, 0, sizeof(desc));
+    desc.dma_buf_fd = fd;
+    desc.width = W;
+    desc.height = H;
+    desc.format = FMT_XR30;
+    desc.modifier = 0;
+    desc.fb_id = 0;
+    desc.num_planes = 1;
+    desc.pitches[0] = stride;
+    desc.hdr_eotf = DRMTAP_EOTF_PQ;
+    desc.hdr_max_nits = 1000;
+
+    int ret = drmtap_convert_dmabuf(ctx, &desc, &frame);
+    check(ret == 0, "HDR10 (PQ) XR30 convert succeeds");
+    if (ret == 0) {
+        check(frame.format == FMT_XR24, "tone-mapped output is XRGB8888");
+        check(frame.data != NULL, "tone-mapped pixels returned");
+    }
+    close(fd);
+}
+
+int main(void) {
+    printf("test_convert: split-capture convert API\n");
+
+    test_null_args();
+
+    /* Prefer a render-only context (the split-model consumer); fall back to a
+     * full context — convert works on any ctx with a usable backend. */
+    int render_only = 1;
+    drmtap_ctx *ctx = drmtap_open_render(NULL);
+    if (!ctx) {
+        render_only = 0;
+        ctx = drmtap_open(NULL);
+    }
+    if (!ctx) {
+        printf("  SKIP: no render node or DRM device available\n");
+        printf("test_convert: %d failures\n", failures);
+        return failures ? 1 : 0;
+    }
+    printf("  using %s context\n", render_only ? "render-only" : "full");
+
+    test_desc_validation(ctx);
+    test_grab_guard(ctx, render_only);
+    test_linear_xrgb8888(ctx);
+    test_padded_stride_passthrough(ctx);
+    test_linear_xr30(ctx);
+    test_hdr_pq_xr30(ctx);
+
+    drmtap_close(ctx);
+
+    printf("test_convert: %d failures\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
phase 1 of the two-process split for rustdesk#15420. keep the DRM export in the privileged path and move the EGL detile/convert to an unprivileged one, so the GPU userspace never loads into the privileged process.

## what changed
1- lazy dlopen of libEGL/libGLESv2 (X-macro loader, typeof-typed function pointers, GLAD-style name routing) so they are no longer in DT_NEEDED. a process that only calls drmtap_open/drmtap_grab never maps the GPU stack. verified: readelf NEEDED is libdrm/libm/libc only, and the generated libdrmtap.pc no longer lists egl/glesv2 in Requires.private.
2- import-once EGLImage cache keyed by fb_id plus the dma-buf inode (the real buffer identity). the compositor recycles a freed fb_id onto a new buffer that can have byte-identical geometry, so geometry alone cannot tell them apart. the inode can, so a recycled id re-imports instead of serving a stale frozen frame. glReadPixels now reads into the ctx grow-once buffer, so steady-state convert does no per-frame malloc.
3- new split API:
   - drmtap_open_render(render_node) opens a render-node-only context (no KMS, no helper, no elevated cap). grab entry points return -ENOTSUP on it.
   - drmtap_convert_dmabuf(ctx, desc, frame) takes an exporter-supplied drmtap_dmabuf_desc (fd + geometry + the CCS aux planes as num_planes/offsets/pitches + the HDR eotf/max_nits the exporter read from the connector) and returns linear RGBA. the descriptor crosses a process boundary so it is treated as untrusted: width*bpp larger than the stride is rejected before any per-pixel conversion can walk off the row. GPU path first, CPU mmap+deswizzle fallback.
4- fast-path plane-layout restage: a grab_mapped_fast cache HIT skipped GetFB2, leaving ctx->fb2_* describing whichever fb was last read. the EGL CCS import reads ctx->fb2_*, so a HIT could import with the wrong plane count. the plane layout is now captured per fast slot and restaged on every HIT.

## verification
1- 6 unit suites incl. a new test_convert (validation, render-only guards, XR30 reduce, HDR PQ tone-map, padded-stride repack, narrow-stride reject).
2- asan + lsan clean across all unit suites and the i915 integration capture.
3- 6s stream on a real i915 CCS scanout: 178 frames EGL-detiled, exactly 1 EGLImage import, zero leaks (import-once holds).
4- per-thread-close leak-test (open+grab_mapped+fast+close on a fresh pthread x60): RSS flat, 64 kB growth over 60 iters.
5- builds clean with and without EGL, -Werror -Wpedantic.

the two new public entry points are additive; existing callers (drmtap_grab / _mapped / _fast, helper mode, virgl) are unchanged.