### PR TITLE
release: libdrmtap-sys 0.4.13

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 **Language:** C11  
 **License:** MIT  
 **Tests:** unit (no hardware) + integration via VKMS (Virtual KMS) or a real GPU  
-**Version:** C library `0.4.12` · Rust crates `libdrmtap-sys 0.4.12` / `libdrmtap 0.3.4`  
+**Version:** C library `0.4.13` · Rust crates `libdrmtap-sys 0.4.13` / `libdrmtap 0.3.4`  
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ Notable changes to libdrmtap. Loosely follows Keep a Changelog; the project uses
 semantic versioning. The C library, the `libdrmtap-sys` crate and the meson
 project share one version; the `libdrmtap` wrapper crate is versioned separately.
 
+## [0.4.13] - 2026-07-20
+
+### Hardening
+
+- The privileged helper command frame now carries a magic and a protocol
+  version. The helper validates the magic, version, length and command type of
+  every frame at one gate before dispatch, and closes the connection on a
+  mismatch instead of replying, so a helper and a library built from different
+  releases fail closed rather than misreading each other while the helper holds
+  CAP_SYS_ADMIN. The command frame moved to one shared header (wire.h) instead of
+  being duplicated on each side.
+
+### Changed
+
+- SECURITY.md now documents the split-capture convert trust boundary (the
+  converter treats the exporter-supplied descriptor and fd as untrusted IPC
+  input) and the new command-frame header.
+
 ## [0.4.12] - 2026-07-20
 
 ### Security
@@ -115,6 +133,7 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 - amdgpu EGL detile fix, privileged-helper hardening, and a batch of full-audit
   fixes.
 
