### PR TITLE
helper: magic + version header on the command frame; document the convert boundary

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -104,9 +104,11 @@ The wire protocol is tiny: three commands (`CMD_GRAB`, `CMD_GET_CURSOR`,
 `CMD_QUIT`) in a fixed 16-byte command frame (`helper_cmd_grab_t` in
 `src/wire.h`). The frame carries a `magic` + protocol `version` + `type` +
 `length` header, and the helper rejects any frame whose magic, version or length
-do not match its own build and stops serving — so a stale helper or library
-binary fails closed rather than misparsing a frame while holding
-`CAP_SYS_ADMIN`. The only semantically attacker-controllable field is a
+do not match its own build, or whose type is not one of the three commands, and
+stops serving — so a stale helper or library binary fails closed rather than
+misparsing a frame while holding `CAP_SYS_ADMIN`. Every field of the frame
+originates from the peer and is validated before use (the magic/version/length/
+type gate above). The only attacker-controllable payload field is a
 `u32 crtc_id`, used purely as an equality filter against a plane's CRTC id — a
 bad value yields "no active framebuffer", not memory unsafety. The request path
 carries no path or fd field. Fd passing (`SCM_RIGHTS`) is one-directional,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -101,12 +101,17 @@ why).
 ### Request protocol / attack surface
 
 The wire protocol is tiny: three commands (`CMD_GRAB`, `CMD_GET_CURSOR`,
-`CMD_QUIT`) in a fixed 8-byte struct. The only attacker-controllable per-request
-field is a `u32 crtc_id`, used purely as an equality filter against a plane's
-CRTC id — a bad value yields "no active framebuffer", not memory unsafety. The
-request path carries no path or fd field. Fd passing (`SCM_RIGHTS`) is
-one-directional, **helper → main only** (the DMA-BUF export); the unprivileged
-side cannot hand the privileged side a path or fd to open.
+`CMD_QUIT`) in a fixed 16-byte command frame (`helper_cmd_grab_t` in
+`src/wire.h`). The frame carries a `magic` + protocol `version` + `type` +
+`length` header, and the helper rejects any frame whose magic, version or length
+do not match its own build and stops serving — so a stale helper or library
+binary fails closed rather than misparsing a frame while holding
+`CAP_SYS_ADMIN`. The only semantically attacker-controllable field is a
+`u32 crtc_id`, used purely as an equality filter against a plane's CRTC id — a
+bad value yields "no active framebuffer", not memory unsafety. The request path
+carries no path or fd field. Fd passing (`SCM_RIGHTS`) is one-directional,
+**helper → main only** (the DMA-BUF export); the unprivileged side cannot hand
+the privileged side a path or fd to open.
 
 Before any size computation, the helper validates the framebuffer geometry
 (`pitch`/`height`) reported by the kernel: it rejects a zero pitch/height and
@@ -114,6 +119,45 @@ caps `pitch * height` at one 8K BGRA frame (~126 MB). This guards against an
 integer-overflow of `size_t` and keeps the `u32 data_size` put on the wire from
 disagreeing with the payload actually sent, so a malformed scanout cannot drive
 an oversized allocation or a short write.
+
+---
+
+## The split-capture convert boundary
+
+The helper above is one trust boundary. The split-capture API is a second,
+independent one, for integrators that keep the GPU/EGL stack out of the
+privileged process entirely:
+
+- The **exporter** side (`drmtap_open` / `drmtap_grab_desc`) runs privileged and
+  does only the minimal DRM work: pick the active CRTC, get its scanout
+  framebuffer, export it as a DMA-BUF fd, and fill a `drmtap_dmabuf_desc`
+  (geometry, per-plane offsets/pitches, modifier, HDR state). No EGL, no GPU
+  driver on this side.
+- The **converter** side (`drmtap_open_render` / `drmtap_convert_dmabuf`) runs
+  unprivileged (a render node only, no KMS master, no helper), imports the
+  DMA-BUF, EGL-detiles it and converts to linear RGBA.
+- The DMA-BUF fd is passed to the converter over the integrator's IPC
+  (`SCM_RIGHTS`), together with the descriptor.
+
+Because the descriptor and fd arrive over a process boundary,
+**`drmtap_convert_dmabuf()` treats them as untrusted IPC input**, exactly like
+the helper treats a command frame. Before it maps or reads anything it:
+
+- rejects `num_planes > 4`, a zero/short stride (`pitches[0] < width * bpp`), and
+  a frame whose `stride * height` exceeds the same one-8K-frame cap
+  (`validate_fb_size`, ~126 MB) used on the privileged side;
+- requires the fd to be a **genuine DMA-BUF** — a non-dma-buf fd is rejected (an
+  immutable dma-buf cannot be truncated mid-read, so it is safe to `mmap` on the
+  CPU fallback path);
+- bounds the CPU read against the buffer size (via `lseek`, reliable across
+  kernels unlike `fstat`, which reports 0 for a dma-buf before Linux 5.3) and
+  **fails closed** (returns `-EINVAL`) when the size cannot be determined.
+
+A descriptor that claims a frame larger than its fd actually backs therefore
+returns `-EINVAL` instead of faulting the converter with `SIGBUS` (a
+denial-of-service on a malformed IPC message, fixed in 0.4.12 and covered by the
+`fuzz/fuzz_convert.c` libFuzzer target). The converter never trusts the
+descriptor's geometry against the real buffer.
 
 ---
 
