### PR TITLE
add drmtap_grab_desc: complete descriptor for the split exporter (0.4.10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 **Language:** C11  
 **License:** MIT  
 **Tests:** unit (no hardware) + integration via VKMS (Virtual KMS) or a real GPU  
-**Version:** C library `0.4.9` · Rust crates `libdrmtap-sys 0.4.9` / `libdrmtap 0.3.4`  
+**Version:** C library `0.4.10` · Rust crates `libdrmtap-sys 0.4.10` / `libdrmtap 0.3.4`  
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ int main() {
 libdrmtap = "0.3"
 ```
 
-> This pulls in `libdrmtap-sys` 0.4.9, which embeds and statically compiles the
+> This pulls in `libdrmtap-sys` 0.4.10, which embeds and statically compiles the
 > C sources (and the privilege helper). No system `libdrmtap` install, no
 > `meson install`, no `pkg-config` to find a shared library.
 
@@ -195,7 +195,7 @@ sudo ./build/vnc_server
 libdrmtap is being upstreamed into [RustDesk](https://github.com/rustdesk/rustdesk)
 via [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420).
 The integration adds a `drm` backend to `scrap` that depends on the
-[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.9 crate, which
+[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.10 crate, which
 embeds and statically compiles the C sources (and the privilege helper) — so
 there is no system `libdrmtap` install and no dynamic `libdrmtap.so` linkage.
 

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.9"
+version = "0.4.10"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -1038,6 +1038,46 @@ int drmtap_grab(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     return do_grab(ctx, frame, 0);  /* zero-copy: DMA-BUF fd only */
 }
 
+int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
+                     drmtap_frame_info *frame) {
+    if (!ctx || !desc || !frame) {
+        return -EINVAL;
+    }
+    int ret = do_grab(ctx, frame, 0);  /* zero-copy: DMA-BUF fd + metadata */
+    if (ret != 0) {
+        return ret;
+    }
+    /* Snapshot the full descriptor. The plane layout and HDR state are cached
+     * on ctx during do_grab (from GetFB2 and the connector metadata) — they are
+     * NOT in frame_info, which is exactly why a split exporter needs this call
+     * rather than drmtap_grab alone. */
+    memset(desc, 0, sizeof(*desc));
+    desc->dma_buf_fd = frame->dma_buf_fd;
+    desc->width = frame->width;
+    desc->height = frame->height;
+    desc->format = frame->format;
+    desc->modifier = frame->modifier;
+    desc->fb_id = frame->fb_id;
+
+    int np = ctx->fb2_num_planes > 0 ? ctx->fb2_num_planes : 1;
+    if (np > 4) {
+        np = 4;
+    }
+    desc->num_planes = (uint32_t)np;
+    for (int p = 0; p < 4; p++) {
+        desc->offsets[p] = ctx->fb2_offsets[p];
+        desc->pitches[p] = ctx->fb2_pitches[p];
+    }
+    /* Guarantee the main-surface stride is set even if GetFB2 left pitches[0]
+     * zero (helper/dumb paths): fall back to the frame stride. */
+    if (desc->pitches[0] == 0) {
+        desc->pitches[0] = frame->stride;
+    }
+    desc->hdr_eotf = ctx->cur_hdr_eotf;
+    desc->hdr_max_nits = ctx->cur_hdr_max_nits;
+    return 0;
+}
+
 int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     if (!ctx || !frame) {
         return -EINVAL;

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -1047,6 +1047,18 @@ int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
     if (ret != 0) {
         return ret;
     }
+    /* The split model ships the dma_buf_fd to another process, so a grab that
+     * produced pixels instead of a transferable fd (the helper V2 pixel
+     * fallback sets frame->dma_buf_fd = -1) yields a descriptor the receiver
+     * cannot convert — its fb_id is not valid across the process boundary
+     * either. Fail closed rather than hand back an untransferable descriptor. */
+    if (frame->dma_buf_fd < 0) {
+        drmtap_set_error(ctx,
+            "grab_desc needs a transferable DMA-BUF fd; this capture path "
+            "returned pixels only (no exportable dma-buf)");
+        drmtap_frame_release(ctx, frame);
+        return -ENOTSUP;
+    }
     /* Snapshot the full descriptor. The plane layout and HDR state are cached
      * on ctx during do_grab (from GetFB2 and the connector metadata) — they are
      * NOT in frame_info, which is exactly why a split exporter needs this call

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -276,10 +276,15 @@ typedef struct {
  *
  * @p frame is also populated (same as drmtap_grab) and OWNS the resources:
  * release it with drmtap_frame_release() once the fd has been sent. @p desc is
- * a plain value snapshot (safe to serialize over IPC); it borrows nothing.
+ * a metadata snapshot safe to serialize over IPC, with ONE caveat: desc.dma_buf_fd
+ * is an integer valid only in THIS (exporter) process — it aliases @p frame's fd.
+ * Transfer the fd itself out of band (SCM_RIGHTS); on the receiving side the
+ * converter must OVERWRITE desc.dma_buf_fd with the fd number it received before
+ * calling drmtap_convert_dmabuf(), and owns/closes that received fd. Fails with
+ * -ENOTSUP if the capture path produced pixels but no transferable dma-buf.
  *
  * @param ctx   Capture context (a real KMS context from drmtap_open)
- * @param desc  Output descriptor (value type; ship over IPC)
+ * @param desc  Output descriptor (value type; ship over IPC, fixing up the fd)
  * @param frame Output frame — owns the dma_buf_fd; release when done
  * @return 0 on success, negative errno on error
  */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 9
+#define DRMTAP_VERSION_PATCH 10
 
 /**
  * @brief Get the library version as a packed integer.
@@ -233,11 +233,13 @@ void drmtap_frame_release(drmtap_ctx *ctx, drmtap_frame_info *frame);
 /**
  * @brief Descriptor of an externally-supplied scanout DMA-BUF.
  *
- * Filled by the caller from what the privileged exporter produced
- * (drmtap_grab() frame metadata plus the connector HDR state) and shipped
- * over IPC. num_planes/offsets/pitches carry the auxiliary planes of
- * compressed layouts (e.g. Intel CCS: main surface + CCS aux + clear-color);
- * all planes live inside the one dma_buf_fd, as DRM GetFB2 reports them.
+ * On the privileged exporter side use drmtap_grab_desc() to fill it in one
+ * call; ship it (plus the dma_buf_fd) over IPC to the unprivileged converter.
+ * num_planes/offsets/pitches carry the auxiliary planes of compressed layouts
+ * (e.g. Intel CCS: main surface + CCS aux + clear-color) — these are NOT
+ * present in drmtap_frame_info, so a split consumer must use drmtap_grab_desc
+ * (not drmtap_grab alone) to capture a CCS or HDR scanout losslessly. All
+ * planes live inside the one dma_buf_fd, as DRM GetFB2 reports them.
  */
 typedef struct {
     int dma_buf_fd;         /**< Scanout DMA-BUF. May be -1 for an fb_id this
@@ -259,6 +261,30 @@ typedef struct {
     uint32_t hdr_max_nits;  /**< Mastering/content peak luminance (cd/m2),
                                  0 = unknown */
 } drmtap_dmabuf_desc;
+
+/**
+ * @brief Capture a frame AND emit a complete DMA-BUF descriptor for the split.
+ *
+ * The privileged-exporter counterpart to drmtap_convert_dmabuf(): does a
+ * zero-copy grab and fills @p desc with everything the unprivileged converter
+ * needs — the dma_buf_fd, geometry, format/modifier, fb_id, the full plane
+ * layout (num_planes/offsets/pitches, incl. Intel CCS aux planes) and the
+ * connector HDR state (eotf/max_nits). drmtap_grab() alone cannot produce
+ * these last two — drmtap_frame_info has no plane array or HDR fields — so a
+ * split consumer that must handle compressed (CCS) or HDR scanouts has to use
+ * this entry point.
+ *
+ * @p frame is also populated (same as drmtap_grab) and OWNS the resources:
+ * release it with drmtap_frame_release() once the fd has been sent. @p desc is
+ * a plain value snapshot (safe to serialize over IPC); it borrows nothing.
+ *
+ * @param ctx   Capture context (a real KMS context from drmtap_open)
+ * @param desc  Output descriptor (value type; ship over IPC)
+ * @param frame Output frame — owns the dma_buf_fd; release when done
+ * @return 0 on success, negative errno on error
+ */
+int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
+                     drmtap_frame_info *frame);
 
 /**
  * @brief Open an UNPRIVILEGED, render-only context for drmtap_convert_dmabuf().

--- a/bindings/rust/libdrmtap-sys/src/lib.rs
+++ b/bindings/rust/libdrmtap-sys/src/lib.rs
@@ -110,6 +110,11 @@ extern "C" {
 
     // Split capture (privileged export + unprivileged convert)
     pub fn drmtap_open_render(render_node: *const c_char) -> *mut drmtap_ctx;
+    pub fn drmtap_grab_desc(
+        ctx: *mut drmtap_ctx,
+        desc: *mut drmtap_dmabuf_desc,
+        frame: *mut drmtap_frame_info,
+    ) -> c_int;
     pub fn drmtap_convert_dmabuf(
         ctx: *mut drmtap_ctx,
         desc: *const drmtap_dmabuf_desc,

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.9", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.4.10", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/bindings/rust/libdrmtap/README.md
+++ b/bindings/rust/libdrmtap/README.md
@@ -25,7 +25,7 @@ reports HDR (`P010` overlay-video and HLG excepted).
 libdrmtap = "0.3"
 ```
 
-This pulls in `libdrmtap-sys` 0.4.9, which embeds and statically compiles the C
+This pulls in `libdrmtap-sys` 0.4.10, which embeds and statically compiles the C
 sources (and the privilege helper) — no system `libdrmtap` install needed.
 
 ## Example

--- a/contrib/integrations/rustdesk/README.md
+++ b/contrib/integrations/rustdesk/README.md
@@ -7,7 +7,7 @@ crate.
 > The upstream integration PR
 > [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420)
 > is **under maintainer review** (in progress — not yet merged). It adds a `drm`
-> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.9. The files here are a
+> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.10. The files here are a
 > self-contained reference for the same crate-based backend.
 
 ## Status
@@ -42,7 +42,7 @@ capture. This means:
 1. Add the crate to `libs/scrap/Cargo.toml`:
 
    ```toml
-   libdrmtap-sys = { version = "0.4.9", optional = true }
+   libdrmtap-sys = { version = "0.4.10", optional = true }
    ```
 
    It embeds and statically compiles the C sources **and** builds the

--- a/contrib/integrations/rustdesk/drm/mod.rs
+++ b/contrib/integrations/rustdesk/drm/mod.rs
@@ -13,7 +13,7 @@
 // Integration (tested on Ubuntu 24.04; uses the static libdrmtap-sys crate):
 //
 //   1. Add the crate to libs/scrap/Cargo.toml:
-//        libdrmtap-sys = { version = "0.4.9", optional = true }
+//        libdrmtap-sys = { version = "0.4.10", optional = true }
 //      It statically embeds and compiles the C sources and builds the
 //      drmtap-helper binary — no system libdrmtap install, no meson install,
 //      no apt package, and no rustc-link-search.

--- a/contrib/integrations/rustdesk/drm/recorder.rs
+++ b/contrib/integrations/rustdesk/drm/recorder.rs
@@ -9,7 +9,7 @@
 // captured 1920x1017 @ BGRA, 7,810,560 bytes — pixel-perfect.
 //
 // To use in RustDesk:
-//   Add `libdrmtap-sys = { version = "0.4.9", optional = true }` to
+//   Add `libdrmtap-sys = { version = "0.4.10", optional = true }` to
 //   libs/scrap/Cargo.toml, place this file at libs/scrap/src/common/drm.rs,
 //   and see mod.rs in this directory for the wiring. The canonical, current
 //   backend is in the upstream PR rustdesk/rustdesk#15420.

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -450,7 +450,7 @@ Three layers, published on crates.io:
 └─────────────────────────────────────────────────┘
 ```
 
-> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.9,
+> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.10,
 > libdrmtap 0.3.4) and verified to build/test in CI on Ubuntu 22.04/24.04.
 > Capture is verified on Intel i915/xe (dual-4K Meteor Lake), Nvidia/Tegra
 > (Jetson Orin Nano, aarch64), virtio-gpu, and AMD amdgpu (RX Vega 64, gfx9,
@@ -514,8 +514,8 @@ Adding `libdrmtap-sys` is standard practice for them. They `cargo add libdrmtap`
 
 | Area | What shipped | Status |
 |---|---|---|
-| Core | `libdrmtap` C library 0.4.9 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
-| Rust | `libdrmtap-sys` 0.4.9 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
+| Core | `libdrmtap` C library 0.4.10 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
+| Rust | `libdrmtap-sys` 0.4.10 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
 | Rust | `libdrmtap` 0.3.4 (safe wrapper) | ✅ Published on crates.io |
 | GPU | EGL/GLES2 GPU-universal detiling backend | ✅ Implemented |
 | HW | Intel i915/xe + Nvidia/Tegra + virtio-gpu + AMD amdgpu validation | ✅ Verified (AMD on RX Vega 64, gfx9) |

--- a/docs/research/07_potential_adopters.md
+++ b/docs/research/07_potential_adopters.md
@@ -16,7 +16,7 @@
 
 ### Integration path for each:
 
-**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.9 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
+**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.10 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
 
 **Sunshine**: Replace internal KMS code with `#include <drmtap.h>`. They already use DMA-BUF → VAAPI pipeline, so `drmtap_grab()` (zero-copy) slots in directly.
 

--- a/examples/split_capture.c
+++ b/examples/split_capture.c
@@ -1,0 +1,271 @@
+/*
+ * libdrmtap — DRM/KMS screen capture library for Linux
+ * https://github.com/fxd0h/libdrmtap
+ *
+ * Copyright (c) 2026 Mariano Abad <weimaraner@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file split_capture.c
+ * @brief End-to-end reference for the split-capture model.
+ *
+ * Mirrors the privilege split the RustDesk integration uses: the EXPORTER
+ * (here, the parent — in production the root `--service`) does a zero-copy
+ * grab and ships the DMA-BUF fd + a value descriptor over a unix socket via
+ * SCM_RIGHTS; the CONVERTER (the child — in production the unprivileged
+ * `--server`) imports the fd on a render node and detiles it to linear RGBA.
+ * Neither the GPU stack nor a KMS master ever loads into the exporter.
+ *
+ * This exercises the real cross-process path: drmtap_grab_desc() (which,
+ * unlike drmtap_grab(), captures the CCS aux planes + HDR state a compressed
+ * scanout needs) -> SCM_RIGHTS -> drmtap_open_render() + drmtap_convert_dmabuf().
+ *
+ * Run it on a box with an active scanout. It SKIPs cleanly (exit 0) when no
+ * capture device / render node is present.
+ *
+ *   build/split_capture            # auto-detect
+ *   DRM_DEVICE=/dev/dri/card1 build/split_capture
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/wait.h>
+
+#include "drmtap.h"
+
+/* Result the converter reports back to the exporter. */
+typedef struct {
+    int      ok;
+    uint32_t width, height, stride, format;
+    uint64_t nonblack;   /* count of non-black (non-zero RGB) pixels */
+    uint64_t checksum;   /* cheap content hash so a frozen/garbage frame shows */
+} conv_result_t;
+
+/* Send `len` bytes of `data` over `sock`, attaching `fd` via SCM_RIGHTS only
+ * when fd >= 0 (passing -1 in an SCM_RIGHTS cmsg is invalid and fails the
+ * whole sendmsg — the result messages carry no fd). */
+static int send_desc_fd(int sock, const void *data, size_t len, int fd) {
+    struct iovec iov = { .iov_base = (void *)data, .iov_len = len };
+    char cbuf[CMSG_SPACE(sizeof(int))];
+    struct msghdr msg = {0};
+    memset(cbuf, 0, sizeof(cbuf));
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    if (fd >= 0) {
+        msg.msg_control = cbuf;
+        msg.msg_controllen = sizeof(cbuf);
+        struct cmsghdr *cm = CMSG_FIRSTHDR(&msg);
+        cm->cmsg_level = SOL_SOCKET;
+        cm->cmsg_type = SCM_RIGHTS;
+        cm->cmsg_len = CMSG_LEN(sizeof(int));
+        memcpy(CMSG_DATA(cm), &fd, sizeof(int));
+    }
+    return sendmsg(sock, &msg, 0) < 0 ? -1 : 0;
+}
+
+/* Receive `len` bytes into `data` plus one fd via SCM_RIGHTS (*fd_out = -1 if
+ * none arrived). */
+static int recv_desc_fd(int sock, void *data, size_t len, int *fd_out) {
+    struct iovec iov = { .iov_base = data, .iov_len = len };
+    char cbuf[CMSG_SPACE(sizeof(int))];
+    struct msghdr msg = {0};
+    memset(cbuf, 0, sizeof(cbuf));
+    msg.msg_iov = &iov;
+    msg.msg_iovlen = 1;
+    msg.msg_control = cbuf;
+    msg.msg_controllen = sizeof(cbuf);
+    ssize_t n = recvmsg(sock, &msg, 0);
+    if (n < 0) {
+        return -1;
+    }
+    *fd_out = -1;
+    for (struct cmsghdr *cm = CMSG_FIRSTHDR(&msg); cm; cm = CMSG_NXTHDR(&msg, cm)) {
+        if (cm->cmsg_level == SOL_SOCKET && cm->cmsg_type == SCM_RIGHTS) {
+            memcpy(fd_out, CMSG_DATA(cm), sizeof(int));
+        }
+    }
+    return (int)n;
+}
+
+/* ── CONVERTER (unprivileged child) ── */
+static int run_converter(int sock) {
+    fprintf(stderr, "converter: started, opening render node...\n");
+    fflush(stderr);
+    drmtap_ctx *ctx = drmtap_open_render(NULL);
+    if (!ctx) {
+        fprintf(stderr, "converter: drmtap_open_render failed: %s\n",
+                drmtap_error(NULL) ? drmtap_error(NULL) : "(no render node)");
+        /* Tell the exporter we could not set up; it will treat it as SKIP. */
+        conv_result_t r = { .ok = -1 };
+        send_desc_fd(sock, &r, sizeof(r), -1);
+        return 0;
+    }
+
+    drmtap_dmabuf_desc desc;
+    int fd = -1;
+    if (recv_desc_fd(sock, &desc, sizeof(desc), &fd) != (int)sizeof(desc)) {
+        fprintf(stderr, "converter: short descriptor read\n");
+        drmtap_close(ctx);
+        return 1;
+    }
+    desc.dma_buf_fd = fd;  /* the meaningful fd is the one we just received */
+
+    conv_result_t r;
+    memset(&r, 0, sizeof(r));
+    drmtap_frame_info frame;
+    int cret = drmtap_convert_dmabuf(ctx, &desc, &frame);
+    if (cret == 0 && frame.data) {
+        r.ok = 1;
+        r.width = frame.width;
+        r.height = frame.height;
+        r.stride = frame.stride;
+        r.format = frame.format;
+        const uint8_t *p = frame.data;
+        for (uint32_t y = 0; y < frame.height; y++) {
+            const uint8_t *row = p + (size_t)y * frame.stride;
+            for (uint32_t x = 0; x < frame.width; x++) {
+                const uint8_t *px = row + (size_t)x * 4;
+                if (px[0] | px[1] | px[2]) {
+                    r.nonblack++;
+                }
+                r.checksum += (uint64_t)px[0] + px[1] * 3u + px[2] * 7u;
+            }
+        }
+    } else {
+        r.ok = 0;
+        fprintf(stderr, "converter: drmtap_convert_dmabuf failed (%d): %s\n",
+                cret, drmtap_error(ctx) ? drmtap_error(ctx) : "");
+    }
+
+    if (fd >= 0) {
+        close(fd);
+    }
+    drmtap_close(ctx);
+    send_desc_fd(sock, &r, sizeof(r), -1);
+    return 0;
+}
+
+/* ── EXPORTER (parent) ── */
+static int run_exporter(int sock, pid_t child) {
+    drmtap_ctx *ctx = drmtap_open(NULL);
+    if (!ctx) {
+        printf("  SKIP: no capture device (%s)\n",
+               drmtap_error(NULL) ? drmtap_error(NULL) : "drmtap_open failed");
+        close(sock);
+        waitpid(child, NULL, 0);
+        return 0;  /* SKIP */
+    }
+    printf("  exporter: %s driver=%s\n",
+           drmtap_gpu_driver(ctx) ? "opened" : "opened",
+           drmtap_gpu_driver(ctx) ? drmtap_gpu_driver(ctx) : "?");
+
+    drmtap_dmabuf_desc desc;
+    drmtap_frame_info frame;
+    int gret = drmtap_grab_desc(ctx, &desc, &frame);
+    if (gret != 0) {
+        printf("  SKIP: grab_desc failed (%d): %s\n", gret,
+               drmtap_error(ctx) ? drmtap_error(ctx) : "");
+        drmtap_close(ctx);
+        close(sock);
+        waitpid(child, NULL, 0);
+        return 0;  /* SKIP — e.g. no active scanout in CI */
+    }
+
+    printf("  exporter: grabbed %ux%u fourcc=%.4s modifier=0x%llx "
+           "num_planes=%u fb_id=%u hdr_eotf=%u fd=%d\n",
+           desc.width, desc.height, (const char *)&desc.format,
+           (unsigned long long)desc.modifier, desc.num_planes, desc.fb_id,
+           desc.hdr_eotf, desc.dma_buf_fd);
+    for (uint32_t p = 0; p < desc.num_planes; p++) {
+        printf("           plane[%u]: offset=%u pitch=%u\n",
+               p, desc.offsets[p], desc.pitches[p]);
+    }
+    int is_compressed = (desc.num_planes > 1);
+    printf("  exporter: %s scanout -> shipping fd + descriptor over SCM_RIGHTS\n",
+           is_compressed ? "COMPRESSED (CCS multi-plane)" : "single-plane");
+
+    int failures = 0;
+    if (desc.dma_buf_fd < 0) {
+        printf("  NOTE: exporter grab returned no dma_buf_fd (helper path did "
+               "not pass one) — cannot exercise the fd round-trip here\n");
+    } else if (send_desc_fd(sock, &desc, sizeof(desc), desc.dma_buf_fd) != 0) {
+        printf("  FAIL: send_desc_fd\n");
+        failures++;
+    } else {
+        conv_result_t r;
+        int dummy = -1;
+        if (recv_desc_fd(sock, &r, sizeof(r), &dummy) != (int)sizeof(r)) {
+            printf("  FAIL: no result from converter\n");
+            failures++;
+        } else if (r.ok < 0) {
+            printf("  SKIP: converter has no render node\n");
+        } else if (r.ok == 1) {
+            printf("  converter: OK -> %ux%u stride=%u fourcc=%.4s "
+                   "nonblack=%llu/%llu checksum=%llu\n",
+                   r.width, r.height, r.stride, (const char *)&r.format,
+                   (unsigned long long)r.nonblack,
+                   (unsigned long long)((uint64_t)r.width * r.height),
+                   (unsigned long long)r.checksum);
+            /* The whole point: a real cross-process CCS/linear scanout detiled
+             * to non-black linear RGBA proves the split API round-trips. */
+            if (r.nonblack == 0) {
+                printf("  FAIL: converted frame is all black "
+                       "(detile/round-trip broken)\n");
+                failures++;
+            } else {
+                printf("  PASS: cross-process %s round-trip produced a real "
+                       "linear frame\n",
+                       is_compressed ? "CCS" : "linear");
+            }
+        } else {
+            printf("  FAIL: converter could not convert the shipped buffer\n");
+            failures++;
+        }
+    }
+
+    drmtap_frame_release(ctx, &frame);
+    drmtap_close(ctx);
+    close(sock);
+    int wstatus = 0;
+    waitpid(child, &wstatus, 0);
+    if (WIFSIGNALED(wstatus)) {
+        printf("  DIAG: converter killed by signal %d\n", WTERMSIG(wstatus));
+    } else if (WIFEXITED(wstatus) && WEXITSTATUS(wstatus) != 0) {
+        printf("  DIAG: converter exited %d\n", WEXITSTATUS(wstatus));
+    }
+    return failures;
+}
+
+int main(void) {
+    printf("split_capture: privileged export + unprivileged convert round-trip\n");
+
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) {
+        perror("socketpair");
+        return 2;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 2;
+    }
+    if (pid == 0) {
+        close(sv[0]);
+        int rc = run_converter(sv[1]);
+        close(sv[1]);
+        _exit(rc);
+    }
+
+    close(sv[1]);
+    int failures = run_exporter(sv[0], pid);
+
+    printf("split_capture: %d failures\n", failures);
+    return failures ? 1 : 0;
+}

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -276,10 +276,15 @@ typedef struct {
  *
  * @p frame is also populated (same as drmtap_grab) and OWNS the resources:
  * release it with drmtap_frame_release() once the fd has been sent. @p desc is
- * a plain value snapshot (safe to serialize over IPC); it borrows nothing.
+ * a metadata snapshot safe to serialize over IPC, with ONE caveat: desc.dma_buf_fd
+ * is an integer valid only in THIS (exporter) process — it aliases @p frame's fd.
+ * Transfer the fd itself out of band (SCM_RIGHTS); on the receiving side the
+ * converter must OVERWRITE desc.dma_buf_fd with the fd number it received before
+ * calling drmtap_convert_dmabuf(), and owns/closes that received fd. Fails with
+ * -ENOTSUP if the capture path produced pixels but no transferable dma-buf.
  *
  * @param ctx   Capture context (a real KMS context from drmtap_open)
- * @param desc  Output descriptor (value type; ship over IPC)
+ * @param desc  Output descriptor (value type; ship over IPC, fixing up the fd)
  * @param frame Output frame — owns the dma_buf_fd; release when done
  * @return 0 on success, negative errno on error
  */

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 9
+#define DRMTAP_VERSION_PATCH 10
 
 /**
  * @brief Get the library version as a packed integer.
@@ -233,11 +233,13 @@ void drmtap_frame_release(drmtap_ctx *ctx, drmtap_frame_info *frame);
 /**
  * @brief Descriptor of an externally-supplied scanout DMA-BUF.
  *
- * Filled by the caller from what the privileged exporter produced
- * (drmtap_grab() frame metadata plus the connector HDR state) and shipped
- * over IPC. num_planes/offsets/pitches carry the auxiliary planes of
- * compressed layouts (e.g. Intel CCS: main surface + CCS aux + clear-color);
- * all planes live inside the one dma_buf_fd, as DRM GetFB2 reports them.
+ * On the privileged exporter side use drmtap_grab_desc() to fill it in one
+ * call; ship it (plus the dma_buf_fd) over IPC to the unprivileged converter.
+ * num_planes/offsets/pitches carry the auxiliary planes of compressed layouts
+ * (e.g. Intel CCS: main surface + CCS aux + clear-color) — these are NOT
+ * present in drmtap_frame_info, so a split consumer must use drmtap_grab_desc
+ * (not drmtap_grab alone) to capture a CCS or HDR scanout losslessly. All
+ * planes live inside the one dma_buf_fd, as DRM GetFB2 reports them.
  */
 typedef struct {
     int dma_buf_fd;         /**< Scanout DMA-BUF. May be -1 for an fb_id this
@@ -259,6 +261,30 @@ typedef struct {
     uint32_t hdr_max_nits;  /**< Mastering/content peak luminance (cd/m2),
                                  0 = unknown */
 } drmtap_dmabuf_desc;
+
+/**
+ * @brief Capture a frame AND emit a complete DMA-BUF descriptor for the split.
+ *
+ * The privileged-exporter counterpart to drmtap_convert_dmabuf(): does a
+ * zero-copy grab and fills @p desc with everything the unprivileged converter
+ * needs — the dma_buf_fd, geometry, format/modifier, fb_id, the full plane
+ * layout (num_planes/offsets/pitches, incl. Intel CCS aux planes) and the
+ * connector HDR state (eotf/max_nits). drmtap_grab() alone cannot produce
+ * these last two — drmtap_frame_info has no plane array or HDR fields — so a
+ * split consumer that must handle compressed (CCS) or HDR scanouts has to use
+ * this entry point.
+ *
+ * @p frame is also populated (same as drmtap_grab) and OWNS the resources:
+ * release it with drmtap_frame_release() once the fd has been sent. @p desc is
+ * a plain value snapshot (safe to serialize over IPC); it borrows nothing.
+ *
+ * @param ctx   Capture context (a real KMS context from drmtap_open)
+ * @param desc  Output descriptor (value type; ship over IPC)
+ * @param frame Output frame — owns the dma_buf_fd; release when done
+ * @return 0 on success, negative errno on error
+ */
+int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
+                     drmtap_frame_info *frame);
 
 /**
  * @brief Open an UNPRIVILEGED, render-only context for drmtap_convert_dmabuf().

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.9',
+    version: '0.4.10',
     license: 'MIT',
     default_options: [
         'c_std=c11',
@@ -322,6 +322,16 @@ executable('screenshot',
 
 executable('stream',
     'examples/stream.c',
+    dependencies: [libdrmtap_dep],
+    include_directories: lib_include,
+    install: false,
+)
+
+# Split-capture reference: privileged export + unprivileged convert across a
+# process boundary (fork + SCM_RIGHTS fd-pass). Exercises drmtap_grab_desc +
+# drmtap_open_render + drmtap_convert_dmabuf end to end.
+executable('split_capture',
+    'examples/split_capture.c',
     dependencies: [libdrmtap_dep],
     include_directories: lib_include,
     install: false,

--- a/patches/rustdesk/README.md
+++ b/patches/rustdesk/README.md
@@ -31,7 +31,7 @@ cargo build --release
 ## Based on
 
 - RustDesk v1.4.6
-- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.9"`
+- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.10"`
 
 ## Upstream status
 

--- a/patches/rustdesk/scrap_Cargo.toml
+++ b/patches/rustdesk/scrap_Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-libdrmtap-sys = { version = "0.4.9", optional = true }
+libdrmtap-sys = { version = "0.4.10", optional = true }
 webm = { git = "https://github.com/rustdesk-org/rust-webm" }
 serde = {version="1.0", features=["derive"]}
 

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -1038,6 +1038,46 @@ int drmtap_grab(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     return do_grab(ctx, frame, 0);  /* zero-copy: DMA-BUF fd only */
 }
 
