### PR TITLE
harden libdrmtap.so: export only the public ABI via a version script (0.4.11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 **Language:** C11  
 **License:** MIT  
 **Tests:** unit (no hardware) + integration via VKMS (Virtual KMS) or a real GPU  
-**Version:** C library `0.4.10` · Rust crates `libdrmtap-sys 0.4.10` / `libdrmtap 0.3.4`  
+**Version:** C library `0.4.11` · Rust crates `libdrmtap-sys 0.4.11` / `libdrmtap 0.3.4`  
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,86 +1,80 @@
 # Changelog
 
-All notable changes to libdrmtap are documented here. The format is based on
-[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
-[semantic versioning](https://semver.org/). The C library, the `libdrmtap-sys`
-crate and the meson project share one version line; the higher-level
-`libdrmtap` wrapper crate is versioned separately.
+Notable changes to libdrmtap. Loosely follows Keep a Changelog; the project uses
+semantic versioning. The C library, the `libdrmtap-sys` crate and the meson
+project share one version; the `libdrmtap` wrapper crate is versioned separately.
 
 ## [0.4.11] - 2026-07-20
 
-### Security / Hardening
-- Export only the public ABI from `libdrmtap.so`. A linker version script
-  (`libdrmtap.map`, an anonymous node so the public symbols stay unversioned)
-  keeps every internal cross-module symbol local — `drmtap_set_error`,
+### Hardening
+- `libdrmtap.so` now exports only the public API. A linker version script
+  (`libdrmtap.map`, anonymous node so the public symbols stay unversioned) keeps
+  every internal cross-module symbol local: `drmtap_set_error`,
   `drmtap_gpu_*_process`, `drmtap_helper_*`, `drmtap_ensure_buf`,
-  `drmtap_convert_rgb16`, etc. are no longer `dlsym`-able from the shared object
-  the privileged service loads. Only the documented public entry points are
-  exported.
+  `drmtap_convert_rgb16` and friends are no longer dlsym-able from the shared
+  object the privileged service loads.
 
 ### Changed
-- The library is now built as both a shared object (version-scripted, installed,
-  the artifact that gets dlopen'd) and a static archive (full symbol set). The
-  white-box unit tests link the static archive; examples link the public shared
-  library.
+- Built as both a shared object (version-scripted, installed, the one loaded via
+  dlopen) and a static archive (full symbol set). The white-box unit tests link
+  the static archive; examples link the public shared library.
 
 ## [0.4.10] - 2026-07-20
 
 ### Added
-- `drmtap_grab_desc()` — the privileged-exporter counterpart to
-  `drmtap_convert_dmabuf()`: does a zero-copy grab and fills a complete
-  `drmtap_dmabuf_desc` including the CCS auxiliary planes
-  (num_planes/offsets/pitches) and the connector HDR state (eotf/max_nits),
-  which `drmtap_grab()` + `drmtap_frame_info` alone could not produce. Required
-  to hand a compressed (Intel CCS) or HDR scanout across a process boundary
-  losslessly.
-- `examples/split_capture.c` — an end-to-end split-capture reference: exporter
-  and converter run in separate processes with the DMA-BUF fd passed over
-  SCM_RIGHTS. Verified on a real Intel i915 CCS scanout.
+- `drmtap_grab_desc()`: the exporter-side counterpart to
+  `drmtap_convert_dmabuf()`. Does a zero-copy grab and fills a complete
+  `drmtap_dmabuf_desc`, including the CCS auxiliary planes
+  (num_planes/offsets/pitches) and the connector HDR state (eotf/max_nits) that
+  `drmtap_grab()` and `drmtap_frame_info` do not carry. Needed to ship a
+  compressed (Intel CCS) or HDR scanout across a process boundary without loss.
+- `examples/split_capture.c`: end-to-end split-capture reference. Exporter and
+  converter run in separate processes, the DMA-BUF fd is passed over SCM_RIGHTS.
+  Verified on a real Intel i915 CCS scanout.
 
 ### Fixed
-- `drmtap_grab_desc()` returns `-ENOTSUP` when the capture path produced pixels
-  but no transferable DMA-BUF (helper V2 pixel fallback), instead of handing
-  back a descriptor the receiving process cannot convert.
+- `drmtap_grab_desc()` returns `-ENOTSUP` when the capture path yielded pixels
+  but no transferable DMA-BUF (helper V2 fallback), instead of returning a
+  descriptor the receiving process cannot convert.
 
 ## [0.4.9] - 2026-07-20
 
 ### Added
-- Split-capture API for a privileged-export / unprivileged-convert boundary:
-  `drmtap_open_render()` (a render-node-only context, no KMS master or helper)
-  and `drmtap_convert_dmabuf()` (detile/convert an exporter-supplied DMA-BUF to
-  linear RGBA), with the `drmtap_dmabuf_desc` descriptor.
+- Split-capture API for a privileged-export, unprivileged-convert boundary:
+  `drmtap_open_render()` (render-node-only context, no KMS master or helper) and
+  `drmtap_convert_dmabuf()` (detile and convert an exporter-supplied DMA-BUF to
+  linear RGBA), plus the `drmtap_dmabuf_desc` descriptor.
 
 ### Changed
-- libEGL/libGLESv2 are `dlopen`'d lazily on first conversion instead of being
-  linked, so a process that only grabs never maps the GPU userspace stack. They
-  no longer appear in the `.so` DT_NEEDED nor in the pkg-config
+- libEGL and libGLESv2 are loaded lazily with dlopen on first conversion instead
+  of being linked, so a process that only grabs never maps the GPU userspace
+  stack. They no longer appear in the `.so` DT_NEEDED or the pkg-config
   `Requires.private`.
-- The imported EGLImage is cached per KMS `fb_id` plus the DMA-BUF inode
-  identity (import-once); steady-state conversion performs no per-frame
-  allocation.
+- The imported EGLImage is cached per KMS `fb_id` plus DMA-BUF inode identity
+  (import once); steady-state conversion does no per-frame allocation.
 
 ### Fixed
 - Fast-grab cache-hit paths restage the plane layout, so a CCS import never runs
   with stale plane metadata.
 - `drmtap_convert_dmabuf()` validates the untrusted descriptor and rejects a
-  stride narrower than `width * bytes-per-pixel`, preventing an out-of-bounds
+  stride narrower than `width * bytes-per-pixel`, closing an out-of-bounds
   read/write on the convert boundary.
 
 ## [0.4.8] - 2026-07-15
 
 ### Fixed
-- The per-thread EGL detile context was leaked on `drmtap_close()`, causing OOM
-  under a reconnect flap — it is now released on close and at thread exit.
-- Wrong-CRTC selection (a `crtc_id == 0` / unbound connector was offered and
-  auto-selected the primary) — added an atomic CRTC_ID fallback and
-  inactive-output filtering.
+- The per-thread EGL detile context leaked on `drmtap_close()`, causing OOM under
+  a reconnect flap. It is now freed on close and at thread exit.
+- Wrong-CRTC selection: a `crtc_id == 0` / unbound connector was offered and
+  auto-selected the primary. Added an atomic CRTC_ID fallback and inactive-output
+  filtering.
 - Added a rapid-rebuild demotion guard.
 
 ## [0.4.7] - 2026-07-13
 
 ### Fixed
-- amdgpu EGL detile fix, privileged-helper hardening, and a batch of
-  full-audit fixes.
+- amdgpu EGL detile fix, privileged-helper hardening, and a batch of full-audit
+  fixes.
 
 [0.4.11]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.11
 [0.4.10]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to libdrmtap are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
+[semantic versioning](https://semver.org/). The C library, the `libdrmtap-sys`
+crate and the meson project share one version line; the higher-level
+`libdrmtap` wrapper crate is versioned separately.
+
+## [0.4.11] - 2026-07-20
+
+### Security / Hardening
+- Export only the public ABI from `libdrmtap.so`. A linker version script
+  (`libdrmtap.map`, an anonymous node so the public symbols stay unversioned)
+  keeps every internal cross-module symbol local — `drmtap_set_error`,
+  `drmtap_gpu_*_process`, `drmtap_helper_*`, `drmtap_ensure_buf`,
+  `drmtap_convert_rgb16`, etc. are no longer `dlsym`-able from the shared object
+  the privileged service loads. Only the documented public entry points are
+  exported.
+
+### Changed
+- The library is now built as both a shared object (version-scripted, installed,
+  the artifact that gets dlopen'd) and a static archive (full symbol set). The
+  white-box unit tests link the static archive; examples link the public shared
+  library.
+
+## [0.4.10] - 2026-07-20
+
+### Added
+- `drmtap_grab_desc()` — the privileged-exporter counterpart to
+  `drmtap_convert_dmabuf()`: does a zero-copy grab and fills a complete
+  `drmtap_dmabuf_desc` including the CCS auxiliary planes
+  (num_planes/offsets/pitches) and the connector HDR state (eotf/max_nits),
+  which `drmtap_grab()` + `drmtap_frame_info` alone could not produce. Required
+  to hand a compressed (Intel CCS) or HDR scanout across a process boundary
+  losslessly.
+- `examples/split_capture.c` — an end-to-end split-capture reference: exporter
+  and converter run in separate processes with the DMA-BUF fd passed over
+  SCM_RIGHTS. Verified on a real Intel i915 CCS scanout.
+
+### Fixed
+- `drmtap_grab_desc()` returns `-ENOTSUP` when the capture path produced pixels
+  but no transferable DMA-BUF (helper V2 pixel fallback), instead of handing
+  back a descriptor the receiving process cannot convert.
+
+## [0.4.9] - 2026-07-20
+
+### Added
+- Split-capture API for a privileged-export / unprivileged-convert boundary:
+  `drmtap_open_render()` (a render-node-only context, no KMS master or helper)
+  and `drmtap_convert_dmabuf()` (detile/convert an exporter-supplied DMA-BUF to
+  linear RGBA), with the `drmtap_dmabuf_desc` descriptor.
+
+### Changed
+- libEGL/libGLESv2 are `dlopen`'d lazily on first conversion instead of being
+  linked, so a process that only grabs never maps the GPU userspace stack. They
+  no longer appear in the `.so` DT_NEEDED nor in the pkg-config
+  `Requires.private`.
+- The imported EGLImage is cached per KMS `fb_id` plus the DMA-BUF inode
+  identity (import-once); steady-state conversion performs no per-frame
+  allocation.
+
+### Fixed
+- Fast-grab cache-hit paths restage the plane layout, so a CCS import never runs
+  with stale plane metadata.
+- `drmtap_convert_dmabuf()` validates the untrusted descriptor and rejects a
+  stride narrower than `width * bytes-per-pixel`, preventing an out-of-bounds
+  read/write on the convert boundary.
+
+## [0.4.8] - 2026-07-15
+
+### Fixed
+- The per-thread EGL detile context was leaked on `drmtap_close()`, causing OOM
+  under a reconnect flap — it is now released on close and at thread exit.
+- Wrong-CRTC selection (a `crtc_id == 0` / unbound connector was offered and
+  auto-selected the primary) — added an atomic CRTC_ID fallback and
+  inactive-output filtering.
+- Added a rapid-rebuild demotion guard.
+
+## [0.4.7] - 2026-07-13
+
+### Fixed
+- amdgpu EGL detile fix, privileged-helper hardening, and a batch of
+  full-audit fixes.
+
+[0.4.11]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.11
+[0.4.10]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.10
+[0.4.9]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.9
+[0.4.8]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.8
+[0.4.7]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
   `drmtap_gpu_*_process`, `drmtap_helper_*`, `drmtap_ensure_buf`,
   `drmtap_convert_rgb16` and friends are no longer dlsym-able from the shared
   object the privileged service loads.
+- The shared object gets the same exploit mitigations as the privileged helper:
+  full RELRO (`-z relro -z now`), `_FORTIFY_SOURCE=2`, and an explicit
+  stack-protector.
+- `DRM_DEVICE` is honored only for an unprivileged process. A root capture
+  service now ignores it and uses the explicit config path or KMS
+  auto-detection, so an environment variable cannot redirect which device the
+  privileged process opens.
 
 ### Changed
 - Built as both a shared object (version-scripted, installed, the one loaded via

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ int main() {
 libdrmtap = "0.3"
 ```
 
-> This pulls in `libdrmtap-sys` 0.4.10, which embeds and statically compiles the
+> This pulls in `libdrmtap-sys` 0.4.11, which embeds and statically compiles the
 > C sources (and the privilege helper). No system `libdrmtap` install, no
 > `meson install`, no `pkg-config` to find a shared library.
 
@@ -195,7 +195,7 @@ sudo ./build/vnc_server
 libdrmtap is being upstreamed into [RustDesk](https://github.com/rustdesk/rustdesk)
 via [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420).
 The integration adds a `drm` backend to `scrap` that depends on the
-[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.10 crate, which
+[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.11 crate, which
 embeds and statically compiles the C sources (and the privilege helper) — so
 there is no system `libdrmtap` install and no dynamic `libdrmtap.so` linkage.
 

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.10"
+version = "0.4.11"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -68,8 +68,16 @@ void drmtap_debug_log(drmtap_ctx *ctx, const char *fmt, ...) {
 static int open_drm_auto(drmtap_ctx *ctx) {
     char path[64];
 
-    /* Check DRM_DEVICE env var first */
-    const char *env_dev = getenv("DRM_DEVICE");
+    /* Check DRM_DEVICE env var first, but ONLY when unprivileged. A privileged
+     * capture service (root / effective-root, e.g. the unattended --service)
+     * must not let an attacker-influenceable environment variable redirect which
+     * device it opens; it relies on the explicit config device_path or the KMS
+     * auto-scan below instead. DRM_DEVICE stays honored for unprivileged test /
+     * dev runs. */
+    const char *env_dev = NULL;
+    if (getuid() != 0 && geteuid() != 0) {
+        env_dev = getenv("DRM_DEVICE");
+    }
     if (env_dev) {
         drmtap_debug_log(ctx, "trying DRM_DEVICE=%s", env_dev);
         int fd = open(env_dev, O_RDWR | O_CLOEXEC);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 10
+#define DRMTAP_VERSION_PATCH 11
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.10", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.4.11", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/bindings/rust/libdrmtap/README.md
+++ b/bindings/rust/libdrmtap/README.md
@@ -25,7 +25,7 @@ reports HDR (`P010` overlay-video and HLG excepted).
 libdrmtap = "0.3"
 ```
 
-This pulls in `libdrmtap-sys` 0.4.10, which embeds and statically compiles the C
+This pulls in `libdrmtap-sys` 0.4.11, which embeds and statically compiles the C
 sources (and the privilege helper) — no system `libdrmtap` install needed.
 
 ## Example

--- a/contrib/integrations/rustdesk/README.md
+++ b/contrib/integrations/rustdesk/README.md
@@ -7,7 +7,7 @@ crate.
 > The upstream integration PR
 > [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420)
 > is **under maintainer review** (in progress — not yet merged). It adds a `drm`
-> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.10. The files here are a
+> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.11. The files here are a
 > self-contained reference for the same crate-based backend.
 
 ## Status
@@ -42,7 +42,7 @@ capture. This means:
 1. Add the crate to `libs/scrap/Cargo.toml`:
 
    ```toml
-   libdrmtap-sys = { version = "0.4.10", optional = true }
+   libdrmtap-sys = { version = "0.4.11", optional = true }
    ```
 
    It embeds and statically compiles the C sources **and** builds the

--- a/contrib/integrations/rustdesk/drm/mod.rs
+++ b/contrib/integrations/rustdesk/drm/mod.rs
@@ -13,7 +13,7 @@
 // Integration (tested on Ubuntu 24.04; uses the static libdrmtap-sys crate):
 //
 //   1. Add the crate to libs/scrap/Cargo.toml:
-//        libdrmtap-sys = { version = "0.4.10", optional = true }
+//        libdrmtap-sys = { version = "0.4.11", optional = true }
 //      It statically embeds and compiles the C sources and builds the
 //      drmtap-helper binary — no system libdrmtap install, no meson install,
 //      no apt package, and no rustc-link-search.

--- a/contrib/integrations/rustdesk/drm/recorder.rs
+++ b/contrib/integrations/rustdesk/drm/recorder.rs
@@ -9,7 +9,7 @@
 // captured 1920x1017 @ BGRA, 7,810,560 bytes — pixel-perfect.
 //
 // To use in RustDesk:
-//   Add `libdrmtap-sys = { version = "0.4.10", optional = true }` to
+//   Add `libdrmtap-sys = { version = "0.4.11", optional = true }` to
 //   libs/scrap/Cargo.toml, place this file at libs/scrap/src/common/drm.rs,
 //   and see mod.rs in this directory for the wiring. The canonical, current
 //   backend is in the upstream PR rustdesk/rustdesk#15420.

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -450,7 +450,7 @@ Three layers, published on crates.io:
 └─────────────────────────────────────────────────┘
 ```
 
-> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.10,
+> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.11,
 > libdrmtap 0.3.4) and verified to build/test in CI on Ubuntu 22.04/24.04.
 > Capture is verified on Intel i915/xe (dual-4K Meteor Lake), Nvidia/Tegra
 > (Jetson Orin Nano, aarch64), virtio-gpu, and AMD amdgpu (RX Vega 64, gfx9,
@@ -514,8 +514,8 @@ Adding `libdrmtap-sys` is standard practice for them. They `cargo add libdrmtap`
 
 | Area | What shipped | Status |
 |---|---|---|
-| Core | `libdrmtap` C library 0.4.10 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
-| Rust | `libdrmtap-sys` 0.4.10 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
+| Core | `libdrmtap` C library 0.4.11 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
+| Rust | `libdrmtap-sys` 0.4.11 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
 | Rust | `libdrmtap` 0.3.4 (safe wrapper) | ✅ Published on crates.io |
 | GPU | EGL/GLES2 GPU-universal detiling backend | ✅ Implemented |
 | HW | Intel i915/xe + Nvidia/Tegra + virtio-gpu + AMD amdgpu validation | ✅ Verified (AMD on RX Vega 64, gfx9) |

--- a/docs/research/07_potential_adopters.md
+++ b/docs/research/07_potential_adopters.md
@@ -16,7 +16,7 @@
 
 ### Integration path for each:
 
-**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.10 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
+**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.11 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
 
 **Sunshine**: Replace internal KMS code with `#include <drmtap.h>`. They already use DMA-BUF → VAAPI pipeline, so `drmtap_grab()` (zero-copy) slots in directly.
 

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 10
+#define DRMTAP_VERSION_PATCH 11
 
 /**
  * @brief Get the library version as a packed integer.

--- a/libdrmtap.map
+++ b/libdrmtap.map
@@ -5,7 +5,13 @@
 # attack/ABI surface of the .so that the privileged service dlopen()s — the
 # hardening item raised in review. A new public function MUST be added here or
 # a consumer link will fail (that link error is the intended drift alarm).
-LIBDRMTAP_0.4 {
+#
+# ANONYMOUS version node on purpose: it hides the internals WITHOUT introducing
+# symbol versioning, so the public symbols stay unversioned (drmtap_open, not
+# drmtap_open@@NODE) — byte-for-byte the same export names 0.4.10 and earlier
+# shipped. We are not committing to an ABI-versioning scheme, only trimming the
+# exported set.
+{
     global:
         drmtap_version;
         drmtap_open;

--- a/libdrmtap.map
+++ b/libdrmtap.map
@@ -1,0 +1,33 @@
+# Exported ABI for libdrmtap.so — the public entry points from include/drmtap.h
+# and NOTHING else. Every internal cross-module symbol (drmtap_set_error,
+# drmtap_gpu_*_process, drmtap_helper_*, drmtap_ensure_buf, ...) is made local,
+# so it cannot be resolved via dlsym from another module. This shrinks the
+# attack/ABI surface of the .so that the privileged service dlopen()s — the
+# hardening item raised in review. A new public function MUST be added here or
+# a consumer link will fail (that link error is the intended drift alarm).
+LIBDRMTAP_0.4 {
+    global:
+        drmtap_version;
+        drmtap_open;
+        drmtap_open_render;
+        drmtap_close;
+        drmtap_list_displays;
+        drmtap_displays_changed;
+        drmtap_grab;
+        drmtap_grab_mapped;
+        drmtap_grab_mapped_fast;
+        drmtap_grab_desc;
+        drmtap_convert_dmabuf;
+        drmtap_frame_release;
+        drmtap_get_cursor;
+        drmtap_cursor_release;
+        drmtap_error;
+        drmtap_gpu_driver;
+        drmtap_drm_fd;
+        drmtap_deswizzle;
+        drmtap_convert_format;
+        drmtap_tonemap_hdr10;
+        drmtap_diff_frames;
+    local:
+        *;
+};

--- a/meson.build
+++ b/meson.build
@@ -157,6 +157,22 @@ if cc.has_link_argument('-Wl,--version-script,' + version_script)
     libdrmtap_link_args += '-Wl,--version-script,' + version_script
 endif
 
+# Exploit-mitigation hardening for the shared object the privileged service
+# dlopen()s — the same set the helper binary gets. Full RELRO (-z relro -z now)
+# so the GOT is read-only after relocation, a stack canary, and _FORTIFY_SOURCE.
+# FORTIFY needs an optimized build (at -O0, and in 'plain' where meson adds no -O
+# at all, it only warns, and -Werror would then fail), so gate it on -O like the
+# helper does.
+libdrmtap_c_args = ['-fstack-protector-strong']
+if get_option('optimization') not in ['plain', '0']
+    libdrmtap_c_args += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=2']
+endif
+foreach _la : ['-Wl,-z,relro', '-Wl,-z,now']
+    if cc.has_link_argument(_la)
+        libdrmtap_link_args += _la
+    endif
+endforeach
+
 # Build BOTH a shared and a static library from one compile. The shared object
 # (the artifact the privileged service dlopen()s) is locked down to the public
 # ABI by the version script above. The static archive keeps every symbol so the
@@ -168,6 +184,7 @@ libdrmtap_both = both_libraries('drmtap',
     dependencies: lib_deps,
     version: meson.project_version(),
     soversion: '0',
+    c_args: libdrmtap_c_args,
     link_args: libdrmtap_link_args,
     link_depends: 'libdrmtap.map',
     install: true,

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.10',
+    version: '0.4.11',
     license: 'MIT',
     default_options: [
         'c_std=c11',
@@ -147,14 +147,32 @@ lib_sources += files('src/cursor.c')
 
 lib_include = include_directories('include', 'src')
 
-libdrmtap = library('drmtap',
+# Export ONLY the public API from the shared object (the one the privileged
+# service dlopen()s): a linker version script keeps every internal symbol
+# local. Guard on GNU-ld support so a toolchain without --version-script still
+# builds (it just exports the default symbol set there).
+version_script = meson.current_source_dir() / 'libdrmtap.map'
+libdrmtap_link_args = []
+if cc.has_link_argument('-Wl,--version-script,' + version_script)
+    libdrmtap_link_args += '-Wl,--version-script,' + version_script
+endif
+
+# Build BOTH a shared and a static library from one compile. The shared object
+# (the artifact the privileged service dlopen()s) is locked down to the public
+# ABI by the version script above. The static archive keeps every symbol so the
+# white-box unit tests can reach internal helpers (e.g. drmtap_convert_rgb16);
+# the version script does not apply to an `ar` archive.
+libdrmtap_both = both_libraries('drmtap',
     lib_sources,
     include_directories: lib_include,
     dependencies: lib_deps,
     version: meson.project_version(),
     soversion: '0',
+    link_args: libdrmtap_link_args,
+    link_depends: 'libdrmtap.map',
     install: true,
 )
+libdrmtap = libdrmtap_both.get_shared_lib()
 
 # Install the public header
 install_headers('include/drmtap.h')
@@ -167,9 +185,17 @@ pkg.generate(libdrmtap,
     url: 'https://github.com/fxd0h/libdrmtap',
 )
 
-# Declare dependency for subproject use
+# Public dependency (shared, version-scripted): examples/subprojects link this
+# and can only reach the public API.
 libdrmtap_dep = declare_dependency(
     link_with: libdrmtap,
+    include_directories: lib_include,
+)
+
+# Test-only dependency (static, full symbols): unit tests white-box internal
+# helpers not part of the public ABI.
+libdrmtap_test_dep = declare_dependency(
+    link_with: libdrmtap_both.get_static_lib(),
     include_directories: lib_include,
 )
 
@@ -238,41 +264,43 @@ endif # build_helper
 # Tests
 # ============================================================================
 
+# Unit/integration tests link the STATIC lib (libdrmtap_test_dep) so they can
+# white-box internal helpers the version-scripted .so no longer exports.
 test_enumerate = executable('test_enumerate',
     'tests/test_enumerate.c',
-    dependencies: [libdrmtap_dep, libdrm_dep],
+    dependencies: [libdrmtap_test_dep, libdrm_dep],
     include_directories: lib_include,
 )
 
 test_capture = executable('test_capture',
     'tests/test_capture.c',
-    dependencies: [libdrmtap_dep, libdrm_dep],
+    dependencies: [libdrmtap_test_dep, libdrm_dep],
     include_directories: lib_include,
 )
 
 test_formats = executable('test_formats',
     'tests/test_formats.c',
-    dependencies: [libdrmtap_dep],
+    dependencies: [libdrmtap_test_dep],
     include_directories: lib_include,
 )
 test_deswizzle = executable('test_deswizzle',
     'tests/test_deswizzle.c',
-    dependencies: [libdrmtap_dep],
+    dependencies: [libdrmtap_test_dep],
     include_directories: lib_include,
 )
 test_helper = executable('test_helper',
     'tests/test_helper.c',
-    dependencies: [libdrmtap_dep],
+    dependencies: [libdrmtap_test_dep],
     include_directories: lib_include,
 )
 test_hdr = executable('test_hdr',
     'tests/test_hdr.c',
-    dependencies: [libdrmtap_dep, m_dep],
+    dependencies: [libdrmtap_test_dep, m_dep],
     include_directories: lib_include,
 )
 test_convert = executable('test_convert',
     'tests/test_convert.c',
-    dependencies: [libdrmtap_dep],
+    dependencies: [libdrmtap_test_dep],
     include_directories: lib_include,
 )
 # Wire-protocol tests are self-contained (socketpair + fake peer, no DRM, no

--- a/patches/rustdesk/README.md
+++ b/patches/rustdesk/README.md
@@ -31,7 +31,7 @@ cargo build --release
 ## Based on
 
 - RustDesk v1.4.6
-- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.10"`
+- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.11"`
 
 ## Upstream status
 

--- a/patches/rustdesk/scrap_Cargo.toml
+++ b/patches/rustdesk/scrap_Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-libdrmtap-sys = { version = "0.4.10", optional = true }
+libdrmtap-sys = { version = "0.4.11", optional = true }
 webm = { git = "https://github.com/rustdesk-org/rust-webm" }
 serde = {version="1.0", features=["derive"]}
 

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -68,8 +68,16 @@ void drmtap_debug_log(drmtap_ctx *ctx, const char *fmt, ...) {
 static int open_drm_auto(drmtap_ctx *ctx) {
     char path[64];
 
-    /* Check DRM_DEVICE env var first */
-    const char *env_dev = getenv("DRM_DEVICE");
+    /* Check DRM_DEVICE env var first, but ONLY when unprivileged. A privileged
+     * capture service (root / effective-root, e.g. the unattended --service)
+     * must not let an attacker-influenceable environment variable redirect which
+     * device it opens; it relies on the explicit config device_path or the KMS
+     * auto-scan below instead. DRM_DEVICE stays honored for unprivileged test /
+     * dev runs. */
+    const char *env_dev = NULL;
+    if (getuid() != 0 && geteuid() != 0) {
+        env_dev = getenv("DRM_DEVICE");
+    }
     if (env_dev) {
         drmtap_debug_log(ctx, "trying DRM_DEVICE=%s", env_dev);
         int fd = open(env_dev, O_RDWR | O_CLOEXEC);


### PR DESCRIPTION
the shared object the privileged service dlopen()s was exporting every internal cross-module symbol (drmtap_set_error, drmtap_gpu_*_process, drmtap_helper_*, drmtap_ensure_buf, ...). this locks it down to the 21 public entry points with a linker version script — the symbol-visibility hardening raised in the libdrmtap risk review. nothing internal is dlsym-able from the root-loaded .so anymore.

## what changed
1- `libdrmtap.map` — a version script listing exactly the public API from include/drmtap.h; everything else is `local`. adding a public function without listing it fails a consumer link (intended drift alarm).
2- the library is built as `both_libraries`: the shared .so is version-scripted (hardened, installed, the artifact rustdesk dlopens); the static .a keeps all symbols so the white-box unit tests can still reach internal helpers (e.g. drmtap_convert_rgb16). tests link the static dep, examples link the public shared dep. guarded on `--version-script` support so a toolchain without it still builds.

## verification
- `nm -D` on the .so shows EXACTLY the 21 public symbols, zero internals (diffed against the map).
- builds clean with and without EGL, -Werror -Wpedantic; NEEDED still libdrm/libm/libc only.
- 6 unit suites pass (linking the static lib); the split_capture cross-process CCS round-trip and the per-thread-close leak-test are unchanged (0 kB growth).

no source/behaviour change — pure build/link hardening. the libdrmtap-sys crate (statically compiled into consumers) is unaffected; the version script is a .so-only concern.