@@ -159,6 +203,8 @@ Do not read the above as more locked down than it is:
 | Unprivileged side points the helper at an arbitrary device | Device path must canonicalize under `/dev/dri/`, and the node is opened `O_RDONLY` |
 | Unprivileged side makes the helper open an arbitrary path/fd | The request protocol carries no path/fd; fd passing is helper -> main only; `open`/`openat` are not on the seccomp allowlist after init |
 | Malformed scanout geometry drives an oversized allocation / overflow | Geometry guard rejects zero/absurd `pitch`/`height`, capping at one 8K BGRA frame |
+| Malformed convert descriptor faults the unprivileged converter (SIGBUS DoS) | `drmtap_convert_dmabuf` validates geometry, requires a genuine DMA-BUF, and bounds the read against the buffer size (`lseek`), failing closed on unknown size |
+| Stale helper/library binary misparses the command stream | The command frame carries a magic + protocol version; the helper rejects a mismatched frame and stops serving |
 | Helper gains new privileges via exec | `PR_SET_NO_NEW_PRIVS` |
 | Helper runs unconfined if hardening fails | Hard-fails: refuses to serve if cap-drop or seccomp cannot be established |
 | Third party intercepts frames or connects to the helper | Anonymous inherited socketpair, not discoverable, no listening socket |

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -108,18 +108,9 @@ struct drm_virtgpu_getparam {
 /* Socket fd inherited from parent (via socketpair) */
 #define HELPER_SOCKET_FD 3
 
-/* Protocol commands */
-#define CMD_GRAB 0x01
-#define CMD_GET_CURSOR 0x02
-#define CMD_QUIT 0xFF
-
-/* Command structure for CMD_GRAB (client to helper) */
-struct helper_cmd_grab {
-    uint8_t  cmd;           /* CMD_GRAB (0x01) */
-    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
-    uint8_t  _pad1[3];      /* align to 4 bytes */
-    uint32_t crtc_id;       /* target CRTC id (0 = auto-select first active) */
-};
+/* Protocol commands (CMD_*), the command frame (helper_cmd_grab_t) and its
+ * magic/version validation live in wire.h, shared with the library client so
+ * the two ends cannot drift. */
 
 /* Response status */
 #define RESP_OK    0x00
@@ -889,15 +880,23 @@ int main(int argc, char *argv[]) {
 
     /* Event loop: receive commands, process with persistent fd */
     while (1) {
-        struct helper_cmd_grab hcmd;
+        helper_cmd_grab_t hcmd;
         /* Read the whole fixed-size command frame. A clean disconnect (EOF at a
          * boundary) or a truncated/partial frame both end the loop; we never act
          * on a short read with an uninitialized crtc_id. */
         if (recv_all(sock, &hcmd, sizeof(hcmd)) != 0) {
             break;
         }
+        /* Reject a frame from a mismatched protocol (a stale helper or library
+         * binary): the magic/version/length must match this build. Once they
+         * differ the stream framing is unreliable, so fail closed and stop
+         * serving rather than misparse a frame while holding CAP_SYS_ADMIN. */
+        if (!wire_cmd_valid(&hcmd)) {
+            send_error(sock, "protocol version mismatch");
+            break;
+        }
 
-        switch (hcmd.cmd) {
+        switch (hcmd.type) {
             case CMD_GRAB:
                 grab_and_send(sock, drm_fd, hcmd.crtc_id, is_virtio);
                 break;

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -888,11 +888,14 @@ int main(int argc, char *argv[]) {
             break;
         }
         /* Reject a frame from a mismatched protocol (a stale helper or library
-         * binary): the magic/version/length must match this build. Once they
-         * differ the stream framing is unreliable, so fail closed and stop
-         * serving rather than misparse a frame while holding CAP_SYS_ADMIN. */
+         * binary) or an unknown command type: wire_cmd_valid gates the
+         * magic/version/length AND the type at one point, before dispatch. Close
+         * the connection WITHOUT a response: the framing is untrustworthy and we
+         * cannot know which reply schema the peer expects (grab vs cursor), so
+         * any error payload could be misparsed as valid data. A closed socket is
+         * an unambiguous failure every client path already handles. Fail closed
+         * rather than misparse a frame while holding CAP_SYS_ADMIN. */
         if (!wire_cmd_valid(&hcmd)) {
-            send_error(sock, "protocol version mismatch");
             break;
         }
 
@@ -909,8 +912,10 @@ int main(int argc, char *argv[]) {
                 goto done;
 
             default:
-                send_error(sock, "unknown command");
-                break;
+                /* Unreachable: wire_cmd_valid already restricted the type to the
+                 * three commands above. Close defensively rather than reply with
+                 * a schema the peer may not expect. */
+                goto done;
         }
     }
 

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -122,12 +122,9 @@ void drmtap_set_error(drmtap_ctx *ctx, const char *fmt, ...);
 // Debug log to stderr (only when ctx->debug is set)
 void drmtap_debug_log(drmtap_ctx *ctx, const char *fmt, ...);
 
-/* Command structure for CMD_GRAB (client to helper) */
-typedef struct {
-    uint8_t  cmd;           /* CMD_GRAB (0x01) */
-    uint8_t  _pad1[3];      /* align to 4 bytes */
-    uint32_t crtc_id;       /* target CRTC id (0 = auto-select first active) */
-} helper_cmd_grab_t;
+/* The command frame (helper_cmd_grab_t), its CMD_* types and the magic/version
+ * validation are defined in wire.h, shared with the helper so the two ends of
+ * the protocol cannot drift. The library client includes wire.h directly. */
 
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */

--- a/bindings/rust/libdrmtap-sys/csrc/privilege_helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/privilege_helper.c
@@ -40,9 +40,8 @@
 
 /* Must match values in drmtap-helper.c */
 #define HELPER_SOCKET_FD 3
-#define CMD_GRAB 0x01
-#define CMD_GET_CURSOR 0x02
-#define CMD_QUIT 0xFF
+/* CMD_GRAB / CMD_GET_CURSOR / CMD_QUIT and the command frame (helper_cmd_grab_t,
+ * built via wire_cmd()) come from wire.h, shared with the helper. */
 #define RESP_OK    0x00
 
 /* ========================================================================= */
@@ -174,7 +173,7 @@ void drmtap_helper_stop(drmtap_ctx *ctx) {
         /* Send a full-size quit command (best effort). The helper reads one whole
          * fixed-size command frame per iteration, so a 1-byte quit would be a
          * short read that the helper now rejects; send the complete struct. */
-        helper_cmd_grab_t hcmd = { .cmd = CMD_QUIT, .crtc_id = 0 };
+        helper_cmd_grab_t hcmd = wire_cmd(CMD_QUIT, 0);
         ssize_t n = send(ctx->helper_fd, &hcmd, sizeof(hcmd), MSG_NOSIGNAL);
         (void)n;
 
@@ -235,10 +234,7 @@ int drmtap_helper_grab(drmtap_ctx *ctx, helper_grab_result_t *result,
     }
 
     /* Send grab command */
-    helper_cmd_grab_t hcmd = {
-        .cmd = CMD_GRAB,
-        .crtc_id = ctx->crtc_id
-    };
+    helper_cmd_grab_t hcmd = wire_cmd(CMD_GRAB, ctx->crtc_id);
     ssize_t n = send(ctx->helper_fd, &hcmd, sizeof(hcmd), MSG_NOSIGNAL);
     if (n != sizeof(hcmd)) {
         drmtap_debug_log(ctx, "helper send failed, trying respawn");
@@ -337,10 +333,7 @@ int drmtap_helper_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
         }
     }
 
-    helper_cmd_grab_t hcmd = {
-        .cmd = CMD_GET_CURSOR,
-        .crtc_id = ctx->crtc_id,
-    };
+    helper_cmd_grab_t hcmd = wire_cmd(CMD_GET_CURSOR, ctx->crtc_id);
     ssize_t n = send(ctx->helper_fd, &hcmd, sizeof(hcmd), MSG_NOSIGNAL);
     if (n != sizeof(hcmd)) {
         drmtap_helper_stop(ctx);

--- a/bindings/rust/libdrmtap-sys/csrc/wire.h
+++ b/bindings/rust/libdrmtap-sys/csrc/wire.h
@@ -63,13 +63,16 @@ static inline helper_cmd_grab_t wire_cmd(uint16_t type, uint32_t crtc_id) {
     return c;
 }
 
-/* True only for a valid, version-matched command frame. A foreign magic, a
- * different protocol version, or a length that does not match this build's frame
- * all fail here so a stale helper/library binary is rejected, not misparsed. */
+/* True only for a valid, version-matched command frame carrying a known command
+ * type. A foreign magic, a different protocol version, a length that does not
+ * match this build's frame, or a type outside the declared CMD_* set all fail
+ * here, so a stale helper/library binary or a malformed command is rejected at
+ * one gate before dispatch, not misparsed. */
 static inline int wire_cmd_valid(const helper_cmd_grab_t *c) {
     return c->magic == HELPER_PROTO_MAGIC &&
            c->version == HELPER_PROTO_VERSION &&
-           c->length == (uint32_t)sizeof(helper_cmd_grab_t);
+           c->length == (uint32_t)sizeof(helper_cmd_grab_t) &&
+           (c->type == CMD_GRAB || c->type == CMD_GET_CURSOR || c->type == CMD_QUIT);
 }
 
 /* Send exactly len bytes, handling partial writes and EINTR. 0 ok, -1 error. */

--- a/bindings/rust/libdrmtap-sys/csrc/wire.h
+++ b/bindings/rust/libdrmtap-sys/csrc/wire.h
@@ -20,10 +20,57 @@
 #define DRMTAP_WIRE_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/socket.h>
+
+/* ---- Command framing (library -> helper) --------------------------------
+ * A command frame carries a magic + protocol version so a helper and a library
+ * built from different releases fail cleanly instead of misreading each other:
+ * the helper rejects any frame whose magic/version/length do not match its own
+ * build and stops serving, rather than acting on a misparsed frame. The channel
+ * is a host-local socketpair between two ends of the same machine, so the multi
+ * byte fields are native byte order (both ends share the host endianness); there
+ * is no cross-machine transport to byte-swap for. Defined here, once, so the
+ * helper, the library client and the tests cannot drift apart. */
+#define HELPER_PROTO_MAGIC   0x544D5244u  /* "DRMT" as a little-endian u32 */
+#define HELPER_PROTO_VERSION 1u
+
+/* Command types (the `type` field of a command frame). */
+#define CMD_GRAB       0x01u
+#define CMD_GET_CURSOR 0x02u
+#define CMD_QUIT       0xFFu
+
+typedef struct {
+    uint32_t magic;    /* HELPER_PROTO_MAGIC */
+    uint16_t version;  /* HELPER_PROTO_VERSION */
+    uint16_t type;     /* CMD_GRAB / CMD_GET_CURSOR / CMD_QUIT */
+    uint32_t length;   /* total frame length in bytes (== sizeof(helper_cmd_grab_t)) */
+    uint32_t crtc_id;  /* target CRTC id (0 = auto-select first active) */
+} helper_cmd_grab_t;   /* 16 bytes, naturally aligned, no padding */
+
+/* Build a command frame with the header fields set for this build. */
+static inline helper_cmd_grab_t wire_cmd(uint16_t type, uint32_t crtc_id) {
+    helper_cmd_grab_t c;
+    memset(&c, 0, sizeof(c));
+    c.magic = HELPER_PROTO_MAGIC;
+    c.version = HELPER_PROTO_VERSION;
+    c.type = type;
+    c.length = (uint32_t)sizeof(helper_cmd_grab_t);
+    c.crtc_id = crtc_id;
+    return c;
+}
+
+/* True only for a valid, version-matched command frame. A foreign magic, a
+ * different protocol version, or a length that does not match this build's frame
+ * all fail here so a stale helper/library binary is rejected, not misparsed. */
+static inline int wire_cmd_valid(const helper_cmd_grab_t *c) {
+    return c->magic == HELPER_PROTO_MAGIC &&
+           c->version == HELPER_PROTO_VERSION &&
+           c->length == (uint32_t)sizeof(helper_cmd_grab_t);
+}
 
 /* Send exactly len bytes, handling partial writes and EINTR. 0 ok, -1 error. */
 static inline int wire_send_all(int sock, const void *buf, size_t len) {

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -108,18 +108,9 @@ struct drm_virtgpu_getparam {
 /* Socket fd inherited from parent (via socketpair) */
 #define HELPER_SOCKET_FD 3
 
-/* Protocol commands */
-#define CMD_GRAB 0x01
-#define CMD_GET_CURSOR 0x02
-#define CMD_QUIT 0xFF
-
-/* Command structure for CMD_GRAB (client to helper) */
-struct helper_cmd_grab {
-    uint8_t  cmd;           /* CMD_GRAB (0x01) */
-    /* cppcheck-suppress unusedStructMember ; explicit wire-format padding */
-    uint8_t  _pad1[3];      /* align to 4 bytes */
-    uint32_t crtc_id;       /* target CRTC id (0 = auto-select first active) */
-};
+/* Protocol commands (CMD_*), the command frame (helper_cmd_grab_t) and its
+ * magic/version validation live in wire.h, shared with the library client so
+ * the two ends cannot drift. */
 
 /* Response status */
 #define RESP_OK    0x00
@@ -889,15 +880,23 @@ int main(int argc, char *argv[]) {
 
     /* Event loop: receive commands, process with persistent fd */
     while (1) {
-        struct helper_cmd_grab hcmd;
+        helper_cmd_grab_t hcmd;
         /* Read the whole fixed-size command frame. A clean disconnect (EOF at a
          * boundary) or a truncated/partial frame both end the loop; we never act
          * on a short read with an uninitialized crtc_id. */
         if (recv_all(sock, &hcmd, sizeof(hcmd)) != 0) {
             break;
         }
+        /* Reject a frame from a mismatched protocol (a stale helper or library
+         * binary): the magic/version/length must match this build. Once they
+         * differ the stream framing is unreliable, so fail closed and stop
+         * serving rather than misparse a frame while holding CAP_SYS_ADMIN. */
+        if (!wire_cmd_valid(&hcmd)) {
+            send_error(sock, "protocol version mismatch");
+            break;
+        }
 
-        switch (hcmd.cmd) {
+        switch (hcmd.type) {
             case CMD_GRAB:
                 grab_and_send(sock, drm_fd, hcmd.crtc_id, is_virtio);
                 break;

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -888,11 +888,14 @@ int main(int argc, char *argv[]) {
             break;
         }
         /* Reject a frame from a mismatched protocol (a stale helper or library
-         * binary): the magic/version/length must match this build. Once they
-         * differ the stream framing is unreliable, so fail closed and stop
-         * serving rather than misparse a frame while holding CAP_SYS_ADMIN. */
+         * binary) or an unknown command type: wire_cmd_valid gates the
+         * magic/version/length AND the type at one point, before dispatch. Close
+         * the connection WITHOUT a response: the framing is untrustworthy and we
+         * cannot know which reply schema the peer expects (grab vs cursor), so
+         * any error payload could be misparsed as valid data. A closed socket is
+         * an unambiguous failure every client path already handles. Fail closed
+         * rather than misparse a frame while holding CAP_SYS_ADMIN. */
         if (!wire_cmd_valid(&hcmd)) {
-            send_error(sock, "protocol version mismatch");
             break;
         }
 
@@ -909,8 +912,10 @@ int main(int argc, char *argv[]) {
                 goto done;
 
             default:
-                send_error(sock, "unknown command");
-                break;
+                /* Unreachable: wire_cmd_valid already restricted the type to the
+                 * three commands above. Close defensively rather than reply with
+                 * a schema the peer may not expect. */
+                goto done;
         }
     }
 

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -122,12 +122,9 @@ void drmtap_set_error(drmtap_ctx *ctx, const char *fmt, ...);
 // Debug log to stderr (only when ctx->debug is set)
 void drmtap_debug_log(drmtap_ctx *ctx, const char *fmt, ...);
 
-/* Command structure for CMD_GRAB (client to helper) */
-typedef struct {
-    uint8_t  cmd;           /* CMD_GRAB (0x01) */
-    uint8_t  _pad1[3];      /* align to 4 bytes */
-    uint32_t crtc_id;       /* target CRTC id (0 = auto-select first active) */
-} helper_cmd_grab_t;
+/* The command frame (helper_cmd_grab_t), its CMD_* types and the magic/version
+ * validation are defined in wire.h, shared with the helper so the two ends of
+ * the protocol cannot drift. The library client includes wire.h directly. */
 
 /* Result from helper v2 grab — helper reads pixels and sends via socket.
  * Must match struct grab_metadata in drmtap-helper.c */

--- a/src/privilege_helper.c
+++ b/src/privilege_helper.c
@@ -40,9 +40,8 @@
 
 /* Must match values in drmtap-helper.c */
 #define HELPER_SOCKET_FD 3
-#define CMD_GRAB 0x01
-#define CMD_GET_CURSOR 0x02
-#define CMD_QUIT 0xFF
+/* CMD_GRAB / CMD_GET_CURSOR / CMD_QUIT and the command frame (helper_cmd_grab_t,
+ * built via wire_cmd()) come from wire.h, shared with the helper. */
 #define RESP_OK    0x00
 
 /* ========================================================================= */
@@ -174,7 +173,7 @@ void drmtap_helper_stop(drmtap_ctx *ctx) {
         /* Send a full-size quit command (best effort). The helper reads one whole
          * fixed-size command frame per iteration, so a 1-byte quit would be a
          * short read that the helper now rejects; send the complete struct. */
-        helper_cmd_grab_t hcmd = { .cmd = CMD_QUIT, .crtc_id = 0 };
+        helper_cmd_grab_t hcmd = wire_cmd(CMD_QUIT, 0);
         ssize_t n = send(ctx->helper_fd, &hcmd, sizeof(hcmd), MSG_NOSIGNAL);
         (void)n;
 
@@ -235,10 +234,7 @@ int drmtap_helper_grab(drmtap_ctx *ctx, helper_grab_result_t *result,
     }
 
     /* Send grab command */
-    helper_cmd_grab_t hcmd = {
-        .cmd = CMD_GRAB,
-        .crtc_id = ctx->crtc_id
-    };
+    helper_cmd_grab_t hcmd = wire_cmd(CMD_GRAB, ctx->crtc_id);
     ssize_t n = send(ctx->helper_fd, &hcmd, sizeof(hcmd), MSG_NOSIGNAL);
     if (n != sizeof(hcmd)) {
         drmtap_debug_log(ctx, "helper send failed, trying respawn");
@@ -337,10 +333,7 @@ int drmtap_helper_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
         }
     }
 
-    helper_cmd_grab_t hcmd = {
-        .cmd = CMD_GET_CURSOR,
-        .crtc_id = ctx->crtc_id,
-    };
+    helper_cmd_grab_t hcmd = wire_cmd(CMD_GET_CURSOR, ctx->crtc_id);
     ssize_t n = send(ctx->helper_fd, &hcmd, sizeof(hcmd), MSG_NOSIGNAL);
     if (n != sizeof(hcmd)) {
         drmtap_helper_stop(ctx);

--- a/src/wire.h
+++ b/src/wire.h
@@ -63,13 +63,16 @@ static inline helper_cmd_grab_t wire_cmd(uint16_t type, uint32_t crtc_id) {
     return c;
 }
 
-/* True only for a valid, version-matched command frame. A foreign magic, a
- * different protocol version, or a length that does not match this build's frame
- * all fail here so a stale helper/library binary is rejected, not misparsed. */
+/* True only for a valid, version-matched command frame carrying a known command
+ * type. A foreign magic, a different protocol version, a length that does not
+ * match this build's frame, or a type outside the declared CMD_* set all fail
+ * here, so a stale helper/library binary or a malformed command is rejected at
+ * one gate before dispatch, not misparsed. */
 static inline int wire_cmd_valid(const helper_cmd_grab_t *c) {
     return c->magic == HELPER_PROTO_MAGIC &&
            c->version == HELPER_PROTO_VERSION &&
-           c->length == (uint32_t)sizeof(helper_cmd_grab_t);
+           c->length == (uint32_t)sizeof(helper_cmd_grab_t) &&
+           (c->type == CMD_GRAB || c->type == CMD_GET_CURSOR || c->type == CMD_QUIT);
 }
 
 /* Send exactly len bytes, handling partial writes and EINTR. 0 ok, -1 error. */

--- a/src/wire.h
+++ b/src/wire.h
@@ -20,10 +20,57 @@
 #define DRMTAP_WIRE_H
 
 #include <stddef.h>
+#include <stdint.h>
 #include <string.h>
 #include <errno.h>
 #include <unistd.h>
 #include <sys/socket.h>
+
+/* ---- Command framing (library -> helper) --------------------------------
+ * A command frame carries a magic + protocol version so a helper and a library
+ * built from different releases fail cleanly instead of misreading each other:
+ * the helper rejects any frame whose magic/version/length do not match its own
+ * build and stops serving, rather than acting on a misparsed frame. The channel
+ * is a host-local socketpair between two ends of the same machine, so the multi
+ * byte fields are native byte order (both ends share the host endianness); there
+ * is no cross-machine transport to byte-swap for. Defined here, once, so the
+ * helper, the library client and the tests cannot drift apart. */
+#define HELPER_PROTO_MAGIC   0x544D5244u  /* "DRMT" as a little-endian u32 */
+#define HELPER_PROTO_VERSION 1u
+
+/* Command types (the `type` field of a command frame). */
+#define CMD_GRAB       0x01u
+#define CMD_GET_CURSOR 0x02u
+#define CMD_QUIT       0xFFu
+
+typedef struct {
+    uint32_t magic;    /* HELPER_PROTO_MAGIC */
+    uint16_t version;  /* HELPER_PROTO_VERSION */
+    uint16_t type;     /* CMD_GRAB / CMD_GET_CURSOR / CMD_QUIT */
+    uint32_t length;   /* total frame length in bytes (== sizeof(helper_cmd_grab_t)) */
+    uint32_t crtc_id;  /* target CRTC id (0 = auto-select first active) */
+} helper_cmd_grab_t;   /* 16 bytes, naturally aligned, no padding */
+
+/* Build a command frame with the header fields set for this build. */
+static inline helper_cmd_grab_t wire_cmd(uint16_t type, uint32_t crtc_id) {
+    helper_cmd_grab_t c;
+    memset(&c, 0, sizeof(c));
+    c.magic = HELPER_PROTO_MAGIC;
+    c.version = HELPER_PROTO_VERSION;
+    c.type = type;
+    c.length = (uint32_t)sizeof(helper_cmd_grab_t);
+    c.crtc_id = crtc_id;
+    return c;
+}
+
+/* True only for a valid, version-matched command frame. A foreign magic, a
+ * different protocol version, or a length that does not match this build's frame
+ * all fail here so a stale helper/library binary is rejected, not misparsed. */
+static inline int wire_cmd_valid(const helper_cmd_grab_t *c) {
+    return c->magic == HELPER_PROTO_MAGIC &&
+           c->version == HELPER_PROTO_VERSION &&
+           c->length == (uint32_t)sizeof(helper_cmd_grab_t);
+}
 
 /* Send exactly len bytes, handling partial writes and EINTR. 0 ok, -1 error. */
 static inline int wire_send_all(int sock, const void *buf, size_t len) {

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -199,6 +199,40 @@ static void test_eof_midframe_rejected(void) {
     close(sv[1]);
 }
 
+/* The command frame carries a magic + protocol version so a helper and a library
+ * built from different releases fail cleanly. wire_cmd() builds a valid frame and
+ * wire_cmd_valid() (the check the helper runs before acting on a frame) must
+ * accept it and reject a foreign magic, a different version, or a wrong length. */
+static void test_cmd_frame_magic_version(void) {
+    helper_cmd_grab_t c = wire_cmd(CMD_GRAB, 42);
+    CHECK(sizeof(helper_cmd_grab_t) == 16, "command frame is 16 bytes (fixed wire layout)");
+    CHECK(c.magic == HELPER_PROTO_MAGIC && c.version == HELPER_PROTO_VERSION &&
+          c.length == sizeof(helper_cmd_grab_t) && c.type == CMD_GRAB && c.crtc_id == 42,
+          "wire_cmd sets magic/version/length/type/crtc_id");
+    CHECK(wire_cmd_valid(&c), "well-formed command frame accepted");
+
+    /* Round-trip over a socketpair, exactly as the helper reads it. */
+    int sv[2];
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sv) != 0) { CHECK(0, "cmd: socketpair"); return; }
+    helper_cmd_grab_t sent = wire_cmd(CMD_GET_CURSOR, 7);
+    CHECK(wire_send_all(sv[0], &sent, sizeof(sent)) == 0, "command frame sent");
+    helper_cmd_grab_t got;
+    memset(&got, 0, sizeof(got));
+    int r = wire_recv_all(sv[1], &got, sizeof(got));
+    CHECK(r == 0 && wire_cmd_valid(&got) && got.type == CMD_GET_CURSOR && got.crtc_id == 7,
+          "received command frame is valid and preserves type/crtc_id");
+    close(sv[0]); close(sv[1]);
+
+    /* A foreign magic, a bumped version, and a wrong length are each rejected. */
+    helper_cmd_grab_t bad = wire_cmd(CMD_GRAB, 0);
+    bad.magic ^= 0xFFFFFFFFu;
+    CHECK(!wire_cmd_valid(&bad), "foreign magic rejected");
+    bad = wire_cmd(CMD_GRAB, 0); bad.version = (uint16_t)(HELPER_PROTO_VERSION + 1);
+    CHECK(!wire_cmd_valid(&bad), "mismatched protocol version rejected");
+    bad = wire_cmd(CMD_GRAB, 0); bad.length = sizeof(helper_cmd_grab_t) + 1;
+    CHECK(!wire_cmd_valid(&bad), "wrong frame length rejected");
+}
+
 int main(void) {
     printf("Running wire-protocol tests (against src/wire.h)...\n");
     test_received_fd_is_cloexec();
@@ -208,6 +242,7 @@ int main(void) {
     test_zero_fds_accepted();
     test_fragmented_frame_reassembled();
     test_eof_midframe_rejected();
+    test_cmd_frame_magic_version();
     if (g_failures == 0) {
         printf("All wire-protocol tests passed.\n");
         return 0;

--- a/tests/test_wire.c
+++ b/tests/test_wire.c
@@ -231,6 +231,8 @@ static void test_cmd_frame_magic_version(void) {
     CHECK(!wire_cmd_valid(&bad), "mismatched protocol version rejected");
     bad = wire_cmd(CMD_GRAB, 0); bad.length = sizeof(helper_cmd_grab_t) + 1;
     CHECK(!wire_cmd_valid(&bad), "wrong frame length rejected");
+    bad = wire_cmd(CMD_GRAB, 0); bad.type = 0x7Fu; /* not a declared CMD_* */
+    CHECK(!wire_cmd_valid(&bad), "unknown command type rejected");
 }
 
 int main(void) {


### PR DESCRIPTION
Addresses the last open backlog item of the helper security review (#27): a protocol magic/version header so a helper and library built from different releases fail cleanly instead of misparsing each other.

## What changed
1- The command frame moves to `src/wire.h` as the single source of truth (it was duplicated as `struct helper_cmd_grab` in the helper and `helper_cmd_grab_t` in `drmtap_internal.h`, a drift risk in itself).
2- The frame gains a `magic` + protocol `version` + `type` + `length` header (16 bytes, fixed layout). The helper validates it (`wire_cmd_valid`) before acting on a frame and stops serving on a mismatch, so a stale binary fails closed rather than misparsing a frame while holding CAP_SYS_ADMIN.
3- The three library send sites use `wire_cmd(type, crtc_id)`.
4- `tests/test_wire.c` covers accept (round-trip over a socketpair) and reject (foreign magic, bumped version, wrong length).
5- The bundled `csrc/` copies are re-synced (coherence check passes).

## Docs
`SECURITY.md` now documents the split-capture convert trust boundary (`drmtap_convert_dmabuf` treats the descriptor and fd as untrusted IPC input) and the new command-frame header, with matching threat-model rows.

The other review backlog item (drop `open`/`openat` from the seccomp allowlist after the device is opened) was already in place.

closes #27