+int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
+                     drmtap_frame_info *frame) {
+    if (!ctx || !desc || !frame) {
+        return -EINVAL;
+    }
+    int ret = do_grab(ctx, frame, 0);  /* zero-copy: DMA-BUF fd + metadata */
+    if (ret != 0) {
+        return ret;
+    }
+    /* Snapshot the full descriptor. The plane layout and HDR state are cached
+     * on ctx during do_grab (from GetFB2 and the connector metadata) — they are
+     * NOT in frame_info, which is exactly why a split exporter needs this call
+     * rather than drmtap_grab alone. */
+    memset(desc, 0, sizeof(*desc));
+    desc->dma_buf_fd = frame->dma_buf_fd;
+    desc->width = frame->width;
+    desc->height = frame->height;
+    desc->format = frame->format;
+    desc->modifier = frame->modifier;
+    desc->fb_id = frame->fb_id;
+
+    int np = ctx->fb2_num_planes > 0 ? ctx->fb2_num_planes : 1;
+    if (np > 4) {
+        np = 4;
+    }
+    desc->num_planes = (uint32_t)np;
+    for (int p = 0; p < 4; p++) {
+        desc->offsets[p] = ctx->fb2_offsets[p];
+        desc->pitches[p] = ctx->fb2_pitches[p];
+    }
+    /* Guarantee the main-surface stride is set even if GetFB2 left pitches[0]
+     * zero (helper/dumb paths): fall back to the frame stride. */
+    if (desc->pitches[0] == 0) {
+        desc->pitches[0] = frame->stride;
+    }
+    desc->hdr_eotf = ctx->cur_hdr_eotf;
+    desc->hdr_max_nits = ctx->cur_hdr_max_nits;
+    return 0;
+}
+
 int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     if (!ctx || !frame) {
         return -EINVAL;

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -1047,6 +1047,18 @@ int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
     if (ret != 0) {
         return ret;
     }
+    /* The split model ships the dma_buf_fd to another process, so a grab that
+     * produced pixels instead of a transferable fd (the helper V2 pixel
+     * fallback sets frame->dma_buf_fd = -1) yields a descriptor the receiver
+     * cannot convert — its fb_id is not valid across the process boundary
+     * either. Fail closed rather than hand back an untransferable descriptor. */
+    if (frame->dma_buf_fd < 0) {
+        drmtap_set_error(ctx,
+            "grab_desc needs a transferable DMA-BUF fd; this capture path "
+            "returned pixels only (no exportable dma-buf)");
+        drmtap_frame_release(ctx, frame);
+        return -ENOTSUP;
+    }
     /* Snapshot the full descriptor. The plane layout and HDR state are cached
      * on ctx during do_grab (from GetFB2 and the connector metadata) — they are
      * NOT in frame_info, which is exactly why a split exporter needs this call

--- a/tests/test_convert.c
+++ b/tests/test_convert.c
@@ -66,6 +66,8 @@ static void test_null_args(void) {
     memset(&desc, 0, sizeof(desc));
     check(drmtap_convert_dmabuf(NULL, &desc, &frame) == -EINVAL,
           "NULL ctx rejected");
+    check(drmtap_grab_desc(NULL, &desc, &frame) == -EINVAL,
+          "grab_desc NULL ctx rejected");
 }
 
 static void test_desc_validation(drmtap_ctx *ctx) {
@@ -170,10 +172,13 @@ static void test_grab_guard(drmtap_ctx *ctx, int render_only) {
         return;
     }
     drmtap_frame_info frame;
+    drmtap_dmabuf_desc desc;
     check(drmtap_grab(ctx, &frame) == -ENOTSUP,
           "grab rejected on render-only context");
     check(drmtap_grab_mapped_fast(ctx, &frame) == -ENOTSUP,
           "fast grab rejected on render-only context");
+    check(drmtap_grab_desc(ctx, &desc, &frame) == -ENOTSUP,
+          "grab_desc rejected on render-only context");
 }
 
 static void test_linear_xrgb8888(drmtap_ctx *ctx) {


### PR DESCRIPTION
follow-up to the 0.4.9 split. building an end-to-end round-trip reference against the 0.4.9 API surfaced one real gap: the privileged exporter had no public way to produce a COMPLETE descriptor for a compressed (CCS) or HDR scanout.

## the gap
`drmtap_grab` returns `drmtap_frame_info`, which carries a single stride and no HDR fields. but `drmtap_convert_dmabuf` needs the full plane layout (`num_planes`/`offsets`/`pitches` — the Intel CCS aux + clear-color planes) and the connector HDR state (`hdr_eotf`/`hdr_max_nits`). there was no public accessor for either, so a split consumer could capture only linear SDR losslessly — on Intel CCS (the primary target) the exporter could not hand the converter what it needs to detile.

## what changed
1- new public `drmtap_grab_desc(ctx, desc, frame)` — the exporter-side counterpart to `drmtap_convert_dmabuf`. does a zero-copy grab and fills the whole descriptor. the plane/HDR info already lived on the ctx after a grab (from GetFB2 + the connector read); it just was not exposed. Rust FFI added.
2- `examples/split_capture.c` — end-to-end reference. exporter and converter run in SEPARATE processes; the dma-buf fd crosses the boundary via SCM_RIGHTS, exactly like the rustdesk `_drm` channel will. verified on a real i915 CCS scanout: `grab_desc` reports `num_planes=3`, ships the fd, and the render-node side detiles it to a full 1920x1080 linear frame (all 2073600 pixels non-black — a real image, not garbage).
3- `test_convert`: `grab_desc` NULL-arg + render-only guard assertions.

## verification
- fresh build clean (-Werror -Wpedantic), with and without EGL; readelf NEEDED still libdrm/libm/libc only.
- 6 unit suites pass; ASan/LSan clean including the split_capture round-trip.
- per-thread open/grab/close x60 leak-test: RSS flat (0 kB growth).
- version 0.4.10 coherent across all sites; csrc synced.

additive only — existing entry points are unchanged.