+[0.4.13]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.13
 [0.4.12]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.12
 [0.4.11]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.11
 [0.4.10]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.10

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ int main() {
 libdrmtap = "0.3"
 ```
 
-> This pulls in `libdrmtap-sys` 0.4.12, which embeds and statically compiles the
+> This pulls in `libdrmtap-sys` 0.4.13, which embeds and statically compiles the
 > C sources (and the privilege helper). No system `libdrmtap` install, no
 > `meson install`, no `pkg-config` to find a shared library.
 
@@ -195,7 +195,7 @@ sudo ./build/vnc_server
 libdrmtap is being upstreamed into [RustDesk](https://github.com/rustdesk/rustdesk)
 via [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420).
 The integration adds a `drm` backend to `scrap` that depends on the
-[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.12 crate, which
+[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.13 crate, which
 embeds and statically compiles the C sources (and the privilege helper) — so
 there is no system `libdrmtap` install and no dynamic `libdrmtap.so` linkage.
 

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.12"
+version = "0.4.13"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 12
+#define DRMTAP_VERSION_PATCH 13
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.12", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.4.13", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/bindings/rust/libdrmtap/README.md
+++ b/bindings/rust/libdrmtap/README.md
@@ -25,7 +25,7 @@ reports HDR (`P010` overlay-video and HLG excepted).
 libdrmtap = "0.3"
 ```
 
-This pulls in `libdrmtap-sys` 0.4.12, which embeds and statically compiles the C
+This pulls in `libdrmtap-sys` 0.4.13, which embeds and statically compiles the C
 sources (and the privilege helper) — no system `libdrmtap` install needed.
 
 ## Example

--- a/contrib/integrations/rustdesk/README.md
+++ b/contrib/integrations/rustdesk/README.md
@@ -7,7 +7,7 @@ crate.
 > The upstream integration PR
 > [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420)
 > is **under maintainer review** (in progress — not yet merged). It adds a `drm`
-> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.12. The files here are a
+> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.13. The files here are a
 > self-contained reference for the same crate-based backend.
 
 ## Status
@@ -42,7 +42,7 @@ capture. This means:
 1. Add the crate to `libs/scrap/Cargo.toml`:
 
    ```toml
-   libdrmtap-sys = { version = "0.4.12", optional = true }
+   libdrmtap-sys = { version = "0.4.13", optional = true }
    ```
 
    It embeds and statically compiles the C sources **and** builds the

--- a/contrib/integrations/rustdesk/drm/mod.rs
+++ b/contrib/integrations/rustdesk/drm/mod.rs
@@ -13,7 +13,7 @@
 // Integration (tested on Ubuntu 24.04; uses the static libdrmtap-sys crate):
 //
 //   1. Add the crate to libs/scrap/Cargo.toml:
-//        libdrmtap-sys = { version = "0.4.12", optional = true }
+//        libdrmtap-sys = { version = "0.4.13", optional = true }
 //      It statically embeds and compiles the C sources and builds the
 //      drmtap-helper binary — no system libdrmtap install, no meson install,
 //      no apt package, and no rustc-link-search.

--- a/contrib/integrations/rustdesk/drm/recorder.rs
+++ b/contrib/integrations/rustdesk/drm/recorder.rs
@@ -9,7 +9,7 @@
 // captured 1920x1017 @ BGRA, 7,810,560 bytes — pixel-perfect.
 //
 // To use in RustDesk:
-//   Add `libdrmtap-sys = { version = "0.4.12", optional = true }` to
+//   Add `libdrmtap-sys = { version = "0.4.13", optional = true }` to
 //   libs/scrap/Cargo.toml, place this file at libs/scrap/src/common/drm.rs,
 //   and see mod.rs in this directory for the wiring. The canonical, current
 //   backend is in the upstream PR rustdesk/rustdesk#15420.

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -450,7 +450,7 @@ Three layers, published on crates.io:
 └─────────────────────────────────────────────────┘
 ```
 
-> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.12,
+> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.13,
 > libdrmtap 0.3.4) and verified to build/test in CI on Ubuntu 22.04/24.04.
 > Capture is verified on Intel i915/xe (dual-4K Meteor Lake), Nvidia/Tegra
 > (Jetson Orin Nano, aarch64), virtio-gpu, and AMD amdgpu (RX Vega 64, gfx9,
@@ -514,8 +514,8 @@ Adding `libdrmtap-sys` is standard practice for them. They `cargo add libdrmtap`
 
 | Area | What shipped | Status |
 |---|---|---|
-| Core | `libdrmtap` C library 0.4.12 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
-| Rust | `libdrmtap-sys` 0.4.12 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
+| Core | `libdrmtap` C library 0.4.13 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
+| Rust | `libdrmtap-sys` 0.4.13 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
 | Rust | `libdrmtap` 0.3.4 (safe wrapper) | ✅ Published on crates.io |
 | GPU | EGL/GLES2 GPU-universal detiling backend | ✅ Implemented |
 | HW | Intel i915/xe + Nvidia/Tegra + virtio-gpu + AMD amdgpu validation | ✅ Verified (AMD on RX Vega 64, gfx9) |

--- a/docs/research/07_potential_adopters.md
+++ b/docs/research/07_potential_adopters.md
@@ -16,7 +16,7 @@
 
 ### Integration path for each:
 
-**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.12 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
+**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.13 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
 
 **Sunshine**: Replace internal KMS code with `#include <drmtap.h>`. They already use DMA-BUF → VAAPI pipeline, so `drmtap_grab()` (zero-copy) slots in directly.
 

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 12
+#define DRMTAP_VERSION_PATCH 13
 
 /**
  * @brief Get the library version as a packed integer.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.12',
+    version: '0.4.13',
     license: 'MIT',
     default_options: [
         'c_std=c11',

--- a/patches/rustdesk/README.md
+++ b/patches/rustdesk/README.md
@@ -31,7 +31,7 @@ cargo build --release
 ## Based on
 
 - RustDesk v1.4.6
-- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.12"`
+- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.13"`
 
 ## Upstream status
 

--- a/patches/rustdesk/scrap_Cargo.toml
+++ b/patches/rustdesk/scrap_Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-libdrmtap-sys = { version = "0.4.12", optional = true }
+libdrmtap-sys = { version = "0.4.13", optional = true }
 webm = { git = "https://github.com/rustdesk-org/rust-webm" }
 serde = {version="1.0", features=["derive"]}
 


### PR DESCRIPTION
Release libdrmtap-sys 0.4.13.

Bumps the C library, the -sys crate and meson to 0.4.13 and refreshes the current-version pointers (READMEs, contrib, patches, docs). Genuine history ("fixed in 0.4.12") is left as-is.

Ships the work already on main:
1- the privileged helper command frame gained a magic + protocol version + type + length header, validated at one gate before dispatch; on a mismatch the helper closes the connection instead of replying, so a helper and library built from different releases fail closed rather than misreading each other while the helper holds CAP_SYS_ADMIN (closed #27);
2- SECURITY.md documents the split-capture convert trust boundary and the new header.

Clean build, 8/8 tests, csrc coherence OK.
