### PR TITLE
drm: drop implicit DRM master and honor the FB_MODIFIERS flag (0.4.14)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 **Language:** C11  
 **License:** MIT  
 **Tests:** unit (no hardware) + integration via VKMS (Virtual KMS) or a real GPU  
-**Version:** C library `0.4.13` · Rust crates `libdrmtap-sys 0.4.13` / `libdrmtap 0.3.4`  
+**Version:** C library `0.4.14` · Rust crates `libdrmtap-sys 0.4.14` / `libdrmtap 0.3.4`  
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,104 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 
 ### Fixed
 
-- Drop DRM master after opening the card node when running privileged (root /
-  CAP_SYS_ADMIN), in both the library and the privileged helper. libdrmtap only
-  reads scanout and never modesets, but if a privileged process opened the node
-  while no client held master (e.g. an unattended service started at boot before
-  the compositor) the kernel granted it implicitly, which then blocked a compositor
-  from reacquiring master on a VT switch and left the display black or frozen.
-  Master is now dropped defensively there. An unprivileged caller keeps master,
-  since it relies on it for drmModeGetFB2 to return framebuffer handles.
-- Honor the DRM_MODE_FB_MODIFIERS flag before trusting the framebuffer modifier.
-  drmModeGetFB2 leaves the modifier field undefined when the flag is clear, so a
-  driver that tiles the scanout without advertising a modifier was imported as if
-  linear and produced corruption (the recurring 10-bit XR30 class). When the flag
-  is clear the modifier is now reported as DRM_FORMAT_MOD_INVALID, so the EGL import
-  omits the modifier attribute and lets the driver infer the real layout; the CPU
-  fallback keeps treating an unknown modifier as linear.
+- Drop DRM master after opening the card node when the caller holds CAP_SYS_ADMIN,
+  in both the library and the privileged helper. libdrmtap only reads scanout and
+  never modesets, but if a process holding CAP_SYS_ADMIN opened the node while no
+  client held master (e.g. an unattended service started at boot before the
+  compositor) the kernel granted it implicitly, which then blocked a compositor from
+  reacquiring master on a VT switch and left the display black or frozen. Master is
+  now dropped defensively there. The gate is the capability, checked with the capget
+  syscall, not the uid: a caller without CAP_SYS_ADMIN (including a uid-0 process
+  that dropped it) relies on the implicit master for drmModeGetFB2 to return
+  framebuffer handles and must keep it.
+- Honor the DRM_MODE_FB_MODIFIERS flag before trusting the framebuffer modifier, on
+  every grab path (the primary grab, the fast-capture cache and the privileged
+  helper). drmModeGetFB2 leaves the modifier field undefined when the flag is clear,
+  so a driver that tiles the scanout without advertising a modifier was imported as
+  if linear and produced corruption (the recurring 10-bit XR30 class). When the flag
+  is clear the modifier is now reported as DRM_FORMAT_MOD_INVALID: with a DMA-BUF and
+  EGL the import omits the modifier attribute and lets the driver infer the real
+  layout; when EGL cannot run (no DMA-BUF fd, or EGL unavailable) an unknown layout is
+  treated as linear and reduced from the raw mapping, which keeps 10-bit and 16-bit
+  scanouts correct instead of diverting them into the CPU deswizzle.
+- The EGL import no longer falls back to reinterpreting a high-bit-depth scanout as
+  XRGB8888. When the native fourcc import failed, the retry forced XRGB8888 while
+  keeping the source stride, which sampled a 10-bit (XR30 family) or 16-bit (XR48
+  family) buffer at the wrong bit depth and returned it as a valid frame. A
+  high-bit-depth import that fails now fails cleanly so the caller reduces the real
+  bit depth from the raw mapping on the CPU; the XRGB8888 retry stays for genuine
+  8-bit sources whose exact fourcc a driver does not recognize.
+- The privileged helper leaked a GEM handle on every grab and every cursor poll:
+  drmModeGetFB2 mints a fresh handle the caller owns, and no path closed it, so the
+  long-running root helper pinned one buffer object per frame until exhaustion. Both
+  helper paths and the direct cursor path in the library now close the handle on every
+  return. (The main grab path in the library already closed its handles.)
+- The EGL convert path no longer returns a stale or uninitialized frame as success
+  after GPU context loss. A failed eglMakeCurrent is now fatal, and a GL error across
+  the render and readback (notably a context reset) fails the convert instead of
+  handing back whatever was in the readback buffer.
+- HDR displays are now tone-mapped on Wayland direct capture. Both HDR-metadata reads
+  (the library and the helper) mapped a CRTC to its connector through the legacy
+  encoder link, which reads 0 under atomic KMS, so a compositor-managed HDR connector
+  never matched and never tone-mapped. They now match on the atomic CRTC_ID property.
+- Half-float FP16 scanouts (XRGB16161616F and siblings) are reduced correctly on the
+  CPU fallback instead of being misread as 8-bit and returned as a corrupt frame. The
+  new converter decodes each half as linear light and re-encodes through the sRGB
+  OETF (HDR highlights clip).
+- Monitor hotplug and modeset are now detected. drmtap_displays_changed compared the
+  connector and CRTC object counts, which are fixed by the GPU hardware, so a monitor
+  plugged or unplugged on an existing connector never registered. It now hashes the
+  connection state and bound CRTC of each connector.
+- The XRGB8888 EGL import retries honor the plane-0 offset from the framebuffer
+  instead of hardcoding 0, so a scanout whose pixels start at a non-zero BO offset is
+  not imported shifted.
+- drmtap_convert_format rejects a source or destination stride narrower than
+  width times four, matching drmtap_convert_rgb16, closing an out-of-bounds row
+  access on a malformed geometry.
+- 10-bit BGR scanouts (XBGR2101010 / ABGR2101010, the XB30 family) are now reduced
+  and tone-mapped on the CPU fallback. Both the SDR reduction and the HDR tone-map
+  handled only the RGB 10-bit order (XR30 / AR30), so a 10-bit BGR scanout fell
+  through unreduced and was returned as a corrupt frame. The channel order is now
+  selected from the fourcc.
+- The fast-capture path falls back to EGL when a scanout cannot be CPU-mapped. A
+  tiled scanout on some drivers (amdgpu GFX9+, discrete VRAM, nvidia) refuses an mmap
+  of the exported DMA-BUF; grab_mapped_fast returned -ENOMEM there instead of
+  EGL-detiling the fd the way the primary grab does. It now takes that fallback (no
+  CPU mapping is cached for such a frame; the fd is re-exported each grab). Validated
+  on Intel via a DRMTAP_FORCE_MMAP_FAIL test hook that drops the CPU mapping so the
+  fallback runs on any EGL-capable GPU.
+- The grab_mapped_fast doc no longer claims it returns 1 on an unchanged framebuffer.
+  It always re-reads the current scanout and returns a fresh frame, because a
+  compositor can render into the same framebuffer without a page flip, so an
+  fb_id-unchanged skip would miss content updates. The identity assumption (a stable
+  fb_id denotes the same buffer between captures) is now documented.
+
+### Security
+
+- drmtap_convert_dmabuf now validates the untrusted fd (genuine dma-buf plus the
+  offset-and-size bound added in 0.4.12) BEFORE the EGL import, not only in the CPU
+  fallback. The EGL path runs first and is the one the intended unprivileged converter
+  takes, so a hostile descriptor claiming a frame larger than the dma-buf backs
+  previously reached eglCreateImage unbounded; it is now rejected up front.
+- The helper seccomp filter restricts ioctl to the DRM ioctl type instead of allowing
+  every ioctl. The helper issues nothing but DRM ioctls on its one DRM fd, so a
+  memory-corrupted helper can no longer reach an unrelated ioctl (terminal control,
+  console injection). Matching the type byte stays robust across drivers without
+  risking a KILL on a DRM command not individually listed.
+- The privileged helper no longer honors DRM_DEVICE from the environment. It takes the
+  device solely from the library-selected, vetted argv path (the library already
+  ignores DRM_DEVICE when privileged, since 0.4.11).
+
+### Performance
+
+- The HDR-metadata read no longer forces a hardware connector probe on every captured
+  frame. Both the library and the helper now use drmModeGetConnectorCurrent, which
+  reads cached kernel state instead of re-probing the connector each frame.
+- The 16-bit HDR (PQ) reduction uses a precomputed 65536-entry lookup table instead of
+  calling pow twice per channel per pixel (tens of millions of pow calls per 4K frame).
+- The privileged helper caches which planes are PRIMARY instead of re-reading each
+  plane's static type property (an object-properties fetch plus a per-property lookup)
+  on every captured frame.
 
 ## [0.4.13] - 2026-07-20
 
@@ -153,6 +236,7 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 - amdgpu EGL detile fix, privileged-helper hardening, and a batch of full-audit
   fixes.
 
+[0.4.14]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.14
 [0.4.13]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.13
 [0.4.12]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.12
 [0.4.11]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ Notable changes to libdrmtap. Loosely follows Keep a Changelog; the project uses
 semantic versioning. The C library, the `libdrmtap-sys` crate and the meson
 project share one version; the `libdrmtap` wrapper crate is versioned separately.
 
+## [0.4.14] - 2026-07-22
+
+### Fixed
+
+- Drop DRM master after opening the card node when running privileged (root /
+  CAP_SYS_ADMIN), in both the library and the privileged helper. libdrmtap only
+  reads scanout and never modesets, but if a privileged process opened the node
+  while no client held master (e.g. an unattended service started at boot before
+  the compositor) the kernel granted it implicitly, which then blocked a compositor
+  from reacquiring master on a VT switch and left the display black or frozen.
+  Master is now dropped defensively there. An unprivileged caller keeps master,
+  since it relies on it for drmModeGetFB2 to return framebuffer handles.
+- Honor the DRM_MODE_FB_MODIFIERS flag before trusting the framebuffer modifier.
+  drmModeGetFB2 leaves the modifier field undefined when the flag is clear, so a
+  driver that tiles the scanout without advertising a modifier was imported as if
+  linear and produced corruption (the recurring 10-bit XR30 class). When the flag
+  is clear the modifier is now reported as DRM_FORMAT_MOD_INVALID, so the EGL import
+  omits the modifier attribute and lets the driver infer the real layout; the CPU
+  fallback keeps treating an unknown modifier as linear.
+
 ## [0.4.13] - 2026-07-20
 
 ### Hardening

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ int main() {
 libdrmtap = "0.3"
 ```
 
-> This pulls in `libdrmtap-sys` 0.4.13, which embeds and statically compiles the
+> This pulls in `libdrmtap-sys` 0.4.14, which embeds and statically compiles the
 > C sources (and the privilege helper). No system `libdrmtap` install, no
 > `meson install`, no `pkg-config` to find a shared library.
 
@@ -82,7 +82,7 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 | Intel (i915/xe) X/Y-tiled deswizzle | ✅ CPU fallback |
 | AMD (amdgpu) deswizzle | ✅ CPU fallback |
 | Nvidia (nvidia-drm) blocklinear deswizzle | ✅ CPU fallback |
-| HDR10 → SDR tone-map (AR30/XR30, XR48/AR48/XB48/AB48) | ✅ Implemented (P010 not yet) |
+| HDR10 → SDR tone-map (AR30/XR30/AB30/XB30, XR48/AR48/XB48/AB48) | ✅ Implemented (P010 not yet) |
 | Frame differencing (dirty rects) | ✅ Implemented |
 | Thread-safe (one `drmtap_ctx` per thread) | ✅ By design |
 | Coexists with NoMachine/Sunshine | ✅ By design |
@@ -107,10 +107,14 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 > tone-map, sRGB — and returns correct 8-bit SDR, instead of the washed-out
 > top-8-of-10-bits result. This matches what consumers like RustDesk expect
 > (their pipeline is 8-bit SDR; on other platforms the OS/compositor tone-maps
-> before they see it — on DRM we do it). Covers `AR30`/`XR30` (10-bit) and
-> `XR48`/`AR48` (16-bit), in both the CPU and the EGL (tiled) paths.
-> `P010` (10-bit YUV, used for overlay-video planes rather than the primary
-> desktop scanout) is not handled.
+> before they see it — on DRM we do it). Covers `AR30`/`XR30`/`AB30`/`XB30`
+> (10-bit) and `XR48`/`AR48`/`XB48`/`AB48` (16-bit), in both the CPU and the EGL
+> (tiled) paths. `P010` (10-bit YUV, used for overlay-video planes rather than the
+> primary desktop scanout) is not handled.
+>
+> **FP16 half-float scanouts** (`XRGB16161616F` and its BGR/alpha siblings) are
+> reduced to 8-bit sRGB on the CPU fallback — linear-light decode through the sRGB
+> OETF, not HDR tone-mapped (values above 1.0 clip to white).
 
 ## Quick Start
 
@@ -195,7 +199,7 @@ sudo ./build/vnc_server
 libdrmtap is being upstreamed into [RustDesk](https://github.com/rustdesk/rustdesk)
 via [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420).
 The integration adds a `drm` backend to `scrap` that depends on the
-[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.13 crate, which
+[`libdrmtap-sys`](https://crates.io/crates/libdrmtap-sys) 0.4.14 crate, which
 embeds and statically compiles the C sources (and the privilege helper) — so
 there is no system `libdrmtap` install and no dynamic `libdrmtap.so` linkage.
 
@@ -212,6 +216,18 @@ meson test -C build --suite unit
 # Integration tests (needs DRM device)
 sudo DRM_DEVICE=/dev/dri/card0 meson test -C build --suite integration
 ```
+
+### Environment variables
+
+| Variable | Effect |
+|---|---|
+| `DRM_DEVICE` | DRM node to open (e.g. `/dev/dri/card0`). **Ignored for privileged (root / `CAP_SYS_ADMIN`) callers** — a privileged capture service uses its configured `device_path` or the KMS auto-scan, so the environment cannot redirect which device it opens. Honored only for unprivileged runs. |
+| `DRMTAP_DEBUG` | Set to `1` for verbose debug logging on stderr. |
+| `DRMTAP_NO_EGL` | Set to `1` to force the CPU deswizzle/convert path (skip EGL/GLES). |
+| `DRMTAP_NO_IMAGE_CACHE` | Set to `1` to re-import the `EGLImage` every frame (disable the import-once cache). |
+| `DRMTAP_FORCE_MMAP_FAIL` | Test hook — set to `1` to force the fast-path CPU mmap to fail so the EGL-detile fallback runs. |
+
+The privilege model is described in [`SECURITY.md`](SECURITY.md).
 
 ## Performance
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -53,8 +53,9 @@ this specific operation:
 So `CAP_SYS_ADMIN` is what the kernel requires. We are upfront that it is broad
 and overpowered for what the helper actually does with it. The mitigation is
 **structural** (keep it out of the main process, confine the helper), not a
-clever capability minimization. The helper never becomes DRM master (it does not
-call `drmSetMaster`).
+clever capability minimization. The helper never sets itself DRM master (it does
+not call `drmSetMaster`), and right after opening the node it calls
+`drmDropMaster` to release any master the kernel granted it implicitly.
 
 > A narrower kernel capability for scanout read-back would let us drop
 > `CAP_SYS_ADMIN` entirely. We would welcome such a change.
@@ -67,28 +68,38 @@ At startup, in this order (`main()` in `helper/drmtap-helper.c`):
 
 1. **Refuses to run standalone** — validates that fd 3 is a connected socket and
    that the peer uid (via `SO_PEERCRED`) matches its own uid; exits otherwise.
-2. **Restricts the device path** — the device comes from `argv[1]` or the
-   `DRM_DEVICE` env var (both attacker-influenceable). The helper canonicalizes
-   it with `realpath()` and **refuses any path that does not resolve under
-   `/dev/dri/`** before opening it.
+2. **Restricts the device path** — the device comes solely from `argv[1]` (the
+   path the library selected). The helper does not read `DRM_DEVICE` from the
+   environment (0.4.14 hardening), and the library itself ignores `DRM_DEVICE`
+   when privileged (since 0.4.11), so an env var cannot redirect which device the
+   privileged process opens. The still attacker-influenceable `argv[1]` is
+   canonicalized with `realpath()`, and the helper **refuses any path that does
+   not resolve under `/dev/dri/`** before opening it.
 3. **`PR_SET_NO_NEW_PRIVS`** — set via `prctl`, before seccomp; hard-fails if it
    cannot be set.
 4. **Opens the DRM device once, read-only** — `open(..., O_RDONLY | O_CLOEXEC)`.
    Only read ioctls are issued (`GetFB2` / `PrimeHandleToFD` / `SetClientCap`),
    which all work on an `O_RDONLY` fd on the CAP_SYS_ADMIN path; the helper never
    becomes DRM master and never modifies KMS state. Opening happens **before**
-   seccomp so the filter can forbid `open`/`openat` outright (next step).
-5. **Drops all capabilities except `CAP_SYS_ADMIN`** — via libcap
+   seccomp so the filter can forbid `open`/`openat` outright (the seccomp step
+   below).
+5. **Drops any implicitly-granted DRM master** — calls `drmDropMaster` right
+   after opening, so a boot-time capture process (started before the compositor
+   holds master) cannot block a compositor from (re)acquiring master on a VT
+   switch. It is a no-op unless the kernel had made the helper master implicitly.
+6. **Drops all capabilities except `CAP_SYS_ADMIN`** — via libcap
    (`cap_set_proc`). **Hard-fails** (refuses to serve) if it cannot.
-6. **Installs a seccomp filter** — `seccomp_init(SCMP_ACT_KILL_PROCESS)` (a
+7. **Installs a seccomp filter** — `seccomp_init(SCMP_ACT_KILL_PROCESS)` (a
    default-**KILL** allowlist), allowing only: `read, write, close, ioctl,
    sendto, sendmsg, recvfrom, mmap, munmap, brk, fstat, newfstatat, fcntl,
-   exit_group, exit, rt_sigreturn, clock_gettime`. **`open`/`openat` are
-   deliberately NOT on the allowlist** — the device fd was already opened in
-   step 4 and the grab loop only ever reuses it, so a compromised helper cannot
-   open arbitrary files even while it holds `CAP_SYS_ADMIN`. **Hard-fails** if it
-   cannot install.
-7. Serves grab/cursor requests on the persistent fd in a loop.
+   exit_group, exit, rt_sigreturn, clock_gettime`. `ioctl` is further restricted
+   by request **type** to DRM ioctls only — a masked equality on the request's
+   type byte (`'d'`), so a non-DRM `ioctl` such as `TIOCSTI` console injection
+   hits the default KILL. **`open`/`openat` are deliberately NOT on the
+   allowlist** — the device fd was already opened in step 4 and the grab loop
+   only ever reuses it, so a compromised helper cannot open arbitrary files even
+   while it holds `CAP_SYS_ADMIN`. **Hard-fails** if it cannot install.
+8. Serves grab/cursor requests on the persistent fd in a loop.
 
 The helper binary is also built with exploit-mitigation flags
 (`-fstack-protector-strong`, `_FORTIFY_SOURCE=2` on optimized builds, PIE, and
@@ -143,17 +154,22 @@ privileged process entirely:
 
 Because the descriptor and fd arrive over a process boundary,
 **`drmtap_convert_dmabuf()` treats them as untrusted IPC input**, exactly like
-the helper treats a command frame. Before it maps or reads anything it:
+the helper treats a command frame. The gates below run up front, before
+**either** conversion path touches the fd — the EGL import runs first and would
+otherwise hand the descriptor's width/height/stride/offset straight to
+`eglCreateImage` with no size check, so they protect it as much as the CPU
+`mmap` fallback:
 
 - rejects `num_planes > 4`, a zero/short stride (`pitches[0] < width * bpp`), and
   a frame whose `stride * height` exceeds the same one-8K-frame cap
   (`validate_fb_size`, ~126 MB) used on the privileged side;
 - requires the fd to be a **genuine DMA-BUF** — a non-dma-buf fd is rejected (an
-  immutable dma-buf cannot be truncated mid-read, so it is safe to `mmap` on the
-  CPU fallback path);
-- bounds the CPU read against the buffer size (via `lseek`, reliable across
-  kernels unlike `fstat`, which reports 0 for a dma-buf before Linux 5.3) and
-  **fails closed** (returns `-EINVAL`) when the size cannot be determined.
+  immutable dma-buf cannot be truncated mid-read, so it cannot be shrunk between
+  the check and the import or `mmap`);
+- bounds the read against the buffer size — `offsets[0] + pitches[0] * height`
+  must fit the real fd size (via `lseek`, reliable across kernels unlike
+  `fstat`, which reports 0 for a dma-buf before Linux 5.3) — and **fails closed**
+  (returns `-EINVAL`) when the size cannot be determined.
 
 A descriptor that claims a frame larger than its fd actually backs therefore
 returns `-EINVAL` instead of faulting the converter with `SIGBUS` (a
@@ -176,9 +192,12 @@ Do not read the above as more locked down than it is:
   the dynamic loader ignores `LD_PRELOAD`/`LD_LIBRARY_PATH` for the secure-exec
   case, but this is the loader's `AT_SECURE` behavior, not something the helper
   itself enforces.
-- **The seccomp filter has no per-argument filtering.** `ioctl` is allowed on
-  any fd. It blocks whole syscall classes (including `open`/`openat` entirely),
-  but it does not narrow the argument values of the syscalls it does allow.
+- **The seccomp filter narrows only `ioctl`, and only by request type.** `ioctl`
+  is restricted to the DRM type — a masked equality on the request's type byte
+  (`'d'`), so a non-DRM `ioctl` such as `TIOCSTI` console injection is killed —
+  but the fd argument itself is not filtered, and the other allowed syscalls have
+  no per-argument narrowing at all. It otherwise blocks whole syscall classes
+  (including `open`/`openat` entirely).
 - **A world-executable setcap helper on a multi-user host is a real
   consideration.** Anyone who can execute the binary gets a process holding
   `CAP_SYS_ADMIN` (confined by seccomp, and the `SO_PEERCRED` check stops them
@@ -204,7 +223,9 @@ Do not read the above as more locked down than it is:
 | Helper exec'd standalone or by a different user | Refuses unless fd 3 is a connected socket whose `SO_PEERCRED` peer uid matches its own |
 | Unprivileged side points the helper at an arbitrary device | Device path must canonicalize under `/dev/dri/`, and the node is opened `O_RDONLY` |
 | Unprivileged side makes the helper open an arbitrary path/fd | The request protocol carries no path/fd; fd passing is helper -> main only; `open`/`openat` are not on the seccomp allowlist after init |
+| Compromised helper issues a non-DRM ioctl (e.g. `TIOCSTI` console injection) | seccomp allows `ioctl` only for the DRM request type (masked equality on the type byte); any other ioctl hits `SCMP_ACT_KILL_PROCESS` |
 | Malformed scanout geometry drives an oversized allocation / overflow | Geometry guard rejects zero/absurd `pitch`/`height`, capping at one 8K BGRA frame |
+| Long-running helper exhausts kernel GEM handles / pins buffer objects | The helper closes the GEM handle `drmModeGetFB2` mints on every grab and cursor path (`helper_gem_close`), so handle/BO use cannot grow unboundedly |
 | Malformed convert descriptor faults the unprivileged converter (SIGBUS DoS) | `drmtap_convert_dmabuf` validates geometry, requires a genuine DMA-BUF, and bounds the read against the buffer size (`lseek`), failing closed on unknown size |
 | Stale helper/library binary misparses the command stream | The command frame carries a magic + protocol version; the helper rejects a mismatched frame and stops serving |
 | Helper gains new privileges via exec | `PR_SET_NO_NEW_PRIVS` |

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.13"
+version = "0.4.14"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/cursor.c
+++ b/bindings/rust/libdrmtap-sys/csrc/cursor.c
@@ -230,6 +230,13 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
         }
     }
 
+    /* drmModeGetFB2 minted a fresh GEM handle we own; close it before freeing fb2,
+     * or the privileged direct cursor path leaks a kernel handle (pinning the BO)
+     * on every poll. The pixels were already copied out and the prime_fd closed. */
+    if (fb2->handles[0] != 0) {
+        struct drm_gem_close gc = { .handle = fb2->handles[0] };
+        drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
+    }
     drmModeFreeFB2(fb2);
     drmModeFreePlane(plane);
 

--- a/bindings/rust/libdrmtap-sys/csrc/drm_enumerate.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_enumerate.c
@@ -56,11 +56,12 @@ static uint32_t connector_crtc_from_atomic(int fd, uint32_t connector_id) {
     return crtc_id;
 }
 
-/* Fold the current connector topology (per-connector connection state + bound
- * CRTC) into a hash. Unlike the raw connector/CRTC counts -- fixed by the GPU
- * hardware -- this changes when a monitor is plugged/unplugged on an existing
- * connector or a CRTC is (re)bound by a modeset, which is what hotplug detection
- * needs. GetConnectorCurrent reads cached kernel state (no forced probe). */
+/* Fold the current connector topology (per-connector connection state, bound CRTC,
+ * and that CRTC's active mode) into a hash. Unlike the raw connector/CRTC counts --
+ * fixed by the GPU hardware -- this changes when a monitor is plugged/unplugged on an
+ * existing connector, a CRTC is (re)bound, or a modeset changes the active resolution
+ * or refresh, which is what hotplug/modeset detection needs. GetConnectorCurrent reads
+ * cached kernel state (no forced probe). */
 static uint64_t topology_hash(int drm_fd, drmModeRes *res) {
     uint64_t h = 1469598103934665603ULL; /* FNV-1a 64-bit offset basis */
 #define TH_FOLD(v) do { h ^= (uint64_t)(uint32_t)(v); h *= 1099511628211ULL; } while (0)
@@ -75,7 +76,20 @@ static uint64_t topology_hash(int drm_fd, drmModeRes *res) {
         }
         TH_FOLD(conn->connector_id);
         TH_FOLD(conn->connection);
-        TH_FOLD(connector_crtc_from_atomic(drm_fd, conn->connector_id));
+        uint32_t crtc = connector_crtc_from_atomic(drm_fd, conn->connector_id);
+        TH_FOLD(crtc);
+        if (crtc) {
+            /* Fold the active mode so a modeset (resolution / refresh change) on the
+             * same connector+CRTC binding is detected, not just plug/unplug/rebind. */
+            drmModeCrtc *c = drmModeGetCrtc(drm_fd, crtc);
+            if (c) {
+                TH_FOLD(c->mode_valid);
+                TH_FOLD(c->mode.hdisplay);
+                TH_FOLD(c->mode.vdisplay);
+                TH_FOLD(c->mode.vrefresh);
+                drmModeFreeCrtc(c);
+            }
+        }
         drmModeFreeConnector(conn);
     }
 #undef TH_FOLD

--- a/bindings/rust/libdrmtap-sys/csrc/drm_enumerate.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_enumerate.c
@@ -56,6 +56,32 @@ static uint32_t connector_crtc_from_atomic(int fd, uint32_t connector_id) {
     return crtc_id;
 }
 
+/* Fold the current connector topology (per-connector connection state + bound
+ * CRTC) into a hash. Unlike the raw connector/CRTC counts -- fixed by the GPU
+ * hardware -- this changes when a monitor is plugged/unplugged on an existing
+ * connector or a CRTC is (re)bound by a modeset, which is what hotplug detection
+ * needs. GetConnectorCurrent reads cached kernel state (no forced probe). */
+static uint64_t topology_hash(int drm_fd, drmModeRes *res) {
+    uint64_t h = 1469598103934665603ULL; /* FNV-1a 64-bit offset basis */
+#define TH_FOLD(v) do { h ^= (uint64_t)(uint32_t)(v); h *= 1099511628211ULL; } while (0)
+    TH_FOLD(res->count_connectors);
+    TH_FOLD(res->count_crtcs);
+    for (int i = 0; i < res->count_connectors; i++) {
+        drmModeConnector *conn =
+            drmModeGetConnectorCurrent(drm_fd, res->connectors[i]);
+        if (!conn) {
+            TH_FOLD(res->connectors[i]);
+            continue;
+        }
+        TH_FOLD(conn->connector_id);
+        TH_FOLD(conn->connection);
+        TH_FOLD(connector_crtc_from_atomic(drm_fd, conn->connector_id));
+        drmModeFreeConnector(conn);
+    }
+#undef TH_FOLD
+    return h;
+}
+
 /* ========================================================================= */
 /* Public API                                                                */
 /* ========================================================================= */
@@ -188,9 +214,8 @@ int drmtap_list_displays(drmtap_ctx *ctx, drmtap_display *out, int max_count) {
         drmModeFreeConnector(conn);
     }
 
-    /* Cache counts for hotplug detection */
-    ctx->cached_connector_count = (uint32_t)res->count_connectors;
-    ctx->cached_crtc_count = (uint32_t)res->count_crtcs;
+    /* Cache the topology signature for hotplug detection. */
+    ctx->cached_topology_hash = topology_hash(ctx->drm_fd, res);
 
     drmModeFreeResources(res);
     return found;
@@ -210,15 +235,12 @@ int drmtap_displays_changed(drmtap_ctx *ctx) {
         return -ENODEV;
     }
 
-    int changed = 0;
-    if ((uint32_t)res->count_connectors != ctx->cached_connector_count ||
-        (uint32_t)res->count_crtcs != ctx->cached_crtc_count) {
-        changed = 1;
-    }
-
-    /* Update cache */
-    ctx->cached_connector_count = (uint32_t)res->count_connectors;
-    ctx->cached_crtc_count = (uint32_t)res->count_crtcs;
+    /* Hash the per-connector connection + CRTC binding, not the fixed object
+     * counts: an ordinary monitor plug/unplug on an existing HDMI/DP connector,
+     * and a modeset that rebinds a CRTC, both leave the counts unchanged. */
+    uint64_t h = topology_hash(ctx->drm_fd, res);
+    int changed = (h != ctx->cached_topology_hash);
+    ctx->cached_topology_hash = h;
 
     drmModeFreeResources(res);
     return changed;

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -682,7 +682,15 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     frame->height = fb2->height;
     frame->stride = fb2->pitches[0];
     frame->format = fb2->pixel_format;
-    frame->modifier = fb2->modifier;
+    /* fb2->modifier is only meaningful when the framebuffer was created with the
+     * DRM_MODE_FB_MODIFIERS flag. When the flag is clear the field is undefined
+     * (commonly 0, but garbage on some drivers), and trusting a bogus 0/LINEAR on a
+     * driver that is actually tiling the scanout corrupts the import (the recurring
+     * XR30 / "special fix" class). Report DRM_FORMAT_MOD_INVALID instead so the EGL
+     * import omits the modifier attribute and the driver infers the real layout. */
+    frame->modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                          ? fb2->modifier
+                          : DRM_FORMAT_MOD_INVALID;
     frame->fb_id = fb_id;
     frame->dma_buf_fd = prime_fd;
     frame->data = NULL;
@@ -857,7 +865,17 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     if (!data && !force_egl && frame->dma_buf_fd < 0) return 0;
 
     uint64_t modifier = frame->modifier;
-    int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0);
+    /* INVALID means the FB advertised no modifier (flag clear), so the layout is
+     * unknown. Treat it as linear ONLY when EGL import is unavailable: this is the
+     * CPU fallback for the simple drivers that take that path (virtio, embedded),
+     * where an unknown scanout is in practice linear. When EGL IS available we must
+     * NOT short-circuit to the linear early-return below -- a modern tiling driver
+     * leaves the modifier flag clear on a tiled scanout (the XR30 class), and only
+     * the EGL path further down, which omits the modifier and lets the driver infer
+     * the real layout, decodes it correctly. */
+    int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0 ||
+                     (modifier == DRM_FORMAT_MOD_INVALID &&
+                      !drmtap_gpu_egl_available(ctx)));
 
     /* A linear high-bit-depth / HDR scanout still needs reduction to 8-bit
      * (the early-return below is only safe for 8-bit RGB). */

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -76,6 +76,18 @@ static void drmtap_gem_close(drmtap_ctx *ctx, uint32_t handle) {
     drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
+/* Test hook: DRMTAP_FORCE_MMAP_FAIL=1 makes the fast-path cache-miss drop a
+ * successful CPU mapping so the EGL-detile fd fallback runs on any EGL-capable GPU,
+ * not only a discrete/tiled one that genuinely refuses the mmap. Off by default. */
+static int drmtap_force_mmap_fail(void) {
+    static int v = -1;
+    if (v < 0) {
+        const char *e = getenv("DRMTAP_FORCE_MMAP_FAIL");
+        v = (e && e[0] == '1') ? 1 : 0;
+    }
+    return v;
+}
+
 /* ========================================================================= */
 /* Internal state for a captured frame (stored in frame->_priv)              */
 /* ========================================================================= */
@@ -100,6 +112,33 @@ typedef struct {
  * into ctx->cur_hdr_eotf / cur_hdr_max_nits, for the direct (no-helper) capture
  * path. Mirrors read_hdr_metadata in the helper. Best-effort: any failure leaves
  * it SDR (0), so a non-HDR display just means no tone-mapping. */
+/* Resolve the CRTC bound to a connector via the atomic CRTC_ID property; the
+ * legacy encoder link (drmModeGetEncoder(conn->encoder_id)->crtc_id) reads 0 for
+ * an atomically-bound connector under atomic KMS (Wayland), so an HDR display never
+ * matched its CRTC and never got tone-mapped. Returns 0 if unbound/unavailable. */
+static uint32_t connector_crtc_atomic(int drm_fd, uint32_t connector_id) {
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return 0;
+    }
+    uint32_t crtc = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(drm_fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        if (strcmp(p->name, "CRTC_ID") == 0) {
+            crtc = (uint32_t)props->prop_values[i];
+            drmModeFreeProperty(p);
+            break;
+        }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    return crtc;
+}
+
 static void read_hdr_metadata_direct(drmtap_ctx *ctx, uint32_t crtc_id) {
     ctx->cur_hdr_eotf = 0;
     ctx->cur_hdr_max_nits = 0;
@@ -110,22 +149,19 @@ static void read_hdr_metadata_direct(drmtap_ctx *ctx, uint32_t crtc_id) {
     if (!res) {
         return;
     }
+    /* Match on the atomic CRTC_ID property (see connector_crtc_atomic), not the
+     * legacy encoder link. GetConnectorCurrent reads cached kernel state instead of
+     * forcing a hardware connector probe on every do_grab. */
     uint32_t conn_id = 0;
     for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
         drmModeConnector *conn =
-            drmModeGetConnector(ctx->drm_fd, res->connectors[i]);
+            drmModeGetConnectorCurrent(ctx->drm_fd, res->connectors[i]);
         if (!conn) {
             continue;
         }
-        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
-            drmModeEncoder *enc =
-                drmModeGetEncoder(ctx->drm_fd, conn->encoder_id);
-            if (enc) {
-                if (enc->crtc_id == crtc_id) {
-                    conn_id = conn->connector_id;
-                }
-                drmModeFreeEncoder(enc);
-            }
+        if (conn->connection == DRM_MODE_CONNECTED &&
+            connector_crtc_atomic(ctx->drm_fd, conn->connector_id) == crtc_id) {
+            conn_id = conn->connector_id;
         }
         drmModeFreeConnector(conn);
     }
@@ -469,7 +505,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         ret = drmPrimeHandleToFD(ctx->drm_fd, fb2->handles[0],
                                   O_RDONLY | O_CLOEXEC, &prime_fd);
         if (ret < 0 && (errno == EACCES || errno == EPERM)) {
+            /* Export denied: the capture goes through the helper (which mints its
+             * own handle over IPC) and never adopts this one into priv->gem_handle.
+             * Close the handle GetFB2 just minted, or the needs_helper path -- and
+             * its per-frame V2/V3 success returns -- leaks it. */
             needs_helper = 1;
+            drmtap_gem_close(ctx, fb2->handles[0]);
         } else if (ret < 0) {
             ret = -errno;
             drmtap_set_error(ctx, "drmPrimeHandleToFD failed: %s", strerror(errno));
@@ -794,11 +835,17 @@ cleanup:
 /* DRM fourccs for the high-bit-depth scanout formats we reduce to 8-bit. */
 #define DRMTAP_FMT_XR30 0x30335258u  /* XRGB2101010 */
 #define DRMTAP_FMT_AR30 0x30335241u  /* ARGB2101010 */
+#define DRMTAP_FMT_XB30 0x30334258u  /* XBGR2101010 */
+#define DRMTAP_FMT_AB30 0x30334241u  /* ABGR2101010 */
 #define DRMTAP_FMT_XR48 0x38345258u  /* XRGB16161616 */
 #define DRMTAP_FMT_AR48 0x38345241u  /* ARGB16161616 */
 #define DRMTAP_FMT_XB48 0x38344258u  /* XBGR16161616 */
 #define DRMTAP_FMT_AB48 0x38344241u  /* ABGR16161616 */
 #define DRMTAP_FMT_XR24 0x34325258u  /* XRGB8888 */
+#define DRMTAP_FMT_XR4H 0x48345258u  /* XRGB16161616F (half-float) */
+#define DRMTAP_FMT_AR4H 0x48345241u  /* ARGB16161616F */
+#define DRMTAP_FMT_XB4H 0x48344258u  /* XBGR16161616F */
+#define DRMTAP_FMT_AB4H 0x48344241u  /* ABGR16161616F */
 
 /* Reduce a LINEAR high-bit-depth scanout (10-bit AR30/XR30 or 16-bit
  * XR48/AR48/XB48/AB48) to 8-bit XRGB8888, tone-mapping when the connector
@@ -809,10 +856,13 @@ cleanup:
 static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
                                      drmtap_frame_info *frame) {
     uint32_t fmt = frame->format;
-    int is_ar30 = (fmt == DRMTAP_FMT_XR30 || fmt == DRMTAP_FMT_AR30);
+    int is_ar30 = (fmt == DRMTAP_FMT_XR30 || fmt == DRMTAP_FMT_AR30 ||
+                   fmt == DRMTAP_FMT_XB30 || fmt == DRMTAP_FMT_AB30);
     int is_rgb16 = (fmt == DRMTAP_FMT_XR48 || fmt == DRMTAP_FMT_AR48 ||
                     fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
-    if (!is_ar30 && !is_rgb16) {
+    int is_rgb16f = (fmt == DRMTAP_FMT_XR4H || fmt == DRMTAP_FMT_AR4H ||
+                     fmt == DRMTAP_FMT_XB4H || fmt == DRMTAP_FMT_AB4H);
+    if (!is_ar30 && !is_rgb16 && !is_rgb16f) {
         return 0;  /* 8-bit RGB (or unknown): leave as-is */
     }
 
@@ -834,16 +884,21 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
                     frame->width, frame->height, frame->stride, dst_stride,
                     fmt, DRMTAP_FMT_XR24);
         }
-    } else {
+    } else if (is_rgb16) {
         int bgr = (fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
         ret = drmtap_convert_rgb16(data, ctx->deswizzle_buf,
                 frame->width, frame->height, frame->stride, dst_stride,
                 bgr, ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
+    } else {
+        /* Half-float FP16 (XR4H family): linear-light decode + sRGB re-encode. */
+        int bgr = (fmt == DRMTAP_FMT_XB4H || fmt == DRMTAP_FMT_AB4H);
+        ret = drmtap_convert_rgb16f(data, ctx->deswizzle_buf,
+                frame->width, frame->height, frame->stride, dst_stride, bgr);
     }
     if (ret != 0) return ret;
 
     drmtap_debug_log(ctx, "auto-process: linear %s -> XRGB8888 (%s)",
-                     is_ar30 ? "10-bit" : "16-bit",
+                     is_ar30 ? "10-bit" : (is_rgb16f ? "FP16" : "16-bit"),
                      hdr ? "HDR tone-mapped" : "SDR");
     frame->data = ctx->deswizzle_buf;
     frame->format = DRMTAP_FMT_XR24;
@@ -872,7 +927,12 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
      * NOT short-circuit to the linear early-return below -- a modern tiling driver
      * leaves the modifier flag clear on a tiled scanout (the XR30 class), and only
      * the EGL path further down, which omits the modifier and lets the driver infer
-     * the real layout, decodes it correctly. */
+     * the real layout, decodes it correctly. Tradeoff: a GENUINELY linear flag-clear
+     * scanout on an EGL-capable GPU now takes the EGL round-trip too (it is
+     * indistinguishable from a secretly-tiled one while the flag is clear), losing the
+     * zero-copy path it had before. That is the unavoidable cost of decoding the tiled
+     * case correctly; it does not affect a compositor that advertises modifiers (flag
+     * set, handled above) nor a no-EGL simple driver (linear here). */
     int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0 ||
                      (modifier == DRM_FORMAT_MOD_INVALID &&
                       !drmtap_gpu_egl_available(ctx)));
@@ -976,6 +1036,24 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         return -ENOTSUP;
     }
 
+    /* An INVALID (unknown) modifier reaching this point means the EGL detile did
+     * not run -- no dma-buf fd (helper V2 pixel mode) or EGL unavailable/failed.
+     * INVALID is not a known tiling, so the CPU deswizzle below, which is written
+     * for specific tiled layouts and hardcodes 4 bytes/pixel, cannot decode it and
+     * would mangle a wider (FP16) scanout. Treat an unknown layout as linear -- its
+     * practical case -- and reduce it from the RAW mapping, which handles 8/10/16-bit
+     * correctly. This restores the pre-INVALID behavior for a flag-clear buffer that
+     * used to read back as modifier 0, without diverting it into the tiled deswizzle. */
+    if (modifier == DRM_FORMAT_MOD_INVALID) {
+        int red = reduce_linear_to_xrgb8888(ctx, data, frame);
+        if (red < 0) {
+            return red;
+        }
+        /* red == 1: reduced to XRGB8888 (frame->data repointed). red == 0: already
+         * 8-bit -- the raw linear mapping (frame->data, pre-set by the caller) stands. */
+        return 0;
+    }
+
     /* --- CPU deswizzle for classic tiling (buffer already allocated above) --- */
     const char *driver = ctx->driver_name;
     if (drmtap_gpu_intel_match(driver) ||
@@ -1005,11 +1083,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             frame->data = ctx->deswizzle_buf;
             drmtap_debug_log(ctx, "auto-process: CPU deswizzled to linear");
 
-            /* Reduce 10-bit XR30/AR30 to 8-bit XRGB8888. An HDR10 (PQ) scanout
-             * needs a real tone-map — the naive bit-shift would wash it out; a
-             * plain SDR 10-bit scanout (same fourcc) just gets truncated. */
+            /* Reduce 10-bit X/AR30 and X/AB30 to 8-bit XRGB8888. An HDR10 (PQ)
+             * scanout needs a real tone-map -- the naive bit-shift would wash it
+             * out; a plain SDR 10-bit scanout (same fourcc) just gets truncated.
+             * Both converters read the fourcc and handle the RGB/BGR order. */
             if (frame->format == DRMTAP_FMT_XR30 ||
-                frame->format == DRMTAP_FMT_AR30) {
+                frame->format == DRMTAP_FMT_AR30 ||
+                frame->format == DRMTAP_FMT_XB30 ||
+                frame->format == DRMTAP_FMT_AB30) {
                 int conv;
                 if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
                     drmtap_debug_log(ctx,
@@ -1340,8 +1421,13 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         /* Restage this slot's plane layout before converting (the cache HIT
          * skipped GetFB2, so ctx->fb2_* is otherwise stale). */
         fast_slot_restage_planes(ctx, slot);
-        /* Auto-deswizzle tiled framebuffers + format convert */
-        gpu_auto_process(ctx, frame->data, frame, 0);
+        /* Auto-deswizzle tiled framebuffers + format convert. Propagate a
+         * processing failure instead of returning unprocessed pixels as success
+         * (the unchanged-fb branch above already does this). */
+        int pr = gpu_auto_process(ctx, frame->data, frame, 0);
+        if (pr != 0) {
+            return pr;
+        }
 
         return 0;   /* new frame */
     }
@@ -1414,7 +1500,55 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                       prime_fd, fb2->offsets[0]);
     }
 
+    /* Test hook (drmtap_force_mmap_fail): drop a successful mapping so the EGL fd
+     * fallback below is exercised on a GPU whose scanout IS cpu-mappable. */
+    if (mapped != MAP_FAILED && drmtap_force_mmap_fail()) {
+        munmap(mapped, size);
+        mapped = MAP_FAILED;
+    }
+
     if (mapped == MAP_FAILED) {
+#ifdef HAVE_EGL
+        /* A tiled scanout can refuse a CPU mmap (amdgpu GFX9+, discrete VRAM,
+         * nvidia) yet be fully capturable by EGL-detiling the exported fd, exactly
+         * as do_grab does. Fall back to that instead of dropping the capture. This
+         * frame has no CPU mapping to cache, so no slot is stored; the fd path
+         * re-exports each frame (still cheaper than failing the stream, and the EGL
+         * image cache keyed on the BO inode keeps the import itself amortized). */
+        if (drmtap_gpu_egl_available(ctx)) {
+            frame->data = NULL;
+            frame->dma_buf_fd = prime_fd;
+            frame->width = fb2->width;
+            frame->height = fb2->height;
+            frame->stride = fb2->pitches[0];
+            frame->format = fb2->pixel_format;
+            frame->modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                                  ? fb2->modifier : DRM_FORMAT_MOD_INVALID;
+            frame->fb_id = fb_id;
+            frame->_priv = NULL;
+            int pr = gpu_auto_process(ctx, NULL, frame, 0);
+            /* A LINEAR-modifier scanout takes gpu_auto_process's linear early-return,
+             * which leaves frame->data NULL when it was called with data==NULL (no CPU
+             * mapping): that path assumes the caller already pointed frame->data at the
+             * raw mapping, which we do not have here. Treat a 0-return with no data as a
+             * failure so the caller never gets a success frame with a NULL buffer
+             * (do_grab guards the same case). Only EGL actually produces pixels here. */
+            if (pr == 0 && !frame->data) {
+                pr = -EIO;
+            }
+            /* gpu_auto_process EGL-read the fd back into ctx->deswizzle_buf, so the
+             * fd and handle are no longer needed and nothing is cached for fb_id. */
+            close(prime_fd);
+            frame->dma_buf_fd = -1;  /* prime_fd is closed; don't hand back a stale fd */
+            drmtap_gem_close(ctx, fb2->handles[0]);
+            drmModeFreeFB2(fb2);
+            ctx->fast_last_fb_id = 0;  /* uncached: next call does a fresh setup */
+            if (pr != 0) {
+                return pr;
+            }
+            return 0;
+        }
+#endif
         close(prime_fd);
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);
@@ -1431,7 +1565,13 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].height = fb2->height;
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;
-    ctx->fast_slots[slot].modifier = fb2->modifier;
+    /* Honor the DRM_MODE_FB_MODIFIERS flag (see do_grab): fb2->modifier is undefined
+     * when the flag is clear, so a tiled scanout that omits it must be cached as
+     * DRM_FORMAT_MOD_INVALID -- not the bogus 0 -- or the cached slot would replay it
+     * as linear on every fast-path hit and corrupt the XR30/tiled class this fixes. */
+    ctx->fast_slots[slot].modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                                         ? fb2->modifier
+                                         : DRM_FORMAT_MOD_INVALID;
     /* Capture this fb's plane layout with the slot so a later cache HIT can
      * restage it into ctx->fb2_* (ctx->fb2_* was set from this same fb2 just
      * above, at the "Cache multi-plane info" block). */
@@ -1458,8 +1598,12 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     frame->fb_id = fb_id;
     frame->_priv = NULL;
 
-    /* Auto-deswizzle tiled framebuffers + format convert */
-    gpu_auto_process(ctx, frame->data, frame, 0);
+    /* Auto-deswizzle tiled framebuffers + format convert. Propagate a processing
+     * failure instead of returning unprocessed pixels as success. */
+    int mpr = gpu_auto_process(ctx, frame->data, frame, 0);
+    if (mpr != 0) {
+        return mpr;
+    }
 
     return 0;   /* new frame */
 }
@@ -1537,6 +1681,40 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
     frame->modifier = desc->modifier;
     frame->fb_id = desc->fb_id;
     frame->dma_buf_fd = desc->dma_buf_fd;
+
+    /* The descriptor and its fd cross an IPC boundary and are UNTRUSTED. Validate
+     * the fd BEFORE either conversion path touches it: the EGL import below hands
+     * width/height/stride/offset straight to eglCreateImage with no size check, so
+     * the 0.4.12 fd-type + size bound (previously only in the CPU fallback) must
+     * gate the EGL path too. Only meaningful when an fd is supplied; a cached-fb_id
+     * EGL import carries no untrusted fd. Gates:
+     *   1. Require a genuine DMA-BUF -- immutable in size, so it cannot be shrunk
+     *      between check and use (a memfd/regular file could, faulting the reader).
+     *      dmabuf_sync returns ENOTTY on a non-dma-buf; sync_end closes the probe.
+     *   2. Bound offsets[0] + pitches[0]*height against the real fd size; fail
+     *      CLOSED when the size cannot be determined. */
+    if (desc->dma_buf_fd >= 0) {
+        size_t need = (size_t)desc->pitches[0] * desc->height;
+        if (dmabuf_sync_start(desc->dma_buf_fd) != 0) {
+            drmtap_set_error(ctx, "convert: fd is not a dma-buf");
+            return -EINVAL;
+        }
+        off_t fd_size = lseek(desc->dma_buf_fd, 0, SEEK_END);
+        if (fd_size <= 0) {
+            struct stat st;
+            if (fstat(desc->dma_buf_fd, &st) == 0) {
+                fd_size = st.st_size;
+            }
+        }
+        dmabuf_sync_end(desc->dma_buf_fd);
+        if (fd_size <= 0 ||
+            (uint64_t)desc->offsets[0] + (uint64_t)need > (uint64_t)fd_size) {
+            drmtap_set_error(ctx, "convert: descriptor exceeds dma-buf size "
+                             "(fd_size=%lld, need offset %u + %zu)",
+                             (long long)fd_size, desc->offsets[0], need);
+            return -EINVAL;
+        }
+    }
 
 #ifdef HAVE_EGL
     /* GPU path first: EGL imports the fd (or reuses the fb_id-cached import)

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -52,6 +52,7 @@
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <drm_fourcc.h>  /* DRM_FORMAT_MOD_INVALID */
 
 #ifdef HAVE_LIBCAP
 #include <sys/capability.h>
@@ -629,7 +630,15 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     meta.stride = fb2->pitches[0];
     meta.format = fb2->pixel_format;
     meta.fb_id = fb_id;
-    meta.modifier = fb2->modifier;
+    /* fb2->modifier is valid only when the FB carries the DRM_MODE_FB_MODIFIERS flag;
+     * otherwise it is undefined. Report DRM_FORMAT_MOD_INVALID when the flag is clear
+     * so the parent's EGL import infers the real layout instead of trusting a bogus
+     * 0/LINEAR on a driver that is actually tiling (the XR30 class). INVALID is
+     * non-zero, so the export-vs-dumb-map branch below correctly routes it to the
+     * EGL-import path (with the dumb-map fallback still intact if export fails). */
+    meta.modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                        ? fb2->modifier
+                        : DRM_FORMAT_MOD_INVALID;
 
     /* HDR transfer + peak from the connector, so the library can decide whether
      * to tone-map (vs a plain bit-depth reduction for SDR 10-bit). */
@@ -692,7 +701,13 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
             return send_error(sock, "virgl DMA-BUF export failed "
                                     "(no usable CPU readback for a host scanout)");
         }
-        /* Otherwise fall through to the dumb-map pixel path. */
+        /* Otherwise fall through to the dumb-map pixel path. This is safe even for an
+         * INVALID (unknown-layout) modifier: a driver that TILES the scanout also
+         * implements PRIME export, so the export above would have succeeded and we
+         * would not be here. A buffer that reaches this fallback (export failed) is in
+         * practice a LINEAR scanout on a non-PRIME driver (plain virtio-gpu guest RAM,
+         * simpledrm, legacy AddFB), whose dumb-mapped pixels the parent reconstructs
+         * correctly from stride/format/dims. */
         fprintf(stderr,
             "drmtap-helper: drmPrimeHandleToFD failed (%d), falling back to pixels\n",
             prime_ret);
@@ -842,6 +857,14 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "drmtap-helper: failed to open %s: %s\n",
                 device, strerror(errno));
         return 1;
+    }
+    /* Defensively drop DRM master. This helper only reads scanout (GetFB2 /
+     * PrimeHandleToFD) and never modesets, but if it opened the card node while no
+     * client held master the kernel made it master implicitly, which would then block
+     * a compositor from (re)acquiring master on a VT switch -> a black/frozen display.
+     * drmDropMaster returns 0 only when we actually held master; otherwise no-op. */
+    if (drmDropMaster(drm_fd) == 0) {
+        fprintf(stderr, "drmtap-helper: dropped implicit DRM master on %s\n", device);
     }
     drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
 

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -194,7 +194,6 @@ static int install_seccomp(void) {
      * even though it holds CAP_SYS_ADMIN. */
     int allowed[] = {
         SCMP_SYS(read), SCMP_SYS(write), SCMP_SYS(close),
-        SCMP_SYS(ioctl),       /* DRM ioctls */
         SCMP_SYS(sendto),      /* send() */
         SCMP_SYS(sendmsg),     /* sendmsg() for SCM_RIGHTS */
         SCMP_SYS(recvfrom),    /* recv() */
@@ -215,6 +214,25 @@ static int install_seccomp(void) {
         if (rc != 0) {
             seccomp_release(ctx);
             fprintf(stderr, "drmtap-helper: seccomp_rule_add failed: %s\n",
+                    strerror(-rc));
+            return -1;
+        }
+    }
+
+    /* ioctl: allow ONLY the DRM ioctl type ('d', bits 8-15 of the request). The
+     * helper issues nothing but DRM ioctls on its single DRM fd (KMS, PRIME, GEM
+     * close, dumb map, VIRTGPU), so a memory-corrupted helper cannot reach an
+     * unrelated ioctl (TIOCSTI console injection, terminal control, etc.). Matching
+     * the type byte rather than enumerating every DRM command keeps this robust
+     * across drivers and libdrm versions without risking a KILL on a legitimate DRM
+     * ioctl we forgot to list. */
+    {
+        int rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ioctl), 1,
+                                  SCMP_A1(SCMP_CMP_MASKED_EQ, 0xFF00u,
+                                          (unsigned)'d' << 8));
+        if (rc != 0) {
+            seccomp_release(ctx);
+            fprintf(stderr, "drmtap-helper: seccomp ioctl rule failed: %s\n",
                     strerror(-rc));
             return -1;
         }
@@ -246,6 +264,19 @@ static int send_all(int sock, const void *buf, size_t len) {
 }
 static int recv_all(int sock, void *buf, size_t len) {
     return wire_recv_all(sock, buf, len);
+}
+
+/* drmModeGetFB2 mints a fresh GEM handle that the caller owns; if it is not
+ * closed, this long-running privileged helper leaks one kernel handle (and pins
+ * the underlying BO) on every grab and every cursor poll. Close it on every path.
+ * Harmless for handle 0. The exported DMA-BUF fd keeps its own BO reference, so
+ * closing the handle after PRIME export is safe. */
+static void helper_gem_close(int drm_fd, uint32_t handle) {
+    if (handle == 0) {
+        return;
+    }
+    struct drm_gem_close gc = { .handle = handle };
+    drmIoctl(drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
 // Send error: metadata with data_size=0. For logical/validation failures where
@@ -361,6 +392,7 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
      * a padded cursor is not sent sheared. The width cap precedes width*4 so
      * that product cannot overflow. */
     if (!(cw <= 256 && ch <= 256 && cstride != 0 && cstride >= cw * 4)) {
+        helper_gem_close(drm_fd, chandle);
         send_all(sock, &meta, sizeof(meta));  /* visible=0 */
         return 0;
     }
@@ -377,6 +409,7 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
         if (prime_fd >= 0) {
             close(prime_fd);
         }
+        helper_gem_close(drm_fd, chandle);
         send_all(sock, &meta, sizeof(meta));  /* visible=0 (couldn't read) */
         return 0;
     }
@@ -394,6 +427,7 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
     }
     munmap(mapped, map_size);
     close(prime_fd);
+    helper_gem_close(drm_fd, chandle);
 
     meta.visible = 1;
     meta.data_size = (uint32_t)tight;
@@ -405,6 +439,33 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
 /* ========================================================================= */
 /* DRM capture (privileged) — reads pixels, sends via socket                 */
 /* ========================================================================= */
+
+/* Resolve the CRTC bound to a connector via the atomic CRTC_ID property. The
+ * legacy encoder link (drmModeGetEncoder(conn->encoder_id)->crtc_id) reads 0 for
+ * an atomically-bound / compositor-managed connector, so on Wayland an HDR display
+ * never matched its CRTC and never got tone-mapped. Returns 0 if unbound. */
+static uint32_t helper_connector_crtc(int drm_fd, uint32_t connector_id) {
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return 0;
+    }
+    uint32_t crtc = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(drm_fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        if (strcmp(p->name, "CRTC_ID") == 0) {
+            crtc = (uint32_t)props->prop_values[i];
+            drmModeFreeProperty(p);
+            break;
+        }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    return crtc;
+}
 
 /* Read the HDR transfer function + peak luminance advertised on the connector
  * driving `crtc_id`. Sets *eotf to the DRM EOTF (0 = SDR / none) and *max_nits
@@ -423,21 +484,19 @@ static void read_hdr_metadata(int drm_fd, uint32_t crtc_id,
     if (!res) {
         return;
     }
-    /* Map the CRTC back to its connected connector via the encoder. */
+    /* Map the CRTC back to its connected connector via the atomic CRTC_ID property
+     * (see helper_connector_crtc). GetConnectorCurrent reads cached kernel state
+     * instead of forcing a hardware connector probe on every captured frame. */
     uint32_t conn_id = 0;
     for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
-        drmModeConnector *conn = drmModeGetConnector(drm_fd, res->connectors[i]);
+        drmModeConnector *conn =
+            drmModeGetConnectorCurrent(drm_fd, res->connectors[i]);
         if (!conn) {
             continue;
         }
-        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
-            drmModeEncoder *enc = drmModeGetEncoder(drm_fd, conn->encoder_id);
-            if (enc) {
-                if (enc->crtc_id == crtc_id) {
-                    conn_id = conn->connector_id;
-                }
-                drmModeFreeEncoder(enc);
-            }
+        if (conn->connection == DRM_MODE_CONNECTED &&
+            helper_connector_crtc(drm_fd, conn->connector_id) == crtc_id) {
+            conn_id = conn->connector_id;
         }
         drmModeFreeConnector(conn);
     }
@@ -481,6 +540,50 @@ static void read_hdr_metadata(int drm_fd, uint32_t crtc_id,
     drmModeFreeObjectProperties(props);
 }
 
+/* A plane's 'type' (PRIMARY/OVERLAY/CURSOR) is fixed for the life of the device,
+ * so probe it once and cache the primary plane ids instead of re-reading the
+ * property list for every plane on every captured frame. The helper serves a single
+ * persistent drm_fd, so a file-static cache is correct. */
+static int plane_is_primary(int drm_fd, uint32_t plane_id) {
+    static uint32_t primary_ids[32];
+    static int primary_count = -1;  /* -1 = not probed yet */
+    if (primary_count < 0) {
+        primary_count = 0;
+        drmModePlaneRes *pr = drmModeGetPlaneResources(drm_fd);
+        if (pr) {
+            const int cap = (int)(sizeof(primary_ids) / sizeof(primary_ids[0]));
+            for (uint32_t i = 0; i < pr->count_planes && primary_count < cap; i++) {
+                drmModeObjectProperties *props = drmModeObjectGetProperties(
+                    drm_fd, pr->planes[i], DRM_MODE_OBJECT_PLANE);
+                if (!props) {
+                    continue;
+                }
+                for (uint32_t p = 0; p < props->count_props; p++) {
+                    drmModePropertyRes *prop =
+                        drmModeGetProperty(drm_fd, props->props[p]);
+                    if (!prop) {
+                        continue;
+                    }
+                    if (strcmp(prop->name, "type") == 0 &&
+                        props->prop_values[p] == DRM_PLANE_TYPE_PRIMARY &&
+                        primary_count < cap) {
+                        primary_ids[primary_count++] = pr->planes[i];
+                    }
+                    drmModeFreeProperty(prop);
+                }
+                drmModeFreeObjectProperties(props);
+            }
+            drmModeFreePlaneResources(pr);
+        }
+    }
+    for (int i = 0; i < primary_count; i++) {
+        if (primary_ids[i] == plane_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Grab current framebuffer. Helper reads pixels in its own process
 // (where dumb_mmap returns fresh data) and sends them via the socket.
 static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virtio) {
@@ -510,24 +613,8 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
         /* Check for active framebuffer */
         if (plane->fb_id != 0) {
-            /* Check plane type — prefer PRIMARY */
-            drmModeObjectProperties *props = drmModeObjectGetProperties(
-                drm_fd, plane->plane_id, DRM_MODE_OBJECT_PLANE);
-            int is_primary = 0;
-            if (props) {
-                for (uint32_t p = 0; p < props->count_props; p++) {
-                    drmModePropertyRes *prop = drmModeGetProperty(
-                        drm_fd, props->props[p]);
-                    if (prop) {
-                        if (strcmp(prop->name, "type") == 0 &&
-                            props->prop_values[p] == DRM_PLANE_TYPE_PRIMARY) {
-                            is_primary = 1;
-                        }
-                        drmModeFreeProperty(prop);
-                    }
-                }
-                drmModeFreeObjectProperties(props);
-            }
+            /* Check plane type — prefer PRIMARY (cached; the type is static). */
+            int is_primary = plane_is_primary(drm_fd, plane->plane_id);
 
             if (is_primary || fb_id == 0) {
                 fb_id = plane->fb_id;
@@ -570,6 +657,9 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
      * 8K BGRA frame (~126 MB, well under UINT32_MAX). */
     if (fb2->pitches[0] == 0 || fb2->height == 0 ||
         (size_t)fb2->height > ((size_t)7680 * 4320 * 4) / fb2->pitches[0]) {
+        /* This early return is BEFORE the gem_handle assignment + out: label, so
+         * close the just-minted handle here or the reject path leaks it. */
+        helper_gem_close(drm_fd, fb2->handles[0]);
         drmModeFreeFB2(fb2);
         return send_error(sock, "rejecting framebuffer geometry (too large)");
     }
@@ -692,14 +782,15 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
             meta.data_size = 0;  /* no pixel data follows */
             ret = send_fd(sock, prime_fd, &meta, sizeof(meta));
             close(prime_fd);
-            return ret;
+            goto out;
         }
         /* Export failed. For a confirmed virgl scanout the dumb-map fallback
          * below would read back black (host-side resource), so fail closed
          * rather than send a bogus all-black frame. */
         if (virtio_virgl) {
-            return send_error(sock, "virgl DMA-BUF export failed "
-                                    "(no usable CPU readback for a host scanout)");
+            ret = send_error(sock, "virgl DMA-BUF export failed "
+                                   "(no usable CPU readback for a host scanout)");
+            goto out;
         }
         /* Otherwise fall through to the dumb-map pixel path. This is safe even for an
          * INVALID (unknown-layout) modifier: a driver that TILES the scanout also
@@ -718,12 +809,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     struct drm_mode_map_dumb map = {0};
     map.handle = gem_handle;
     if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
-        return send_error_errno(sock, "MODE_MAP_DUMB failed");
+        ret = send_error_errno(sock, "MODE_MAP_DUMB failed");
+        goto out;
     }
     mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
                   drm_fd, map.offset);
     if (mapped == MAP_FAILED) {
-        return send_error_errno(sock, "mmap failed");
+        ret = send_error_errno(sock, "mmap failed");
+        goto out;
     }
     meta.flags = 0;
     meta.data_size = (uint32_t)mapped_size;
@@ -755,6 +848,8 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     /* Cleanup — munmap but DON'T close drm_fd (it's persistent). */
     munmap(mapped, mapped_size);
 
+out:
+    helper_gem_close(drm_fd, gem_handle);
     return ret;
 }
 
@@ -816,11 +911,10 @@ int main(int argc, char *argv[]) {
         device = argv[1];
     }
 
-    /* Also check DRM_DEVICE env var */
-    const char *env_dev = getenv("DRM_DEVICE");
-    if (env_dev) {
-        device = env_dev;
-    }
+    /* The device path comes solely from argv[1] -- the value the library selected
+     * and passed. A CAP_SYS_ADMIN process must not take device selection from the
+     * environment (the library itself ignores DRM_DEVICE when privileged, since
+     * 0.4.11), so DRM_DEVICE is deliberately NOT honored here. */
 
     /* The device path is attacker-influenceable (argv / DRM_DEVICE) and we run
      * with CAP_SYS_ADMIN, so refuse anything that does not canonicalize under

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -252,6 +252,22 @@ drmtap_ctx *drmtap_open(const drmtap_config *config) {
         /* If fcntl fails, keep the original fd (best effort) */
     }
 
+    /* Defensively drop DRM master -- but ONLY when we are privileged (root /
+     * CAP_SYS_ADMIN). We only READ scanout and never modeset, so if a PRIVILEGED
+     * process opened the node while no client held master (e.g. an unattended capture
+     * service that started at boot before the compositor), the kernel granted it
+     * implicit master, which would then block the compositor from acquiring master on
+     * a VT switch -> a black/frozen display; dropping it is safe there because
+     * drmModeGetFB2 still returns handles via CAP_SYS_ADMIN. An UNPRIVILEGED caller,
+     * by contrast, has no CAP_SYS_ADMIN and RELIES on that implicit master for
+     * drmModeGetFB2 to return framebuffer handles at all, so it must keep it -- do
+     * not drop. drmDropMaster returns 0 only when we actually held master; when a
+     * compositor already holds it (the normal desktop case) it is a harmless no-op. */
+    if ((geteuid() == 0 || getuid() == 0) &&
+        drmDropMaster(ctx->drm_fd) == 0) {
+        drmtap_debug_log(ctx, "dropped implicit DRM master on %s", ctx->device_path);
+    }
+
     /* Detect GPU driver */
     detect_driver(ctx);
 

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -23,11 +23,37 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <sys/syscall.h>
+#include <linux/capability.h>
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
 #include "drmtap_internal.h"
+
+/* True if this thread holds CAP_SYS_ADMIN in its effective set. drmModeGetFB2
+ * returns framebuffer handles without DRM master only for a caller that holds
+ * CAP_SYS_ADMIN; a process running as uid 0 that has dropped CAP_SYS_ADMIN does
+ * NOT qualify and relies on implicit master exactly like an unprivileged caller.
+ * The raw capget syscall is used so the library links no libcap and adds nothing
+ * to the DT_NEEDED of the .so the privileged service dlopens. On any error the
+ * caller is treated as unprivileged (keep master), which is the safe default. */
+static int drmtap_have_cap_sys_admin(void) {
+    struct __user_cap_header_struct hdr = {
+        .version = _LINUX_CAPABILITY_VERSION_3,
+        .pid = 0, /* 0 == self */
+    };
+    struct __user_cap_data_struct data[2] = {{0, 0, 0}, {0, 0, 0}};
+    if (syscall(SYS_capget, &hdr, data) != 0) {
+        /* capget is unavailable (e.g. a seccomp filter denies the syscall while
+         * still permitting getuid). Fall back to the uid check so a genuine root
+         * capture service still drops master -- this matches the 0.4.13 gate and
+         * avoids regressing the VT-switch blackout fix when capget is filtered. */
+        return (geteuid() == 0 || getuid() == 0);
+    }
+    /* CAP_SYS_ADMIN (21) lives in the first 32-bit word. */
+    return (data[0].effective & (1u << CAP_SYS_ADMIN)) != 0;
+}
 
 /* Error string for when ctx is NULL (from failed drmtap_open). Thread-local so
  * concurrent NULL-ctx failures on different threads don't race on one buffer. */
@@ -252,18 +278,19 @@ drmtap_ctx *drmtap_open(const drmtap_config *config) {
         /* If fcntl fails, keep the original fd (best effort) */
     }
 
-    /* Defensively drop DRM master -- but ONLY when we are privileged (root /
-     * CAP_SYS_ADMIN). We only READ scanout and never modeset, so if a PRIVILEGED
-     * process opened the node while no client held master (e.g. an unattended capture
-     * service that started at boot before the compositor), the kernel granted it
-     * implicit master, which would then block the compositor from acquiring master on
-     * a VT switch -> a black/frozen display; dropping it is safe there because
-     * drmModeGetFB2 still returns handles via CAP_SYS_ADMIN. An UNPRIVILEGED caller,
-     * by contrast, has no CAP_SYS_ADMIN and RELIES on that implicit master for
-     * drmModeGetFB2 to return framebuffer handles at all, so it must keep it -- do
-     * not drop. drmDropMaster returns 0 only when we actually held master; when a
+    /* Defensively drop DRM master -- but ONLY when we hold CAP_SYS_ADMIN. We only
+     * READ scanout and never modeset, so if a process holding CAP_SYS_ADMIN opened
+     * the node while no client held master (e.g. an unattended capture service that
+     * started at boot before the compositor), the kernel granted it implicit master,
+     * which would then block the compositor from acquiring master on a VT switch ->
+     * a black/frozen display; dropping it is safe there because drmModeGetFB2 still
+     * returns handles via CAP_SYS_ADMIN. A caller WITHOUT CAP_SYS_ADMIN -- including a
+     * uid-0 process that dropped it -- RELIES on that implicit master for drmModeGetFB2
+     * to return framebuffer handles at all, so it must keep it. The gate is the
+     * capability, not the uid: uid 0 without CAP_SYS_ADMIN cannot use GetFB2 after
+     * losing master. drmDropMaster returns 0 only when we actually held master; when a
      * compositor already holds it (the normal desktop case) it is a harmless no-op. */
-    if ((geteuid() == 0 || getuid() == 0) &&
+    if (drmtap_have_cap_sys_admin() &&
         drmDropMaster(ctx->drm_fd) == 0) {
         drmtap_debug_log(ctx, "dropped implicit DRM master on %s", ctx->device_path);
     }

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -175,9 +175,24 @@ int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame);
 /**
  * @brief Capture a frame — fast persistent-mmap path.
  *
- * Like drmtap_grab_mapped() but keeps the mmap/GEM handle/prime fd alive
- * between calls. Uses fb_id to detect compositor page flips — if the
- * framebuffer hasn't changed, returns 1 immediately (~0.1ms instead of ~18ms).
+ * Like drmtap_grab_mapped() but keeps the mmap/GEM handle/prime fd alive between
+ * calls, so a repeat capture of the same framebuffer skips the GetFB2 / PRIME
+ * export / mmap setup (about 1 ioctl instead of ~7 syscalls). It ALWAYS re-reads
+ * the current scanout and returns it as a fresh frame (return 0): a compositor can
+ * render into the same framebuffer without a page flip, so treating an unchanged
+ * fb_id as "skip" would miss content updates. It therefore never returns 1.
+ *
+ * Identity is keyed on fb_id: this path assumes a stable fb_id denotes the same
+ * scanout buffer between captures. If the environment destroys a framebuffer and
+ * recycles its id onto a different buffer while it is being captured (uncommon in
+ * steady-state compositing, but possible across a resolution change), re-open or
+ * use drmtap_grab_mapped(), which re-exports every frame.
+ *
+ * If the scanout cannot be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia) and
+ * an EGL backend is available, the call transparently falls back to EGL-detiling
+ * the exported fd instead of returning -ENOMEM. Such a frame is not cached — the
+ * fd is re-exported each grab — and -ENOMEM is returned only when no EGL fallback
+ * is possible.
  *
  * The returned frame->data pointer is valid until the NEXT call to this
  * function OR until drmtap_close(). Do NOT call drmtap_frame_release()
@@ -185,8 +200,7 @@ int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame);
  *
  * @param ctx   Capture context
  * @param frame Output frame info (caller-allocated, reused between calls)
- * @return 0 = new frame captured, 1 = same as last call (unchanged),
- *         negative errno on error
+ * @return 0 = frame captured, negative errno on error
  */
 int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame);
 
@@ -334,13 +348,18 @@ drmtap_ctx *drmtap_open_render(const char *render_node);
  * thread. The EGL state and its cached imports are thread-local; closing on a
  * different thread cannot release them and would strand the cached buffers.
  *
- * When no GPU path is usable the conversion falls back to a CPU mmap +
- * deswizzle of the fd (same pipeline as the in-process grab). The descriptor
- * and fd are treated as untrusted: the geometry is validated, the fd MUST be a
+ * The descriptor and its fd cross an IPC boundary and are treated as untrusted.
+ * Whenever desc->dma_buf_fd >= 0 the fd is validated UP FRONT, before EITHER
+ * conversion path touches it: the geometry is validated, the fd MUST be a
  * genuine DMA-BUF (a non-dma-buf fd is rejected -- only an immutable dma-buf is
  * safe to mmap and read without a truncate-mid-read fault), and it must be
  * large enough to back the declared frame (offset + stride*height); anything
- * else returns -EINVAL rather than faulting.
+ * else returns -EINVAL rather than faulting. This gates the EGL import — which
+ * would otherwise reach eglCreateImage unbounded — as well as the CPU fallback.
+ *
+ * When no GPU path is usable the conversion falls back to a CPU mmap +
+ * deswizzle of the fd (same pipeline as the in-process grab), which repeats the
+ * same size check.
  *
  * @param ctx   Context from drmtap_open_render() (or any context with a
  *              usable EGL backend)
@@ -451,7 +470,7 @@ int drmtap_deswizzle(const void *src, void *dst,
  * @brief Convert between pixel formats.
  *
  * Supported conversions:
- *   - XR30/AR30 (10-bit) → XRGB8888/ARGB8888
+ *   - XR30/AR30/XB30/AB30 (10-bit, RGB or BGR order) → XRGB8888/ARGB8888
  *   - ABGR8888 → ARGB8888/XRGB8888
  *   - Same format → copy
  *
@@ -463,7 +482,8 @@ int drmtap_deswizzle(const void *src, void *dst,
  * @param dst_stride Destination stride (bytes per row)
  * @param src_format Source DRM fourcc (e.g., DRM_FORMAT_XRGB2101010)
  * @param dst_format Destination DRM fourcc (e.g., DRM_FORMAT_XRGB8888)
- * @return 0 on success, -ENOTSUP if conversion not supported
+ * @return 0 on success, -ENOTSUP if conversion not supported, -EINVAL on
+ *         NULL/zero-size arguments or a src/dst stride narrower than width*4
  */
 int drmtap_convert_format(const void *src, void *dst,
                           uint32_t width, uint32_t height,
@@ -481,7 +501,8 @@ int drmtap_convert_format(const void *src, void *dst,
  * HDR_OUTPUT_METADATA, not from the pixel format alone — XR30/AR30 is also used
  * for plain SDR 10-bit).
  *
- * Supported src_format: XR30/AR30 (ARGB2101010). Others return -ENOTSUP.
+ * Supported src_format: XR30/AR30 and XB30/AB30 (X/ARGB2101010 and
+ * X/ABGR2101010). Others return -ENOTSUP.
  *
  * @param src        Source pixel data
  * @param dst        Destination buffer (XRGB8888)
@@ -489,7 +510,8 @@ int drmtap_convert_format(const void *src, void *dst,
  * @param height     Frame height in pixels
  * @param src_stride Source stride (bytes per row)
  * @param dst_stride Destination stride (bytes per row)
- * @param src_format Source DRM fourcc (DRM_FORMAT_XRGB2101010 / ARGB2101010)
+ * @param src_format Source DRM fourcc (DRM_FORMAT_XRGB2101010 / ARGB2101010 /
+ *                   XBGR2101010 / ABGR2101010)
  * @param max_nits   Content/mastering peak luminance for the highlight roll-off
  *                   (0 = a sensible default). Brighter peaks spread highlights
  *                   over more of the top range instead of clipping to white.

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 13
+#define DRMTAP_VERSION_PATCH 14
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -47,8 +47,7 @@ struct drmtap_ctx {
     int is_render_only;
 
     /* Cached resources for hotplug detection */
-    uint32_t cached_connector_count;
-    uint32_t cached_crtc_count;
+    uint64_t cached_topology_hash;  /* per-connector state fold; hotplug/modeset signal */
 
     /* Helper binary */
     char helper_path[512];
@@ -241,5 +240,13 @@ int drmtap_convert_rgb16(const void *src, void *dst,
                          uint32_t width, uint32_t height,
                          uint32_t src_stride, uint32_t dst_stride,
                          int bgr, uint32_t eotf, uint32_t max_nits);
+
+/* Reduce a half-float (FP16) scanout -- XRGB16161616F ('XR4H') and its BGR/alpha
+ * siblings, 8 bytes/pixel -- to 8-bit XRGB8888. FP16 carries linear light, decoded
+ * to linear then re-encoded through the sRGB OETF; HDR highlights (>1.0) clip.
+ * `bgr` selects channel order. (pixel_convert.c) */
+int drmtap_convert_rgb16f(const void *src, void *dst,
+                          uint32_t width, uint32_t height,
+                          uint32_t src_stride, uint32_t dst_stride, int bgr);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -698,6 +698,34 @@ static void ensure_linear_texture(egl_state_t *state, uint32_t w, uint32_t h) {
     state->tex_height = h;
 }
 
+/* True for a scanout fourcc carrying more than 8 bits per channel: the 10-bit
+ * XR30 family and the 16-bit XR48 family (integer and half-float). Such a buffer
+ * must NOT be reinterpreted as XRGB8888 during import retry -- that would sample it
+ * at the wrong bit depth (and, for the 16-bit formats, the wrong row width) and
+ * hand back a garbage frame reported as success. */
+static int egl_fourcc_high_bit_depth(uint32_t fourcc) {
+    switch (fourcc) {
+    /* 10-bit 2:10:10:10 */
+    case fourcc_code('X', 'R', '3', '0'):
+    case fourcc_code('X', 'B', '3', '0'):
+    case fourcc_code('A', 'R', '3', '0'):
+    case fourcc_code('A', 'B', '3', '0'):
+    /* 16-bit integer */
+    case fourcc_code('X', 'R', '4', '8'):
+    case fourcc_code('X', 'B', '4', '8'):
+    case fourcc_code('A', 'R', '4', '8'):
+    case fourcc_code('A', 'B', '4', '8'):
+    /* 16-bit half-float */
+    case fourcc_code('X', 'R', '4', 'H'):
+    case fourcc_code('X', 'B', '4', 'H'):
+    case fourcc_code('A', 'R', '4', 'H'):
+    case fourcc_code('A', 'B', '4', 'H'):
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 /* Import a DMA-BUF as an EGLImage, retrying with progressively simpler
  * attribute sets (XRGB8888 keeping the modifier, then XRGB8888 alone) the way
  * some drivers need. CCS auxiliary planes come from ctx->fb2_*. Returns
@@ -784,6 +812,19 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
                          first_err, (const char *)&fourcc,
                          (unsigned long)modifier);
 
+        /* The XRGB8888 retries below reinterpret the buffer as 8-bit while keeping
+         * the source stride. That only makes sense for a genuine 8-bit scanout whose
+         * exact fourcc the driver does not recognize. For a high-bit-depth source
+         * (10-bit XR30 / 16-bit XR48 family) it would sample the wrong bit depth and
+         * return corruption as success, so fail the import instead: the caller then
+         * reduces the real bit depth from the raw mapping on the CPU. */
+        if (egl_fourcc_high_bit_depth(fourcc)) {
+            drmtap_debug_log(ctx, "egl: no XRGB8888 retry for high-bit-depth "
+                             "fourcc %.4s (would corrupt); failing import so the "
+                             "CPU reduce path runs", (const char *)&fourcc);
+            return EGL_NO_IMAGE_KHR;
+        }
+
         /* Retry with XRGB8888 but keep modifier — the driver needs
          * the modifier for detiling but may support 8-bit import */
         uint32_t xrgb8888 = DRM_FORMAT_XRGB8888;
@@ -798,7 +839,7 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
         retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_FD_EXT;
         retry_attribs[ri++] = dma_buf_fd;
         retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
-        retry_attribs[ri++] = 0;
+        retry_attribs[ri++] = (EGLint)ctx->fb2_offsets[0];
         retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
         retry_attribs[ri++] = (EGLint)stride;
         if (modifier != DRM_FORMAT_MOD_INVALID) {
@@ -826,7 +867,7 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
             retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_FD_EXT;
             retry_attribs[ri++] = dma_buf_fd;
             retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
-            retry_attribs[ri++] = 0;
+            retry_attribs[ri++] = (EGLint)ctx->fb2_offsets[0];
             retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
             retry_attribs[ri++] = (EGLint)stride;
             retry_attribs[ri++] = EGL_NONE;
@@ -1006,7 +1047,10 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     }
     if (!eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                         state.context)) {
+        /* Without a current context every GL call below is a no-op that leaves
+         * the output buffer undefined; fail instead of returning garbage. */
         drmtap_debug_log(NULL, "EGL: eglMakeCurrent in convert failed: 0x%x", eglGetError());
+        return -EIO;
     }
 
     /* ── Import-once: EGLImage cache keyed by fb_id ── */
@@ -1190,7 +1234,16 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     }
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
                  ctx->deswizzle_buf);
-    drmtap_debug_log(NULL, "EGL: glReadPixels done, gl_err=0x%x", glGetError());
+    /* A GL error across the render + readback (notably GL_CONTEXT_LOST after a GPU
+     * reset/TDR) means deswizzle_buf holds stale or undefined pixels. Fail closed
+     * instead of returning them as a valid frame. This glGetError also drains the
+     * error state so the next convert starts clean. */
+    GLenum gl_err = glGetError();
+    if (gl_err != GL_NO_ERROR) {
+        drmtap_debug_log(NULL, "EGL: GL error 0x%x across convert, failing", gl_err);
+        ret = -EIO;
+        goto cleanup;
+    }
 
     /* NOTE: CPU horizontal flip removed. The EGL DMA-BUF import with
      * standard texcoords (no shader manipulation) produces correct

--- a/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
+++ b/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
@@ -225,7 +225,7 @@ static int deswizzle_nvidia_x_tiled(const void *src, void *dst,
 static void convert_ar30_to_xrgb8888(const void *src, void *dst,
                                      uint32_t width, uint32_t height,
                                      uint32_t src_stride,
-                                     uint32_t dst_stride) {
+                                     uint32_t dst_stride, int bgr) {
     for (uint32_t y = 0; y < height; y++) {
         const uint32_t *s = (const uint32_t *)
             ((const uint8_t *)src + y * src_stride);
@@ -234,9 +234,13 @@ static void convert_ar30_to_xrgb8888(const void *src, void *dst,
 
         for (uint32_t x = 0; x < width; x++) {
             uint32_t pixel = s[x];
-            uint8_t r = (uint8_t)((pixel >> 22) & 0xFF);  /* [29:20] >> 2 */
-            uint8_t g = (uint8_t)((pixel >> 12) & 0xFF);  /* [19:10] >> 2 */
-            uint8_t b = (uint8_t)((pixel >> 2) & 0xFF);   /* [9:0] >> 2 */
+            /* Top 8 bits of each 10-bit channel. RGB: R[29:20] G[19:10] B[9:0];
+             * BGR (XB30/AB30) swaps the two outer channels. */
+            uint8_t c_hi = (uint8_t)((pixel >> 22) & 0xFF);  /* [29:20] >> 2 */
+            uint8_t g = (uint8_t)((pixel >> 12) & 0xFF);     /* [19:10] >> 2 */
+            uint8_t c_lo = (uint8_t)((pixel >> 2) & 0xFF);   /* [9:0] >> 2 */
+            uint8_t r = bgr ? c_lo : c_hi;
+            uint8_t b = bgr ? c_hi : c_lo;
             d[x] = (0xFFu << 24) | ((uint32_t)r << 16) |
                    ((uint32_t)g << 8) | b;
         }
@@ -379,9 +383,11 @@ int drmtap_deswizzle(const void *src, void *dst,
 #define DRMTAP_SDR_WHITE_NITS 203.0
 
 #define DRMTAP_PQ_LUT_N   1024    /* one entry per 10-bit code value */
+#define DRMTAP_PQ_LUT16_N 65536   /* one entry per 16-bit code value */
 #define DRMTAP_SRGB_LUT_N 4096    /* linear [0,1] -> 8-bit sRGB */
 
-static float   g_pq_lut[DRMTAP_PQ_LUT_N];      /* code -> luminance (nits) */
+static float   g_pq_lut[DRMTAP_PQ_LUT_N];      /* 10-bit code -> luminance (nits) */
+static float   g_pq_lut16[DRMTAP_PQ_LUT16_N];  /* 16-bit code -> luminance (nits) */
 static uint8_t g_srgb_lut[DRMTAP_SRGB_LUT_N];  /* linear [0,1] -> 8-bit sRGB */
 static pthread_once_t g_hdr_once = PTHREAD_ONCE_INIT;
 
@@ -413,6 +419,9 @@ static double srgb_oetf(double c) {
 static void hdr_lut_init(void) {
     for (int i = 0; i < DRMTAP_PQ_LUT_N; i++) {
         g_pq_lut[i] = (float)pq_eotf_nits((double)i / (DRMTAP_PQ_LUT_N - 1));
+    }
+    for (int i = 0; i < DRMTAP_PQ_LUT16_N; i++) {
+        g_pq_lut16[i] = (float)pq_eotf_nits((double)i / (DRMTAP_PQ_LUT16_N - 1));
     }
     for (int i = 0; i < DRMTAP_SRGB_LUT_N; i++) {
         double s = srgb_oetf((double)i / (DRMTAP_SRGB_LUT_N - 1));
@@ -479,8 +488,10 @@ int drmtap_tonemap_hdr10(const void *src, void *dst,
     if (!src || !dst || width == 0 || height == 0) {
         return -EINVAL;
     }
-    /* XR30 = XRGB2101010 ('XR30'), AR30 = ARGB2101010 ('AR30'). */
-    if (src_format != 0x30335258u && src_format != 0x30335241u) {
+    /* XR30/AR30 = X/ARGB2101010 (RGB order), XB30/AB30 = X/ABGR2101010 (BGR). */
+    int is_rgb = (src_format == 0x30335258u || src_format == 0x30335241u);
+    int is_bgr = (src_format == 0x30334258u || src_format == 0x30334241u);
+    if (!is_rgb && !is_bgr) {
         return -ENOTSUP;
     }
     /* Both buffers are 4 bytes/pixel; a stride that cannot hold a full row
@@ -500,11 +511,14 @@ int drmtap_tonemap_hdr10(const void *src, void *dst,
         uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
         for (uint32_t x = 0; x < width; x++) {
             uint32_t pixel = s[x];
-            /* 10-bit channels, ARGB2101010: R[29:20] G[19:10] B[9:0]. */
+            /* 10-bit channels. RGB: R[29:20] G[19:10] B[9:0]; BGR swaps the two
+             * outer channels (B[29:20] R[9:0]). */
+            uint32_t c_hi = (pixel >> 20) & 0x3FF;
+            uint32_t c_lo = (pixel)       & 0x3FF;
             uint8_t r, g, b;
-            tonemap_rgb_linear(g_pq_lut[(pixel >> 20) & 0x3FF],
+            tonemap_rgb_linear(g_pq_lut[is_bgr ? c_lo : c_hi],
                                g_pq_lut[(pixel >> 10) & 0x3FF],
-                               g_pq_lut[(pixel)       & 0x3FF],
+                               g_pq_lut[is_bgr ? c_hi : c_lo],
                                peak_n, &r, &g, &b);
             d[x] = (0xFFu << 24) | ((uint32_t)r << 16) |
                    ((uint32_t)g << 8) | b;
@@ -548,9 +562,9 @@ int drmtap_convert_rgb16(const void *src, void *dst,
             uint8_t r8, g8, b8;
             if (hdr) {
                 /* 16-bit PQ -> BT.2020 linear nits -> tone-map -> SDR. */
-                tonemap_rgb_linear(pq_eotf_nits((double)cr / 65535.0),
-                                   pq_eotf_nits((double)cg / 65535.0),
-                                   pq_eotf_nits((double)cb / 65535.0),
+                tonemap_rgb_linear(g_pq_lut16[cr],
+                                   g_pq_lut16[cg],
+                                   g_pq_lut16[cb],
                                    peak_n, &r8, &g8, &b8);
             } else {
                 /* Plain SDR 16-bit -> 8-bit (keep the high byte). */
@@ -565,11 +579,98 @@ int drmtap_convert_rgb16(const void *src, void *dst,
     return 0;
 }
 
+/* IEEE 754 binary16 -> binary32. */
+static float half_to_float(uint16_t h) {
+    uint32_t sign = (uint32_t)(h & 0x8000u) << 16;
+    uint32_t exp = (h >> 10) & 0x1Fu;
+    uint32_t mant = h & 0x3FFu;
+    uint32_t bits;
+    if (exp == 0) {
+        if (mant == 0) {
+            bits = sign;                       /* +/-0 */
+        } else {                               /* subnormal */
+            exp = 127u - 15u + 1u;
+            while ((mant & 0x400u) == 0) { mant <<= 1; exp--; }
+            mant &= 0x3FFu;
+            bits = sign | (exp << 23) | (mant << 13);
+        }
+    } else if (exp == 0x1Fu) {                 /* Inf / NaN */
+        bits = sign | 0x7F800000u | (mant << 13);
+    } else {
+        bits = sign | ((exp - 15u + 127u) << 23) | (mant << 13);
+    }
+    float out;
+    memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+/* Linear light [0,1] -> 8-bit sRGB via the shared OETF LUT (caller runs the
+ * pthread_once). Clamps out-of-range (HDR highlights, NaN) into [0,255]. */
+static uint8_t srgb8_from_linear(float f) {
+    if (!(f > 0.0f)) {           /* <= 0 or NaN */
+        return 0;
+    }
+    if (f >= 1.0f) {
+        return 255;
+    }
+    int i = (int)(f * (float)(DRMTAP_SRGB_LUT_N - 1) + 0.5f);
+    return g_srgb_lut[i];
+}
+
+/* Convert a half-float scanout (XRGB16161616F and its BGR/alpha siblings, fourcc
+ * 'XR4H' etc., 8 bytes/pixel) to 8-bit XRGB8888. FP16 scanouts carry LINEAR light,
+ * so each half is decoded to linear and re-encoded through the sRGB OETF -- unlike
+ * the integer 16-bit path, which treats its samples as already sRGB-encoded. HDR
+ * values above 1.0 clip to white: a faithful HDR tone-map needs the FP16 colorimetry
+ * the caller does not carry here, so this favors a correct, viewable SDR-range
+ * result over a speculative remap (and is still far better than the raw 16-bit bytes
+ * a consumer would otherwise misread as XRGB8888). */
+int drmtap_convert_rgb16f(const void *src, void *dst,
+                          uint32_t width, uint32_t height,
+                          uint32_t src_stride, uint32_t dst_stride, int bgr) {
+    if (!src || !dst || width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    size_t src_row = (size_t)width * 8u;
+    size_t dst_row = (size_t)width * 4u;
+    if (src_row > UINT32_MAX || dst_row > UINT32_MAX ||
+        src_stride < src_row || dst_stride < dst_row) {
+        return -EINVAL;
+    }
+    pthread_once(&g_hdr_once, hdr_lut_init);   /* fills g_srgb_lut */
+    /* Memory order of the 16-bit quad is B,G,R,X for the RGB variants (XR4H/AR4H)
+     * and R,G,B,X for the BGR variants (XB4H/AB4H) -- identical to the integer
+     * drmtap_convert_rgb16 path, so red sits at unit 2 unless bgr. */
+    int ri = bgr ? 0 : 2;
+    int bi = bgr ? 2 : 0;
+    for (uint32_t y = 0; y < height; y++) {
+        const uint16_t *s = (const uint16_t *)
+            ((const uint8_t *)src + (size_t)y * src_stride);
+        uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
+        for (uint32_t x = 0; x < width; x++) {
+            const uint16_t *px = s + (size_t)x * 4;
+            uint8_t r8 = srgb8_from_linear(half_to_float(px[ri]));
+            uint8_t g8 = srgb8_from_linear(half_to_float(px[1]));
+            uint8_t b8 = srgb8_from_linear(half_to_float(px[bi]));
+            d[x] = (0xFFu << 24) | ((uint32_t)r8 << 16) |
+                   ((uint32_t)g8 << 8) | b8;
+        }
+    }
+    return 0;
+}
+
 int drmtap_convert_format(const void *src, void *dst,
                           uint32_t width, uint32_t height,
                           uint32_t src_stride, uint32_t dst_stride,
                           uint32_t src_format, uint32_t dst_format) {
     if (!src || !dst || width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    /* Every format this converter handles (AR30/XR30 source, XRGB8888 dest, and
+     * the same-format copy) is 4 bytes/pixel, so a stride narrower than width*4
+     * would read or write past each row. Reject like drmtap_convert_rgb16 does. */
+    if ((size_t)src_stride < (size_t)width * 4u ||
+        (size_t)dst_stride < (size_t)width * 4u) {
         return -EINVAL;
     }
 
@@ -596,14 +697,20 @@ int drmtap_convert_format(const void *src, void *dst,
     #define DRM_FMT_ABGR8888    0x34324241u
     #define DRM_FMT_XRGB2101010 0x30335258u
     #define DRM_FMT_ARGB2101010 0x30335241u
+    #define DRM_FMT_XBGR2101010 0x30334258u
+    #define DRM_FMT_ABGR2101010 0x30334241u
 
-    /* AR30/XR30 → XRGB8888/ARGB8888 */
+    /* X/AR30 (RGB) and X/AB30 (BGR) 10-bit → XRGB8888/ARGB8888 */
     if ((src_format == DRM_FMT_XRGB2101010 ||
-         src_format == DRM_FMT_ARGB2101010) &&
+         src_format == DRM_FMT_ARGB2101010 ||
+         src_format == DRM_FMT_XBGR2101010 ||
+         src_format == DRM_FMT_ABGR2101010) &&
         (dst_format == DRM_FMT_XRGB8888 ||
          dst_format == DRM_FMT_ARGB8888)) {
+        int bgr = (src_format == DRM_FMT_XBGR2101010 ||
+                   src_format == DRM_FMT_ABGR2101010);
         convert_ar30_to_xrgb8888(src, dst, width, height,
-                                 src_stride, dst_stride);
+                                 src_stride, dst_stride, bgr);
         return 0;
     }
 

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.13", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.4.14", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/bindings/rust/libdrmtap/README.md
+++ b/bindings/rust/libdrmtap/README.md
@@ -25,7 +25,7 @@ reports HDR (`P010` overlay-video and HLG excepted).
 libdrmtap = "0.3"
 ```
 
-This pulls in `libdrmtap-sys` 0.4.13, which embeds and statically compiles the C
+This pulls in `libdrmtap-sys` 0.4.14, which embeds and statically compiles the C
 sources (and the privilege helper) — no system `libdrmtap` install needed.
 
 ## Example

--- a/contrib/integrations/rustdesk/README.md
+++ b/contrib/integrations/rustdesk/README.md
@@ -7,7 +7,7 @@ crate.
 > The upstream integration PR
 > [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420)
 > is **under maintainer review** (in progress — not yet merged). It adds a `drm`
-> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.13. The files here are a
+> capture backend to `scrap` on top of `libdrmtap-sys` 0.4.14. The files here are a
 > self-contained reference for the same crate-based backend.
 
 ## Status
@@ -42,7 +42,7 @@ capture. This means:
 1. Add the crate to `libs/scrap/Cargo.toml`:
 
    ```toml
-   libdrmtap-sys = { version = "0.4.13", optional = true }
+   libdrmtap-sys = { version = "0.4.14", optional = true }
    ```
 
    It embeds and statically compiles the C sources **and** builds the

--- a/contrib/integrations/rustdesk/drm/mod.rs
+++ b/contrib/integrations/rustdesk/drm/mod.rs
@@ -13,7 +13,7 @@
 // Integration (tested on Ubuntu 24.04; uses the static libdrmtap-sys crate):
 //
 //   1. Add the crate to libs/scrap/Cargo.toml:
-//        libdrmtap-sys = { version = "0.4.13", optional = true }
+//        libdrmtap-sys = { version = "0.4.14", optional = true }
 //      It statically embeds and compiles the C sources and builds the
 //      drmtap-helper binary — no system libdrmtap install, no meson install,
 //      no apt package, and no rustc-link-search.

--- a/contrib/integrations/rustdesk/drm/recorder.rs
+++ b/contrib/integrations/rustdesk/drm/recorder.rs
@@ -9,7 +9,7 @@
 // captured 1920x1017 @ BGRA, 7,810,560 bytes — pixel-perfect.
 //
 // To use in RustDesk:
-//   Add `libdrmtap-sys = { version = "0.4.13", optional = true }` to
+//   Add `libdrmtap-sys = { version = "0.4.14", optional = true }` to
 //   libs/scrap/Cargo.toml, place this file at libs/scrap/src/common/drm.rs,
 //   and see mod.rs in this directory for the wiring. The canonical, current
 //   backend is in the upstream PR rustdesk/rustdesk#15420.

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -52,6 +52,7 @@
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <drm_fourcc.h>  /* DRM_FORMAT_MOD_INVALID */
 
 #ifdef HAVE_LIBCAP
 #include <sys/capability.h>
@@ -629,7 +630,15 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     meta.stride = fb2->pitches[0];
     meta.format = fb2->pixel_format;
     meta.fb_id = fb_id;
-    meta.modifier = fb2->modifier;
+    /* fb2->modifier is valid only when the FB carries the DRM_MODE_FB_MODIFIERS flag;
+     * otherwise it is undefined. Report DRM_FORMAT_MOD_INVALID when the flag is clear
+     * so the parent's EGL import infers the real layout instead of trusting a bogus
+     * 0/LINEAR on a driver that is actually tiling (the XR30 class). INVALID is
+     * non-zero, so the export-vs-dumb-map branch below correctly routes it to the
+     * EGL-import path (with the dumb-map fallback still intact if export fails). */
+    meta.modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                        ? fb2->modifier
+                        : DRM_FORMAT_MOD_INVALID;
 
     /* HDR transfer + peak from the connector, so the library can decide whether
      * to tone-map (vs a plain bit-depth reduction for SDR 10-bit). */
@@ -692,7 +701,13 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
             return send_error(sock, "virgl DMA-BUF export failed "
                                     "(no usable CPU readback for a host scanout)");
         }
-        /* Otherwise fall through to the dumb-map pixel path. */
+        /* Otherwise fall through to the dumb-map pixel path. This is safe even for an
+         * INVALID (unknown-layout) modifier: a driver that TILES the scanout also
+         * implements PRIME export, so the export above would have succeeded and we
+         * would not be here. A buffer that reaches this fallback (export failed) is in
+         * practice a LINEAR scanout on a non-PRIME driver (plain virtio-gpu guest RAM,
+         * simpledrm, legacy AddFB), whose dumb-mapped pixels the parent reconstructs
+         * correctly from stride/format/dims. */
         fprintf(stderr,
             "drmtap-helper: drmPrimeHandleToFD failed (%d), falling back to pixels\n",
             prime_ret);
@@ -842,6 +857,14 @@ int main(int argc, char *argv[]) {
         fprintf(stderr, "drmtap-helper: failed to open %s: %s\n",
                 device, strerror(errno));
         return 1;
+    }
+    /* Defensively drop DRM master. This helper only reads scanout (GetFB2 /
+     * PrimeHandleToFD) and never modesets, but if it opened the card node while no
+     * client held master the kernel made it master implicitly, which would then block
+     * a compositor from (re)acquiring master on a VT switch -> a black/frozen display.
+     * drmDropMaster returns 0 only when we actually held master; otherwise no-op. */
+    if (drmDropMaster(drm_fd) == 0) {
+        fprintf(stderr, "drmtap-helper: dropped implicit DRM master on %s\n", device);
     }
     drmSetClientCap(drm_fd, DRM_CLIENT_CAP_UNIVERSAL_PLANES, 1);
 

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -194,7 +194,6 @@ static int install_seccomp(void) {
      * even though it holds CAP_SYS_ADMIN. */
     int allowed[] = {
         SCMP_SYS(read), SCMP_SYS(write), SCMP_SYS(close),
-        SCMP_SYS(ioctl),       /* DRM ioctls */
         SCMP_SYS(sendto),      /* send() */
         SCMP_SYS(sendmsg),     /* sendmsg() for SCM_RIGHTS */
         SCMP_SYS(recvfrom),    /* recv() */
@@ -215,6 +214,25 @@ static int install_seccomp(void) {
         if (rc != 0) {
             seccomp_release(ctx);
             fprintf(stderr, "drmtap-helper: seccomp_rule_add failed: %s\n",
+                    strerror(-rc));
+            return -1;
+        }
+    }
+
+    /* ioctl: allow ONLY the DRM ioctl type ('d', bits 8-15 of the request). The
+     * helper issues nothing but DRM ioctls on its single DRM fd (KMS, PRIME, GEM
+     * close, dumb map, VIRTGPU), so a memory-corrupted helper cannot reach an
+     * unrelated ioctl (TIOCSTI console injection, terminal control, etc.). Matching
+     * the type byte rather than enumerating every DRM command keeps this robust
+     * across drivers and libdrm versions without risking a KILL on a legitimate DRM
+     * ioctl we forgot to list. */
+    {
+        int rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ioctl), 1,
+                                  SCMP_A1(SCMP_CMP_MASKED_EQ, 0xFF00u,
+                                          (unsigned)'d' << 8));
+        if (rc != 0) {
+            seccomp_release(ctx);
+            fprintf(stderr, "drmtap-helper: seccomp ioctl rule failed: %s\n",
                     strerror(-rc));
             return -1;
         }
@@ -246,6 +264,19 @@ static int send_all(int sock, const void *buf, size_t len) {
 }
 static int recv_all(int sock, void *buf, size_t len) {
     return wire_recv_all(sock, buf, len);
+}
+
+/* drmModeGetFB2 mints a fresh GEM handle that the caller owns; if it is not
+ * closed, this long-running privileged helper leaks one kernel handle (and pins
+ * the underlying BO) on every grab and every cursor poll. Close it on every path.
+ * Harmless for handle 0. The exported DMA-BUF fd keeps its own BO reference, so
+ * closing the handle after PRIME export is safe. */
+static void helper_gem_close(int drm_fd, uint32_t handle) {
+    if (handle == 0) {
+        return;
+    }
+    struct drm_gem_close gc = { .handle = handle };
+    drmIoctl(drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
 // Send error: metadata with data_size=0. For logical/validation failures where
@@ -361,6 +392,7 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
      * a padded cursor is not sent sheared. The width cap precedes width*4 so
      * that product cannot overflow. */
     if (!(cw <= 256 && ch <= 256 && cstride != 0 && cstride >= cw * 4)) {
+        helper_gem_close(drm_fd, chandle);
         send_all(sock, &meta, sizeof(meta));  /* visible=0 */
         return 0;
     }
@@ -377,6 +409,7 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
         if (prime_fd >= 0) {
             close(prime_fd);
         }
+        helper_gem_close(drm_fd, chandle);
         send_all(sock, &meta, sizeof(meta));  /* visible=0 (couldn't read) */
         return 0;
     }
@@ -394,6 +427,7 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
     }
     munmap(mapped, map_size);
     close(prime_fd);
+    helper_gem_close(drm_fd, chandle);
 
     meta.visible = 1;
     meta.data_size = (uint32_t)tight;
@@ -405,6 +439,33 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
 /* ========================================================================= */
 /* DRM capture (privileged) — reads pixels, sends via socket                 */
 /* ========================================================================= */
+
+/* Resolve the CRTC bound to a connector via the atomic CRTC_ID property. The
+ * legacy encoder link (drmModeGetEncoder(conn->encoder_id)->crtc_id) reads 0 for
+ * an atomically-bound / compositor-managed connector, so on Wayland an HDR display
+ * never matched its CRTC and never got tone-mapped. Returns 0 if unbound. */
+static uint32_t helper_connector_crtc(int drm_fd, uint32_t connector_id) {
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return 0;
+    }
+    uint32_t crtc = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(drm_fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        if (strcmp(p->name, "CRTC_ID") == 0) {
+            crtc = (uint32_t)props->prop_values[i];
+            drmModeFreeProperty(p);
+            break;
+        }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    return crtc;
+}
 
 /* Read the HDR transfer function + peak luminance advertised on the connector
  * driving `crtc_id`. Sets *eotf to the DRM EOTF (0 = SDR / none) and *max_nits
@@ -423,21 +484,19 @@ static void read_hdr_metadata(int drm_fd, uint32_t crtc_id,
     if (!res) {
         return;
     }
-    /* Map the CRTC back to its connected connector via the encoder. */
+    /* Map the CRTC back to its connected connector via the atomic CRTC_ID property
+     * (see helper_connector_crtc). GetConnectorCurrent reads cached kernel state
+     * instead of forcing a hardware connector probe on every captured frame. */
     uint32_t conn_id = 0;
     for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
-        drmModeConnector *conn = drmModeGetConnector(drm_fd, res->connectors[i]);
+        drmModeConnector *conn =
+            drmModeGetConnectorCurrent(drm_fd, res->connectors[i]);
         if (!conn) {
             continue;
         }
-        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
-            drmModeEncoder *enc = drmModeGetEncoder(drm_fd, conn->encoder_id);
-            if (enc) {
-                if (enc->crtc_id == crtc_id) {
-                    conn_id = conn->connector_id;
-                }
-                drmModeFreeEncoder(enc);
-            }
+        if (conn->connection == DRM_MODE_CONNECTED &&
+            helper_connector_crtc(drm_fd, conn->connector_id) == crtc_id) {
+            conn_id = conn->connector_id;
         }
         drmModeFreeConnector(conn);
     }
@@ -481,6 +540,50 @@ static void read_hdr_metadata(int drm_fd, uint32_t crtc_id,
     drmModeFreeObjectProperties(props);
 }
 
+/* A plane's 'type' (PRIMARY/OVERLAY/CURSOR) is fixed for the life of the device,
+ * so probe it once and cache the primary plane ids instead of re-reading the
+ * property list for every plane on every captured frame. The helper serves a single
+ * persistent drm_fd, so a file-static cache is correct. */
+static int plane_is_primary(int drm_fd, uint32_t plane_id) {
+    static uint32_t primary_ids[32];
+    static int primary_count = -1;  /* -1 = not probed yet */
+    if (primary_count < 0) {
+        primary_count = 0;
+        drmModePlaneRes *pr = drmModeGetPlaneResources(drm_fd);
+        if (pr) {
+            const int cap = (int)(sizeof(primary_ids) / sizeof(primary_ids[0]));
+            for (uint32_t i = 0; i < pr->count_planes && primary_count < cap; i++) {
+                drmModeObjectProperties *props = drmModeObjectGetProperties(
+                    drm_fd, pr->planes[i], DRM_MODE_OBJECT_PLANE);
+                if (!props) {
+                    continue;
+                }
+                for (uint32_t p = 0; p < props->count_props; p++) {
+                    drmModePropertyRes *prop =
+                        drmModeGetProperty(drm_fd, props->props[p]);
+                    if (!prop) {
+                        continue;
+                    }
+                    if (strcmp(prop->name, "type") == 0 &&
+                        props->prop_values[p] == DRM_PLANE_TYPE_PRIMARY &&
+                        primary_count < cap) {
+                        primary_ids[primary_count++] = pr->planes[i];
+                    }
+                    drmModeFreeProperty(prop);
+                }
+                drmModeFreeObjectProperties(props);
+            }
+            drmModeFreePlaneResources(pr);
+        }
+    }
+    for (int i = 0; i < primary_count; i++) {
+        if (primary_ids[i] == plane_id) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
 // Grab current framebuffer. Helper reads pixels in its own process
 // (where dumb_mmap returns fresh data) and sends them via the socket.
 static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virtio) {
@@ -510,24 +613,8 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
 
         /* Check for active framebuffer */
         if (plane->fb_id != 0) {
-            /* Check plane type — prefer PRIMARY */
-            drmModeObjectProperties *props = drmModeObjectGetProperties(
-                drm_fd, plane->plane_id, DRM_MODE_OBJECT_PLANE);
-            int is_primary = 0;
-            if (props) {
-                for (uint32_t p = 0; p < props->count_props; p++) {
-                    drmModePropertyRes *prop = drmModeGetProperty(
-                        drm_fd, props->props[p]);
-                    if (prop) {
-                        if (strcmp(prop->name, "type") == 0 &&
-                            props->prop_values[p] == DRM_PLANE_TYPE_PRIMARY) {
-                            is_primary = 1;
-                        }
-                        drmModeFreeProperty(prop);
-                    }
-                }
-                drmModeFreeObjectProperties(props);
-            }
+            /* Check plane type — prefer PRIMARY (cached; the type is static). */
+            int is_primary = plane_is_primary(drm_fd, plane->plane_id);
 
             if (is_primary || fb_id == 0) {
                 fb_id = plane->fb_id;
@@ -570,6 +657,9 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
      * 8K BGRA frame (~126 MB, well under UINT32_MAX). */
     if (fb2->pitches[0] == 0 || fb2->height == 0 ||
         (size_t)fb2->height > ((size_t)7680 * 4320 * 4) / fb2->pitches[0]) {
+        /* This early return is BEFORE the gem_handle assignment + out: label, so
+         * close the just-minted handle here or the reject path leaks it. */
+        helper_gem_close(drm_fd, fb2->handles[0]);
         drmModeFreeFB2(fb2);
         return send_error(sock, "rejecting framebuffer geometry (too large)");
     }
@@ -692,14 +782,15 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
             meta.data_size = 0;  /* no pixel data follows */
             ret = send_fd(sock, prime_fd, &meta, sizeof(meta));
             close(prime_fd);
-            return ret;
+            goto out;
         }
         /* Export failed. For a confirmed virgl scanout the dumb-map fallback
          * below would read back black (host-side resource), so fail closed
          * rather than send a bogus all-black frame. */
         if (virtio_virgl) {
-            return send_error(sock, "virgl DMA-BUF export failed "
-                                    "(no usable CPU readback for a host scanout)");
+            ret = send_error(sock, "virgl DMA-BUF export failed "
+                                   "(no usable CPU readback for a host scanout)");
+            goto out;
         }
         /* Otherwise fall through to the dumb-map pixel path. This is safe even for an
          * INVALID (unknown-layout) modifier: a driver that TILES the scanout also
@@ -718,12 +809,14 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     struct drm_mode_map_dumb map = {0};
     map.handle = gem_handle;
     if (drmIoctl(drm_fd, DRM_IOCTL_MODE_MAP_DUMB, &map) < 0) {
-        return send_error_errno(sock, "MODE_MAP_DUMB failed");
+        ret = send_error_errno(sock, "MODE_MAP_DUMB failed");
+        goto out;
     }
     mapped = mmap(NULL, mapped_size, PROT_READ, MAP_SHARED,
                   drm_fd, map.offset);
     if (mapped == MAP_FAILED) {
-        return send_error_errno(sock, "mmap failed");
+        ret = send_error_errno(sock, "mmap failed");
+        goto out;
     }
     meta.flags = 0;
     meta.data_size = (uint32_t)mapped_size;
@@ -755,6 +848,8 @@ static int grab_and_send(int sock, int drm_fd, uint32_t target_crtc, int is_virt
     /* Cleanup — munmap but DON'T close drm_fd (it's persistent). */
     munmap(mapped, mapped_size);
 
+out:
+    helper_gem_close(drm_fd, gem_handle);
     return ret;
 }
 
@@ -816,11 +911,10 @@ int main(int argc, char *argv[]) {
         device = argv[1];
     }
 
-    /* Also check DRM_DEVICE env var */
-    const char *env_dev = getenv("DRM_DEVICE");
-    if (env_dev) {
-        device = env_dev;
-    }
+    /* The device path comes solely from argv[1] -- the value the library selected
+     * and passed. A CAP_SYS_ADMIN process must not take device selection from the
+     * environment (the library itself ignores DRM_DEVICE when privileged, since
+     * 0.4.11), so DRM_DEVICE is deliberately NOT honored here. */
 
     /* The device path is attacker-influenceable (argv / DRM_DEVICE) and we run
      * with CAP_SYS_ADMIN, so refuse anything that does not canonicalize under

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -175,9 +175,24 @@ int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame);
 /**
  * @brief Capture a frame — fast persistent-mmap path.
  *
- * Like drmtap_grab_mapped() but keeps the mmap/GEM handle/prime fd alive
- * between calls. Uses fb_id to detect compositor page flips — if the
- * framebuffer hasn't changed, returns 1 immediately (~0.1ms instead of ~18ms).
+ * Like drmtap_grab_mapped() but keeps the mmap/GEM handle/prime fd alive between
+ * calls, so a repeat capture of the same framebuffer skips the GetFB2 / PRIME
+ * export / mmap setup (about 1 ioctl instead of ~7 syscalls). It ALWAYS re-reads
+ * the current scanout and returns it as a fresh frame (return 0): a compositor can
+ * render into the same framebuffer without a page flip, so treating an unchanged
+ * fb_id as "skip" would miss content updates. It therefore never returns 1.
+ *
+ * Identity is keyed on fb_id: this path assumes a stable fb_id denotes the same
+ * scanout buffer between captures. If the environment destroys a framebuffer and
+ * recycles its id onto a different buffer while it is being captured (uncommon in
+ * steady-state compositing, but possible across a resolution change), re-open or
+ * use drmtap_grab_mapped(), which re-exports every frame.
+ *
+ * If the scanout cannot be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia) and
+ * an EGL backend is available, the call transparently falls back to EGL-detiling
+ * the exported fd instead of returning -ENOMEM. Such a frame is not cached — the
+ * fd is re-exported each grab — and -ENOMEM is returned only when no EGL fallback
+ * is possible.
  *
  * The returned frame->data pointer is valid until the NEXT call to this
  * function OR until drmtap_close(). Do NOT call drmtap_frame_release()
@@ -185,8 +200,7 @@ int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame);
  *
  * @param ctx   Capture context
  * @param frame Output frame info (caller-allocated, reused between calls)
- * @return 0 = new frame captured, 1 = same as last call (unchanged),
- *         negative errno on error
+ * @return 0 = frame captured, negative errno on error
  */
 int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame);
 
@@ -334,13 +348,18 @@ drmtap_ctx *drmtap_open_render(const char *render_node);
  * thread. The EGL state and its cached imports are thread-local; closing on a
  * different thread cannot release them and would strand the cached buffers.
  *
- * When no GPU path is usable the conversion falls back to a CPU mmap +
- * deswizzle of the fd (same pipeline as the in-process grab). The descriptor
- * and fd are treated as untrusted: the geometry is validated, the fd MUST be a
+ * The descriptor and its fd cross an IPC boundary and are treated as untrusted.
+ * Whenever desc->dma_buf_fd >= 0 the fd is validated UP FRONT, before EITHER
+ * conversion path touches it: the geometry is validated, the fd MUST be a
  * genuine DMA-BUF (a non-dma-buf fd is rejected -- only an immutable dma-buf is
  * safe to mmap and read without a truncate-mid-read fault), and it must be
  * large enough to back the declared frame (offset + stride*height); anything
- * else returns -EINVAL rather than faulting.
+ * else returns -EINVAL rather than faulting. This gates the EGL import — which
+ * would otherwise reach eglCreateImage unbounded — as well as the CPU fallback.
+ *
+ * When no GPU path is usable the conversion falls back to a CPU mmap +
+ * deswizzle of the fd (same pipeline as the in-process grab), which repeats the
+ * same size check.
  *
  * @param ctx   Context from drmtap_open_render() (or any context with a
  *              usable EGL backend)
@@ -451,7 +470,7 @@ int drmtap_deswizzle(const void *src, void *dst,
  * @brief Convert between pixel formats.
  *
  * Supported conversions:
- *   - XR30/AR30 (10-bit) → XRGB8888/ARGB8888
+ *   - XR30/AR30/XB30/AB30 (10-bit, RGB or BGR order) → XRGB8888/ARGB8888
  *   - ABGR8888 → ARGB8888/XRGB8888
  *   - Same format → copy
  *
@@ -463,7 +482,8 @@ int drmtap_deswizzle(const void *src, void *dst,
  * @param dst_stride Destination stride (bytes per row)
  * @param src_format Source DRM fourcc (e.g., DRM_FORMAT_XRGB2101010)
  * @param dst_format Destination DRM fourcc (e.g., DRM_FORMAT_XRGB8888)
- * @return 0 on success, -ENOTSUP if conversion not supported
+ * @return 0 on success, -ENOTSUP if conversion not supported, -EINVAL on
+ *         NULL/zero-size arguments or a src/dst stride narrower than width*4
  */
 int drmtap_convert_format(const void *src, void *dst,
                           uint32_t width, uint32_t height,
@@ -481,7 +501,8 @@ int drmtap_convert_format(const void *src, void *dst,
  * HDR_OUTPUT_METADATA, not from the pixel format alone — XR30/AR30 is also used
  * for plain SDR 10-bit).
  *
- * Supported src_format: XR30/AR30 (ARGB2101010). Others return -ENOTSUP.
+ * Supported src_format: XR30/AR30 and XB30/AB30 (X/ARGB2101010 and
+ * X/ABGR2101010). Others return -ENOTSUP.
  *
  * @param src        Source pixel data
  * @param dst        Destination buffer (XRGB8888)
@@ -489,7 +510,8 @@ int drmtap_convert_format(const void *src, void *dst,
  * @param height     Frame height in pixels
  * @param src_stride Source stride (bytes per row)
  * @param dst_stride Destination stride (bytes per row)
- * @param src_format Source DRM fourcc (DRM_FORMAT_XRGB2101010 / ARGB2101010)
+ * @param src_format Source DRM fourcc (DRM_FORMAT_XRGB2101010 / ARGB2101010 /
+ *                   XBGR2101010 / ABGR2101010)
  * @param max_nits   Content/mastering peak luminance for the highlight roll-off
  *                   (0 = a sensible default). Brighter peaks spread highlights
  *                   over more of the top range instead of clipping to white.

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 13
+#define DRMTAP_VERSION_PATCH 14
 
 /**
  * @brief Get the library version as a packed integer.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.13',
+    version: '0.4.14',
     license: 'MIT',
     default_options: [
         'c_std=c11',

--- a/patches/rustdesk/README.md
+++ b/patches/rustdesk/README.md
@@ -31,7 +31,7 @@ cargo build --release
 ## Based on
 
 - RustDesk v1.4.6
-- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.13"`
+- libdrmtap (this repo, `main` branch) — `scrap` pins `libdrmtap-sys = "0.4.14"`
 
 ## Upstream status
 

--- a/patches/rustdesk/scrap_Cargo.toml
+++ b/patches/rustdesk/scrap_Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0"
 num_cpus = "1.15"
 lazy_static = "1.4"
 hbb_common = { path = "../hbb_common" }
-libdrmtap-sys = { version = "0.4.13", optional = true }
+libdrmtap-sys = { version = "0.4.14", optional = true }
 webm = { git = "https://github.com/rustdesk-org/rust-webm" }
 serde = {version="1.0", features=["derive"]}
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -230,6 +230,13 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
         }
     }
 
+    /* drmModeGetFB2 minted a fresh GEM handle we own; close it before freeing fb2,
+     * or the privileged direct cursor path leaks a kernel handle (pinning the BO)
+     * on every poll. The pixels were already copied out and the prime_fd closed. */
+    if (fb2->handles[0] != 0) {
+        struct drm_gem_close gc = { .handle = fb2->handles[0] };
+        drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
+    }
     drmModeFreeFB2(fb2);
     drmModeFreePlane(plane);
 

--- a/src/drm_enumerate.c
+++ b/src/drm_enumerate.c
@@ -56,11 +56,12 @@ static uint32_t connector_crtc_from_atomic(int fd, uint32_t connector_id) {
     return crtc_id;
 }
 
-/* Fold the current connector topology (per-connector connection state + bound
- * CRTC) into a hash. Unlike the raw connector/CRTC counts -- fixed by the GPU
- * hardware -- this changes when a monitor is plugged/unplugged on an existing
- * connector or a CRTC is (re)bound by a modeset, which is what hotplug detection
- * needs. GetConnectorCurrent reads cached kernel state (no forced probe). */
+/* Fold the current connector topology (per-connector connection state, bound CRTC,
+ * and that CRTC's active mode) into a hash. Unlike the raw connector/CRTC counts --
+ * fixed by the GPU hardware -- this changes when a monitor is plugged/unplugged on an
+ * existing connector, a CRTC is (re)bound, or a modeset changes the active resolution
+ * or refresh, which is what hotplug/modeset detection needs. GetConnectorCurrent reads
+ * cached kernel state (no forced probe). */
 static uint64_t topology_hash(int drm_fd, drmModeRes *res) {
     uint64_t h = 1469598103934665603ULL; /* FNV-1a 64-bit offset basis */
 #define TH_FOLD(v) do { h ^= (uint64_t)(uint32_t)(v); h *= 1099511628211ULL; } while (0)
@@ -75,7 +76,20 @@ static uint64_t topology_hash(int drm_fd, drmModeRes *res) {
         }
         TH_FOLD(conn->connector_id);
         TH_FOLD(conn->connection);
-        TH_FOLD(connector_crtc_from_atomic(drm_fd, conn->connector_id));
+        uint32_t crtc = connector_crtc_from_atomic(drm_fd, conn->connector_id);
+        TH_FOLD(crtc);
+        if (crtc) {
+            /* Fold the active mode so a modeset (resolution / refresh change) on the
+             * same connector+CRTC binding is detected, not just plug/unplug/rebind. */
+            drmModeCrtc *c = drmModeGetCrtc(drm_fd, crtc);
+            if (c) {
+                TH_FOLD(c->mode_valid);
+                TH_FOLD(c->mode.hdisplay);
+                TH_FOLD(c->mode.vdisplay);
+                TH_FOLD(c->mode.vrefresh);
+                drmModeFreeCrtc(c);
+            }
+        }
         drmModeFreeConnector(conn);
     }
 #undef TH_FOLD

--- a/src/drm_enumerate.c
+++ b/src/drm_enumerate.c
@@ -56,6 +56,32 @@ static uint32_t connector_crtc_from_atomic(int fd, uint32_t connector_id) {
     return crtc_id;
 }
 
+/* Fold the current connector topology (per-connector connection state + bound
+ * CRTC) into a hash. Unlike the raw connector/CRTC counts -- fixed by the GPU
+ * hardware -- this changes when a monitor is plugged/unplugged on an existing
+ * connector or a CRTC is (re)bound by a modeset, which is what hotplug detection
+ * needs. GetConnectorCurrent reads cached kernel state (no forced probe). */
+static uint64_t topology_hash(int drm_fd, drmModeRes *res) {
+    uint64_t h = 1469598103934665603ULL; /* FNV-1a 64-bit offset basis */
+#define TH_FOLD(v) do { h ^= (uint64_t)(uint32_t)(v); h *= 1099511628211ULL; } while (0)
+    TH_FOLD(res->count_connectors);
+    TH_FOLD(res->count_crtcs);
+    for (int i = 0; i < res->count_connectors; i++) {
+        drmModeConnector *conn =
+            drmModeGetConnectorCurrent(drm_fd, res->connectors[i]);
+        if (!conn) {
+            TH_FOLD(res->connectors[i]);
+            continue;
+        }
+        TH_FOLD(conn->connector_id);
+        TH_FOLD(conn->connection);
+        TH_FOLD(connector_crtc_from_atomic(drm_fd, conn->connector_id));
+        drmModeFreeConnector(conn);
+    }
+#undef TH_FOLD
+    return h;
+}
+
 /* ========================================================================= */
 /* Public API                                                                */
 /* ========================================================================= */
@@ -188,9 +214,8 @@ int drmtap_list_displays(drmtap_ctx *ctx, drmtap_display *out, int max_count) {
         drmModeFreeConnector(conn);
     }
 
-    /* Cache counts for hotplug detection */
-    ctx->cached_connector_count = (uint32_t)res->count_connectors;
-    ctx->cached_crtc_count = (uint32_t)res->count_crtcs;
+    /* Cache the topology signature for hotplug detection. */
+    ctx->cached_topology_hash = topology_hash(ctx->drm_fd, res);
 
     drmModeFreeResources(res);
     return found;
@@ -210,15 +235,12 @@ int drmtap_displays_changed(drmtap_ctx *ctx) {
         return -ENODEV;
     }
 
-    int changed = 0;
-    if ((uint32_t)res->count_connectors != ctx->cached_connector_count ||
-        (uint32_t)res->count_crtcs != ctx->cached_crtc_count) {
-        changed = 1;
-    }
-
-    /* Update cache */
-    ctx->cached_connector_count = (uint32_t)res->count_connectors;
-    ctx->cached_crtc_count = (uint32_t)res->count_crtcs;
+    /* Hash the per-connector connection + CRTC binding, not the fixed object
+     * counts: an ordinary monitor plug/unplug on an existing HDMI/DP connector,
+     * and a modeset that rebinds a CRTC, both leave the counts unchanged. */
+    uint64_t h = topology_hash(ctx->drm_fd, res);
+    int changed = (h != ctx->cached_topology_hash);
+    ctx->cached_topology_hash = h;
 
     drmModeFreeResources(res);
     return changed;

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -682,7 +682,15 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     frame->height = fb2->height;
     frame->stride = fb2->pitches[0];
     frame->format = fb2->pixel_format;
-    frame->modifier = fb2->modifier;
+    /* fb2->modifier is only meaningful when the framebuffer was created with the
+     * DRM_MODE_FB_MODIFIERS flag. When the flag is clear the field is undefined
+     * (commonly 0, but garbage on some drivers), and trusting a bogus 0/LINEAR on a
+     * driver that is actually tiling the scanout corrupts the import (the recurring
+     * XR30 / "special fix" class). Report DRM_FORMAT_MOD_INVALID instead so the EGL
+     * import omits the modifier attribute and the driver infers the real layout. */
+    frame->modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                          ? fb2->modifier
+                          : DRM_FORMAT_MOD_INVALID;
     frame->fb_id = fb_id;
     frame->dma_buf_fd = prime_fd;
     frame->data = NULL;
@@ -857,7 +865,17 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     if (!data && !force_egl && frame->dma_buf_fd < 0) return 0;
 
     uint64_t modifier = frame->modifier;
-    int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0);
+    /* INVALID means the FB advertised no modifier (flag clear), so the layout is
+     * unknown. Treat it as linear ONLY when EGL import is unavailable: this is the
+     * CPU fallback for the simple drivers that take that path (virtio, embedded),
+     * where an unknown scanout is in practice linear. When EGL IS available we must
+     * NOT short-circuit to the linear early-return below -- a modern tiling driver
+     * leaves the modifier flag clear on a tiled scanout (the XR30 class), and only
+     * the EGL path further down, which omits the modifier and lets the driver infer
+     * the real layout, decodes it correctly. */
+    int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0 ||
+                     (modifier == DRM_FORMAT_MOD_INVALID &&
+                      !drmtap_gpu_egl_available(ctx)));
 
     /* A linear high-bit-depth / HDR scanout still needs reduction to 8-bit
      * (the early-return below is only safe for 8-bit RGB). */

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -76,6 +76,18 @@ static void drmtap_gem_close(drmtap_ctx *ctx, uint32_t handle) {
     drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
+/* Test hook: DRMTAP_FORCE_MMAP_FAIL=1 makes the fast-path cache-miss drop a
+ * successful CPU mapping so the EGL-detile fd fallback runs on any EGL-capable GPU,
+ * not only a discrete/tiled one that genuinely refuses the mmap. Off by default. */
+static int drmtap_force_mmap_fail(void) {
+    static int v = -1;
+    if (v < 0) {
+        const char *e = getenv("DRMTAP_FORCE_MMAP_FAIL");
+        v = (e && e[0] == '1') ? 1 : 0;
+    }
+    return v;
+}
+
 /* ========================================================================= */
 /* Internal state for a captured frame (stored in frame->_priv)              */
 /* ========================================================================= */
@@ -100,6 +112,33 @@ typedef struct {
  * into ctx->cur_hdr_eotf / cur_hdr_max_nits, for the direct (no-helper) capture
  * path. Mirrors read_hdr_metadata in the helper. Best-effort: any failure leaves
  * it SDR (0), so a non-HDR display just means no tone-mapping. */
+/* Resolve the CRTC bound to a connector via the atomic CRTC_ID property; the
+ * legacy encoder link (drmModeGetEncoder(conn->encoder_id)->crtc_id) reads 0 for
+ * an atomically-bound connector under atomic KMS (Wayland), so an HDR display never
+ * matched its CRTC and never got tone-mapped. Returns 0 if unbound/unavailable. */
+static uint32_t connector_crtc_atomic(int drm_fd, uint32_t connector_id) {
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(drm_fd, connector_id, DRM_MODE_OBJECT_CONNECTOR);
+    if (!props) {
+        return 0;
+    }
+    uint32_t crtc = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(drm_fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        if (strcmp(p->name, "CRTC_ID") == 0) {
+            crtc = (uint32_t)props->prop_values[i];
+            drmModeFreeProperty(p);
+            break;
+        }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    return crtc;
+}
+
 static void read_hdr_metadata_direct(drmtap_ctx *ctx, uint32_t crtc_id) {
     ctx->cur_hdr_eotf = 0;
     ctx->cur_hdr_max_nits = 0;
@@ -110,22 +149,19 @@ static void read_hdr_metadata_direct(drmtap_ctx *ctx, uint32_t crtc_id) {
     if (!res) {
         return;
     }
+    /* Match on the atomic CRTC_ID property (see connector_crtc_atomic), not the
+     * legacy encoder link. GetConnectorCurrent reads cached kernel state instead of
+     * forcing a hardware connector probe on every do_grab. */
     uint32_t conn_id = 0;
     for (int i = 0; i < res->count_connectors && conn_id == 0; i++) {
         drmModeConnector *conn =
-            drmModeGetConnector(ctx->drm_fd, res->connectors[i]);
+            drmModeGetConnectorCurrent(ctx->drm_fd, res->connectors[i]);
         if (!conn) {
             continue;
         }
-        if (conn->connection == DRM_MODE_CONNECTED && conn->encoder_id) {
-            drmModeEncoder *enc =
-                drmModeGetEncoder(ctx->drm_fd, conn->encoder_id);
-            if (enc) {
-                if (enc->crtc_id == crtc_id) {
-                    conn_id = conn->connector_id;
-                }
-                drmModeFreeEncoder(enc);
-            }
+        if (conn->connection == DRM_MODE_CONNECTED &&
+            connector_crtc_atomic(ctx->drm_fd, conn->connector_id) == crtc_id) {
+            conn_id = conn->connector_id;
         }
         drmModeFreeConnector(conn);
     }
@@ -469,7 +505,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         ret = drmPrimeHandleToFD(ctx->drm_fd, fb2->handles[0],
                                   O_RDONLY | O_CLOEXEC, &prime_fd);
         if (ret < 0 && (errno == EACCES || errno == EPERM)) {
+            /* Export denied: the capture goes through the helper (which mints its
+             * own handle over IPC) and never adopts this one into priv->gem_handle.
+             * Close the handle GetFB2 just minted, or the needs_helper path -- and
+             * its per-frame V2/V3 success returns -- leaks it. */
             needs_helper = 1;
+            drmtap_gem_close(ctx, fb2->handles[0]);
         } else if (ret < 0) {
             ret = -errno;
             drmtap_set_error(ctx, "drmPrimeHandleToFD failed: %s", strerror(errno));
@@ -794,11 +835,17 @@ cleanup:
 /* DRM fourccs for the high-bit-depth scanout formats we reduce to 8-bit. */
 #define DRMTAP_FMT_XR30 0x30335258u  /* XRGB2101010 */
 #define DRMTAP_FMT_AR30 0x30335241u  /* ARGB2101010 */
+#define DRMTAP_FMT_XB30 0x30334258u  /* XBGR2101010 */
+#define DRMTAP_FMT_AB30 0x30334241u  /* ABGR2101010 */
 #define DRMTAP_FMT_XR48 0x38345258u  /* XRGB16161616 */
 #define DRMTAP_FMT_AR48 0x38345241u  /* ARGB16161616 */
 #define DRMTAP_FMT_XB48 0x38344258u  /* XBGR16161616 */
 #define DRMTAP_FMT_AB48 0x38344241u  /* ABGR16161616 */
 #define DRMTAP_FMT_XR24 0x34325258u  /* XRGB8888 */
+#define DRMTAP_FMT_XR4H 0x48345258u  /* XRGB16161616F (half-float) */
+#define DRMTAP_FMT_AR4H 0x48345241u  /* ARGB16161616F */
+#define DRMTAP_FMT_XB4H 0x48344258u  /* XBGR16161616F */
+#define DRMTAP_FMT_AB4H 0x48344241u  /* ABGR16161616F */
 
 /* Reduce a LINEAR high-bit-depth scanout (10-bit AR30/XR30 or 16-bit
  * XR48/AR48/XB48/AB48) to 8-bit XRGB8888, tone-mapping when the connector
@@ -809,10 +856,13 @@ cleanup:
 static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
                                      drmtap_frame_info *frame) {
     uint32_t fmt = frame->format;
-    int is_ar30 = (fmt == DRMTAP_FMT_XR30 || fmt == DRMTAP_FMT_AR30);
+    int is_ar30 = (fmt == DRMTAP_FMT_XR30 || fmt == DRMTAP_FMT_AR30 ||
+                   fmt == DRMTAP_FMT_XB30 || fmt == DRMTAP_FMT_AB30);
     int is_rgb16 = (fmt == DRMTAP_FMT_XR48 || fmt == DRMTAP_FMT_AR48 ||
                     fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
-    if (!is_ar30 && !is_rgb16) {
+    int is_rgb16f = (fmt == DRMTAP_FMT_XR4H || fmt == DRMTAP_FMT_AR4H ||
+                     fmt == DRMTAP_FMT_XB4H || fmt == DRMTAP_FMT_AB4H);
+    if (!is_ar30 && !is_rgb16 && !is_rgb16f) {
         return 0;  /* 8-bit RGB (or unknown): leave as-is */
     }
 
@@ -834,16 +884,21 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
                     frame->width, frame->height, frame->stride, dst_stride,
                     fmt, DRMTAP_FMT_XR24);
         }
-    } else {
+    } else if (is_rgb16) {
         int bgr = (fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
         ret = drmtap_convert_rgb16(data, ctx->deswizzle_buf,
                 frame->width, frame->height, frame->stride, dst_stride,
                 bgr, ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
+    } else {
+        /* Half-float FP16 (XR4H family): linear-light decode + sRGB re-encode. */
+        int bgr = (fmt == DRMTAP_FMT_XB4H || fmt == DRMTAP_FMT_AB4H);
+        ret = drmtap_convert_rgb16f(data, ctx->deswizzle_buf,
+                frame->width, frame->height, frame->stride, dst_stride, bgr);
     }
     if (ret != 0) return ret;
 
     drmtap_debug_log(ctx, "auto-process: linear %s -> XRGB8888 (%s)",
-                     is_ar30 ? "10-bit" : "16-bit",
+                     is_ar30 ? "10-bit" : (is_rgb16f ? "FP16" : "16-bit"),
                      hdr ? "HDR tone-mapped" : "SDR");
     frame->data = ctx->deswizzle_buf;
     frame->format = DRMTAP_FMT_XR24;
@@ -872,7 +927,12 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
      * NOT short-circuit to the linear early-return below -- a modern tiling driver
      * leaves the modifier flag clear on a tiled scanout (the XR30 class), and only
      * the EGL path further down, which omits the modifier and lets the driver infer
-     * the real layout, decodes it correctly. */
+     * the real layout, decodes it correctly. Tradeoff: a GENUINELY linear flag-clear
+     * scanout on an EGL-capable GPU now takes the EGL round-trip too (it is
+     * indistinguishable from a secretly-tiled one while the flag is clear), losing the
+     * zero-copy path it had before. That is the unavoidable cost of decoding the tiled
+     * case correctly; it does not affect a compositor that advertises modifiers (flag
+     * set, handled above) nor a no-EGL simple driver (linear here). */
     int is_linear = (modifier == DRM_FORMAT_MOD_LINEAR || modifier == 0 ||
                      (modifier == DRM_FORMAT_MOD_INVALID &&
                       !drmtap_gpu_egl_available(ctx)));
@@ -976,6 +1036,24 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         return -ENOTSUP;
     }
 
+    /* An INVALID (unknown) modifier reaching this point means the EGL detile did
+     * not run -- no dma-buf fd (helper V2 pixel mode) or EGL unavailable/failed.
+     * INVALID is not a known tiling, so the CPU deswizzle below, which is written
+     * for specific tiled layouts and hardcodes 4 bytes/pixel, cannot decode it and
+     * would mangle a wider (FP16) scanout. Treat an unknown layout as linear -- its
+     * practical case -- and reduce it from the RAW mapping, which handles 8/10/16-bit
+     * correctly. This restores the pre-INVALID behavior for a flag-clear buffer that
+     * used to read back as modifier 0, without diverting it into the tiled deswizzle. */
+    if (modifier == DRM_FORMAT_MOD_INVALID) {
+        int red = reduce_linear_to_xrgb8888(ctx, data, frame);
+        if (red < 0) {
+            return red;
+        }
+        /* red == 1: reduced to XRGB8888 (frame->data repointed). red == 0: already
+         * 8-bit -- the raw linear mapping (frame->data, pre-set by the caller) stands. */
+        return 0;
+    }
+
     /* --- CPU deswizzle for classic tiling (buffer already allocated above) --- */
     const char *driver = ctx->driver_name;
     if (drmtap_gpu_intel_match(driver) ||
@@ -1005,11 +1083,14 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             frame->data = ctx->deswizzle_buf;
             drmtap_debug_log(ctx, "auto-process: CPU deswizzled to linear");
 
-            /* Reduce 10-bit XR30/AR30 to 8-bit XRGB8888. An HDR10 (PQ) scanout
-             * needs a real tone-map — the naive bit-shift would wash it out; a
-             * plain SDR 10-bit scanout (same fourcc) just gets truncated. */
+            /* Reduce 10-bit X/AR30 and X/AB30 to 8-bit XRGB8888. An HDR10 (PQ)
+             * scanout needs a real tone-map -- the naive bit-shift would wash it
+             * out; a plain SDR 10-bit scanout (same fourcc) just gets truncated.
+             * Both converters read the fourcc and handle the RGB/BGR order. */
             if (frame->format == DRMTAP_FMT_XR30 ||
-                frame->format == DRMTAP_FMT_AR30) {
+                frame->format == DRMTAP_FMT_AR30 ||
+                frame->format == DRMTAP_FMT_XB30 ||
+                frame->format == DRMTAP_FMT_AB30) {
                 int conv;
                 if (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ) {
                     drmtap_debug_log(ctx,
@@ -1340,8 +1421,13 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         /* Restage this slot's plane layout before converting (the cache HIT
          * skipped GetFB2, so ctx->fb2_* is otherwise stale). */
         fast_slot_restage_planes(ctx, slot);
-        /* Auto-deswizzle tiled framebuffers + format convert */
-        gpu_auto_process(ctx, frame->data, frame, 0);
+        /* Auto-deswizzle tiled framebuffers + format convert. Propagate a
+         * processing failure instead of returning unprocessed pixels as success
+         * (the unchanged-fb branch above already does this). */
+        int pr = gpu_auto_process(ctx, frame->data, frame, 0);
+        if (pr != 0) {
+            return pr;
+        }
 
         return 0;   /* new frame */
     }
@@ -1414,7 +1500,55 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                       prime_fd, fb2->offsets[0]);
     }
 
+    /* Test hook (drmtap_force_mmap_fail): drop a successful mapping so the EGL fd
+     * fallback below is exercised on a GPU whose scanout IS cpu-mappable. */
+    if (mapped != MAP_FAILED && drmtap_force_mmap_fail()) {
+        munmap(mapped, size);
+        mapped = MAP_FAILED;
+    }
+
     if (mapped == MAP_FAILED) {
+#ifdef HAVE_EGL
+        /* A tiled scanout can refuse a CPU mmap (amdgpu GFX9+, discrete VRAM,
+         * nvidia) yet be fully capturable by EGL-detiling the exported fd, exactly
+         * as do_grab does. Fall back to that instead of dropping the capture. This
+         * frame has no CPU mapping to cache, so no slot is stored; the fd path
+         * re-exports each frame (still cheaper than failing the stream, and the EGL
+         * image cache keyed on the BO inode keeps the import itself amortized). */
+        if (drmtap_gpu_egl_available(ctx)) {
+            frame->data = NULL;
+            frame->dma_buf_fd = prime_fd;
+            frame->width = fb2->width;
+            frame->height = fb2->height;
+            frame->stride = fb2->pitches[0];
+            frame->format = fb2->pixel_format;
+            frame->modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                                  ? fb2->modifier : DRM_FORMAT_MOD_INVALID;
+            frame->fb_id = fb_id;
+            frame->_priv = NULL;
+            int pr = gpu_auto_process(ctx, NULL, frame, 0);
+            /* A LINEAR-modifier scanout takes gpu_auto_process's linear early-return,
+             * which leaves frame->data NULL when it was called with data==NULL (no CPU
+             * mapping): that path assumes the caller already pointed frame->data at the
+             * raw mapping, which we do not have here. Treat a 0-return with no data as a
+             * failure so the caller never gets a success frame with a NULL buffer
+             * (do_grab guards the same case). Only EGL actually produces pixels here. */
+            if (pr == 0 && !frame->data) {
+                pr = -EIO;
+            }
+            /* gpu_auto_process EGL-read the fd back into ctx->deswizzle_buf, so the
+             * fd and handle are no longer needed and nothing is cached for fb_id. */
+            close(prime_fd);
+            frame->dma_buf_fd = -1;  /* prime_fd is closed; don't hand back a stale fd */
+            drmtap_gem_close(ctx, fb2->handles[0]);
+            drmModeFreeFB2(fb2);
+            ctx->fast_last_fb_id = 0;  /* uncached: next call does a fresh setup */
+            if (pr != 0) {
+                return pr;
+            }
+            return 0;
+        }
+#endif
         close(prime_fd);
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);
@@ -1431,7 +1565,13 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].height = fb2->height;
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;
-    ctx->fast_slots[slot].modifier = fb2->modifier;
+    /* Honor the DRM_MODE_FB_MODIFIERS flag (see do_grab): fb2->modifier is undefined
+     * when the flag is clear, so a tiled scanout that omits it must be cached as
+     * DRM_FORMAT_MOD_INVALID -- not the bogus 0 -- or the cached slot would replay it
+     * as linear on every fast-path hit and corrupt the XR30/tiled class this fixes. */
+    ctx->fast_slots[slot].modifier = (fb2->flags & DRM_MODE_FB_MODIFIERS)
+                                         ? fb2->modifier
+                                         : DRM_FORMAT_MOD_INVALID;
     /* Capture this fb's plane layout with the slot so a later cache HIT can
      * restage it into ctx->fb2_* (ctx->fb2_* was set from this same fb2 just
      * above, at the "Cache multi-plane info" block). */
@@ -1458,8 +1598,12 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     frame->fb_id = fb_id;
     frame->_priv = NULL;
 
-    /* Auto-deswizzle tiled framebuffers + format convert */
-    gpu_auto_process(ctx, frame->data, frame, 0);
+    /* Auto-deswizzle tiled framebuffers + format convert. Propagate a processing
+     * failure instead of returning unprocessed pixels as success. */
+    int mpr = gpu_auto_process(ctx, frame->data, frame, 0);
+    if (mpr != 0) {
+        return mpr;
+    }
 
     return 0;   /* new frame */
 }
@@ -1537,6 +1681,40 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
     frame->modifier = desc->modifier;
     frame->fb_id = desc->fb_id;
     frame->dma_buf_fd = desc->dma_buf_fd;
+
+    /* The descriptor and its fd cross an IPC boundary and are UNTRUSTED. Validate
+     * the fd BEFORE either conversion path touches it: the EGL import below hands
+     * width/height/stride/offset straight to eglCreateImage with no size check, so
+     * the 0.4.12 fd-type + size bound (previously only in the CPU fallback) must
+     * gate the EGL path too. Only meaningful when an fd is supplied; a cached-fb_id
+     * EGL import carries no untrusted fd. Gates:
+     *   1. Require a genuine DMA-BUF -- immutable in size, so it cannot be shrunk
+     *      between check and use (a memfd/regular file could, faulting the reader).
+     *      dmabuf_sync returns ENOTTY on a non-dma-buf; sync_end closes the probe.
+     *   2. Bound offsets[0] + pitches[0]*height against the real fd size; fail
+     *      CLOSED when the size cannot be determined. */
+    if (desc->dma_buf_fd >= 0) {
+        size_t need = (size_t)desc->pitches[0] * desc->height;
+        if (dmabuf_sync_start(desc->dma_buf_fd) != 0) {
+            drmtap_set_error(ctx, "convert: fd is not a dma-buf");
+            return -EINVAL;
+        }
+        off_t fd_size = lseek(desc->dma_buf_fd, 0, SEEK_END);
+        if (fd_size <= 0) {
+            struct stat st;
+            if (fstat(desc->dma_buf_fd, &st) == 0) {
+                fd_size = st.st_size;
+            }
+        }
+        dmabuf_sync_end(desc->dma_buf_fd);
+        if (fd_size <= 0 ||
+            (uint64_t)desc->offsets[0] + (uint64_t)need > (uint64_t)fd_size) {
+            drmtap_set_error(ctx, "convert: descriptor exceeds dma-buf size "
+                             "(fd_size=%lld, need offset %u + %zu)",
+                             (long long)fd_size, desc->offsets[0], need);
+            return -EINVAL;
+        }
+    }
 
 #ifdef HAVE_EGL
     /* GPU path first: EGL imports the fd (or reuses the fb_id-cached import)

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -252,6 +252,22 @@ drmtap_ctx *drmtap_open(const drmtap_config *config) {
         /* If fcntl fails, keep the original fd (best effort) */
     }
 
+    /* Defensively drop DRM master -- but ONLY when we are privileged (root /
+     * CAP_SYS_ADMIN). We only READ scanout and never modeset, so if a PRIVILEGED
+     * process opened the node while no client held master (e.g. an unattended capture
+     * service that started at boot before the compositor), the kernel granted it
+     * implicit master, which would then block the compositor from acquiring master on
+     * a VT switch -> a black/frozen display; dropping it is safe there because
+     * drmModeGetFB2 still returns handles via CAP_SYS_ADMIN. An UNPRIVILEGED caller,
+     * by contrast, has no CAP_SYS_ADMIN and RELIES on that implicit master for
+     * drmModeGetFB2 to return framebuffer handles at all, so it must keep it -- do
+     * not drop. drmDropMaster returns 0 only when we actually held master; when a
+     * compositor already holds it (the normal desktop case) it is a harmless no-op. */
+    if ((geteuid() == 0 || getuid() == 0) &&
+        drmDropMaster(ctx->drm_fd) == 0) {
+        drmtap_debug_log(ctx, "dropped implicit DRM master on %s", ctx->device_path);
+    }
+
     /* Detect GPU driver */
     detect_driver(ctx);
 

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -23,11 +23,37 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <sys/syscall.h>
+#include <linux/capability.h>
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 
 #include "drmtap_internal.h"
+
+/* True if this thread holds CAP_SYS_ADMIN in its effective set. drmModeGetFB2
+ * returns framebuffer handles without DRM master only for a caller that holds
+ * CAP_SYS_ADMIN; a process running as uid 0 that has dropped CAP_SYS_ADMIN does
+ * NOT qualify and relies on implicit master exactly like an unprivileged caller.
+ * The raw capget syscall is used so the library links no libcap and adds nothing
+ * to the DT_NEEDED of the .so the privileged service dlopens. On any error the
+ * caller is treated as unprivileged (keep master), which is the safe default. */
+static int drmtap_have_cap_sys_admin(void) {
+    struct __user_cap_header_struct hdr = {
+        .version = _LINUX_CAPABILITY_VERSION_3,
+        .pid = 0, /* 0 == self */
+    };
+    struct __user_cap_data_struct data[2] = {{0, 0, 0}, {0, 0, 0}};
+    if (syscall(SYS_capget, &hdr, data) != 0) {
+        /* capget is unavailable (e.g. a seccomp filter denies the syscall while
+         * still permitting getuid). Fall back to the uid check so a genuine root
+         * capture service still drops master -- this matches the 0.4.13 gate and
+         * avoids regressing the VT-switch blackout fix when capget is filtered. */
+        return (geteuid() == 0 || getuid() == 0);
+    }
+    /* CAP_SYS_ADMIN (21) lives in the first 32-bit word. */
+    return (data[0].effective & (1u << CAP_SYS_ADMIN)) != 0;
+}
 
 /* Error string for when ctx is NULL (from failed drmtap_open). Thread-local so
  * concurrent NULL-ctx failures on different threads don't race on one buffer. */
@@ -252,18 +278,19 @@ drmtap_ctx *drmtap_open(const drmtap_config *config) {
         /* If fcntl fails, keep the original fd (best effort) */
     }
 
-    /* Defensively drop DRM master -- but ONLY when we are privileged (root /
-     * CAP_SYS_ADMIN). We only READ scanout and never modeset, so if a PRIVILEGED
-     * process opened the node while no client held master (e.g. an unattended capture
-     * service that started at boot before the compositor), the kernel granted it
-     * implicit master, which would then block the compositor from acquiring master on
-     * a VT switch -> a black/frozen display; dropping it is safe there because
-     * drmModeGetFB2 still returns handles via CAP_SYS_ADMIN. An UNPRIVILEGED caller,
-     * by contrast, has no CAP_SYS_ADMIN and RELIES on that implicit master for
-     * drmModeGetFB2 to return framebuffer handles at all, so it must keep it -- do
-     * not drop. drmDropMaster returns 0 only when we actually held master; when a
+    /* Defensively drop DRM master -- but ONLY when we hold CAP_SYS_ADMIN. We only
+     * READ scanout and never modeset, so if a process holding CAP_SYS_ADMIN opened
+     * the node while no client held master (e.g. an unattended capture service that
+     * started at boot before the compositor), the kernel granted it implicit master,
+     * which would then block the compositor from acquiring master on a VT switch ->
+     * a black/frozen display; dropping it is safe there because drmModeGetFB2 still
+     * returns handles via CAP_SYS_ADMIN. A caller WITHOUT CAP_SYS_ADMIN -- including a
+     * uid-0 process that dropped it -- RELIES on that implicit master for drmModeGetFB2
+     * to return framebuffer handles at all, so it must keep it. The gate is the
+     * capability, not the uid: uid 0 without CAP_SYS_ADMIN cannot use GetFB2 after
+     * losing master. drmDropMaster returns 0 only when we actually held master; when a
      * compositor already holds it (the normal desktop case) it is a harmless no-op. */
-    if ((geteuid() == 0 || getuid() == 0) &&
+    if (drmtap_have_cap_sys_admin() &&
         drmDropMaster(ctx->drm_fd) == 0) {
         drmtap_debug_log(ctx, "dropped implicit DRM master on %s", ctx->device_path);
     }

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -47,8 +47,7 @@ struct drmtap_ctx {
     int is_render_only;
 
     /* Cached resources for hotplug detection */
-    uint32_t cached_connector_count;
-    uint32_t cached_crtc_count;
+    uint64_t cached_topology_hash;  /* per-connector state fold; hotplug/modeset signal */
 
     /* Helper binary */
     char helper_path[512];
@@ -241,5 +240,13 @@ int drmtap_convert_rgb16(const void *src, void *dst,
                          uint32_t width, uint32_t height,
                          uint32_t src_stride, uint32_t dst_stride,
                          int bgr, uint32_t eotf, uint32_t max_nits);
+
+/* Reduce a half-float (FP16) scanout -- XRGB16161616F ('XR4H') and its BGR/alpha
+ * siblings, 8 bytes/pixel -- to 8-bit XRGB8888. FP16 carries linear light, decoded
+ * to linear then re-encoded through the sRGB OETF; HDR highlights (>1.0) clip.
+ * `bgr` selects channel order. (pixel_convert.c) */
+int drmtap_convert_rgb16f(const void *src, void *dst,
+                          uint32_t width, uint32_t height,
+                          uint32_t src_stride, uint32_t dst_stride, int bgr);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -698,6 +698,34 @@ static void ensure_linear_texture(egl_state_t *state, uint32_t w, uint32_t h) {
     state->tex_height = h;
 }
 
+/* True for a scanout fourcc carrying more than 8 bits per channel: the 10-bit
+ * XR30 family and the 16-bit XR48 family (integer and half-float). Such a buffer
+ * must NOT be reinterpreted as XRGB8888 during import retry -- that would sample it
+ * at the wrong bit depth (and, for the 16-bit formats, the wrong row width) and
+ * hand back a garbage frame reported as success. */
+static int egl_fourcc_high_bit_depth(uint32_t fourcc) {
+    switch (fourcc) {
+    /* 10-bit 2:10:10:10 */
+    case fourcc_code('X', 'R', '3', '0'):
+    case fourcc_code('X', 'B', '3', '0'):
+    case fourcc_code('A', 'R', '3', '0'):
+    case fourcc_code('A', 'B', '3', '0'):
+    /* 16-bit integer */
+    case fourcc_code('X', 'R', '4', '8'):
+    case fourcc_code('X', 'B', '4', '8'):
+    case fourcc_code('A', 'R', '4', '8'):
+    case fourcc_code('A', 'B', '4', '8'):
+    /* 16-bit half-float */
+    case fourcc_code('X', 'R', '4', 'H'):
+    case fourcc_code('X', 'B', '4', 'H'):
+    case fourcc_code('A', 'R', '4', 'H'):
+    case fourcc_code('A', 'B', '4', 'H'):
+        return 1;
+    default:
+        return 0;
+    }
+}
+
 /* Import a DMA-BUF as an EGLImage, retrying with progressively simpler
  * attribute sets (XRGB8888 keeping the modifier, then XRGB8888 alone) the way
  * some drivers need. CCS auxiliary planes come from ctx->fb2_*. Returns
@@ -784,6 +812,19 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
                          first_err, (const char *)&fourcc,
                          (unsigned long)modifier);
 
+        /* The XRGB8888 retries below reinterpret the buffer as 8-bit while keeping
+         * the source stride. That only makes sense for a genuine 8-bit scanout whose
+         * exact fourcc the driver does not recognize. For a high-bit-depth source
+         * (10-bit XR30 / 16-bit XR48 family) it would sample the wrong bit depth and
+         * return corruption as success, so fail the import instead: the caller then
+         * reduces the real bit depth from the raw mapping on the CPU. */
+        if (egl_fourcc_high_bit_depth(fourcc)) {
+            drmtap_debug_log(ctx, "egl: no XRGB8888 retry for high-bit-depth "
+                             "fourcc %.4s (would corrupt); failing import so the "
+                             "CPU reduce path runs", (const char *)&fourcc);
+            return EGL_NO_IMAGE_KHR;
+        }
+
         /* Retry with XRGB8888 but keep modifier — the driver needs
          * the modifier for detiling but may support 8-bit import */
         uint32_t xrgb8888 = DRM_FORMAT_XRGB8888;
@@ -798,7 +839,7 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
         retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_FD_EXT;
         retry_attribs[ri++] = dma_buf_fd;
         retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
-        retry_attribs[ri++] = 0;
+        retry_attribs[ri++] = (EGLint)ctx->fb2_offsets[0];
         retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
         retry_attribs[ri++] = (EGLint)stride;
         if (modifier != DRM_FORMAT_MOD_INVALID) {
@@ -826,7 +867,7 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
             retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_FD_EXT;
             retry_attribs[ri++] = dma_buf_fd;
             retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_OFFSET_EXT;
-            retry_attribs[ri++] = 0;
+            retry_attribs[ri++] = (EGLint)ctx->fb2_offsets[0];
             retry_attribs[ri++] = EGL_DMA_BUF_PLANE0_PITCH_EXT;
             retry_attribs[ri++] = (EGLint)stride;
             retry_attribs[ri++] = EGL_NONE;
@@ -1006,7 +1047,10 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     }
     if (!eglMakeCurrent(state.display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                         state.context)) {
+        /* Without a current context every GL call below is a no-op that leaves
+         * the output buffer undefined; fail instead of returning garbage. */
         drmtap_debug_log(NULL, "EGL: eglMakeCurrent in convert failed: 0x%x", eglGetError());
+        return -EIO;
     }
 
     /* ── Import-once: EGLImage cache keyed by fb_id ── */
@@ -1190,7 +1234,16 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     }
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
                  ctx->deswizzle_buf);
-    drmtap_debug_log(NULL, "EGL: glReadPixels done, gl_err=0x%x", glGetError());
+    /* A GL error across the render + readback (notably GL_CONTEXT_LOST after a GPU
+     * reset/TDR) means deswizzle_buf holds stale or undefined pixels. Fail closed
+     * instead of returning them as a valid frame. This glGetError also drains the
+     * error state so the next convert starts clean. */
+    GLenum gl_err = glGetError();
+    if (gl_err != GL_NO_ERROR) {
+        drmtap_debug_log(NULL, "EGL: GL error 0x%x across convert, failing", gl_err);
+        ret = -EIO;
+        goto cleanup;
+    }
 
     /* NOTE: CPU horizontal flip removed. The EGL DMA-BUF import with
      * standard texcoords (no shader manipulation) produces correct

--- a/src/pixel_convert.c
+++ b/src/pixel_convert.c
@@ -225,7 +225,7 @@ static int deswizzle_nvidia_x_tiled(const void *src, void *dst,
 static void convert_ar30_to_xrgb8888(const void *src, void *dst,
                                      uint32_t width, uint32_t height,
                                      uint32_t src_stride,
-                                     uint32_t dst_stride) {
+                                     uint32_t dst_stride, int bgr) {
     for (uint32_t y = 0; y < height; y++) {
         const uint32_t *s = (const uint32_t *)
             ((const uint8_t *)src + y * src_stride);
@@ -234,9 +234,13 @@ static void convert_ar30_to_xrgb8888(const void *src, void *dst,
 
         for (uint32_t x = 0; x < width; x++) {
             uint32_t pixel = s[x];
-            uint8_t r = (uint8_t)((pixel >> 22) & 0xFF);  /* [29:20] >> 2 */
-            uint8_t g = (uint8_t)((pixel >> 12) & 0xFF);  /* [19:10] >> 2 */
-            uint8_t b = (uint8_t)((pixel >> 2) & 0xFF);   /* [9:0] >> 2 */
+            /* Top 8 bits of each 10-bit channel. RGB: R[29:20] G[19:10] B[9:0];
+             * BGR (XB30/AB30) swaps the two outer channels. */
+            uint8_t c_hi = (uint8_t)((pixel >> 22) & 0xFF);  /* [29:20] >> 2 */
+            uint8_t g = (uint8_t)((pixel >> 12) & 0xFF);     /* [19:10] >> 2 */
+            uint8_t c_lo = (uint8_t)((pixel >> 2) & 0xFF);   /* [9:0] >> 2 */
+            uint8_t r = bgr ? c_lo : c_hi;
+            uint8_t b = bgr ? c_hi : c_lo;
             d[x] = (0xFFu << 24) | ((uint32_t)r << 16) |
                    ((uint32_t)g << 8) | b;
         }
@@ -379,9 +383,11 @@ int drmtap_deswizzle(const void *src, void *dst,
 #define DRMTAP_SDR_WHITE_NITS 203.0
 
 #define DRMTAP_PQ_LUT_N   1024    /* one entry per 10-bit code value */
+#define DRMTAP_PQ_LUT16_N 65536   /* one entry per 16-bit code value */
 #define DRMTAP_SRGB_LUT_N 4096    /* linear [0,1] -> 8-bit sRGB */
 
-static float   g_pq_lut[DRMTAP_PQ_LUT_N];      /* code -> luminance (nits) */
+static float   g_pq_lut[DRMTAP_PQ_LUT_N];      /* 10-bit code -> luminance (nits) */
+static float   g_pq_lut16[DRMTAP_PQ_LUT16_N];  /* 16-bit code -> luminance (nits) */
 static uint8_t g_srgb_lut[DRMTAP_SRGB_LUT_N];  /* linear [0,1] -> 8-bit sRGB */
 static pthread_once_t g_hdr_once = PTHREAD_ONCE_INIT;
 
@@ -413,6 +419,9 @@ static double srgb_oetf(double c) {
 static void hdr_lut_init(void) {
     for (int i = 0; i < DRMTAP_PQ_LUT_N; i++) {
         g_pq_lut[i] = (float)pq_eotf_nits((double)i / (DRMTAP_PQ_LUT_N - 1));
+    }
+    for (int i = 0; i < DRMTAP_PQ_LUT16_N; i++) {
+        g_pq_lut16[i] = (float)pq_eotf_nits((double)i / (DRMTAP_PQ_LUT16_N - 1));
     }
     for (int i = 0; i < DRMTAP_SRGB_LUT_N; i++) {
         double s = srgb_oetf((double)i / (DRMTAP_SRGB_LUT_N - 1));
@@ -479,8 +488,10 @@ int drmtap_tonemap_hdr10(const void *src, void *dst,
     if (!src || !dst || width == 0 || height == 0) {
         return -EINVAL;
     }
-    /* XR30 = XRGB2101010 ('XR30'), AR30 = ARGB2101010 ('AR30'). */
-    if (src_format != 0x30335258u && src_format != 0x30335241u) {
+    /* XR30/AR30 = X/ARGB2101010 (RGB order), XB30/AB30 = X/ABGR2101010 (BGR). */
+    int is_rgb = (src_format == 0x30335258u || src_format == 0x30335241u);
+    int is_bgr = (src_format == 0x30334258u || src_format == 0x30334241u);
+    if (!is_rgb && !is_bgr) {
         return -ENOTSUP;
     }
     /* Both buffers are 4 bytes/pixel; a stride that cannot hold a full row
@@ -500,11 +511,14 @@ int drmtap_tonemap_hdr10(const void *src, void *dst,
         uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
         for (uint32_t x = 0; x < width; x++) {
             uint32_t pixel = s[x];
-            /* 10-bit channels, ARGB2101010: R[29:20] G[19:10] B[9:0]. */
+            /* 10-bit channels. RGB: R[29:20] G[19:10] B[9:0]; BGR swaps the two
+             * outer channels (B[29:20] R[9:0]). */
+            uint32_t c_hi = (pixel >> 20) & 0x3FF;
+            uint32_t c_lo = (pixel)       & 0x3FF;
             uint8_t r, g, b;
-            tonemap_rgb_linear(g_pq_lut[(pixel >> 20) & 0x3FF],
+            tonemap_rgb_linear(g_pq_lut[is_bgr ? c_lo : c_hi],
                                g_pq_lut[(pixel >> 10) & 0x3FF],
-                               g_pq_lut[(pixel)       & 0x3FF],
+                               g_pq_lut[is_bgr ? c_hi : c_lo],
                                peak_n, &r, &g, &b);
             d[x] = (0xFFu << 24) | ((uint32_t)r << 16) |
                    ((uint32_t)g << 8) | b;
@@ -548,9 +562,9 @@ int drmtap_convert_rgb16(const void *src, void *dst,
             uint8_t r8, g8, b8;
             if (hdr) {
                 /* 16-bit PQ -> BT.2020 linear nits -> tone-map -> SDR. */
-                tonemap_rgb_linear(pq_eotf_nits((double)cr / 65535.0),
-                                   pq_eotf_nits((double)cg / 65535.0),
-                                   pq_eotf_nits((double)cb / 65535.0),
+                tonemap_rgb_linear(g_pq_lut16[cr],
+                                   g_pq_lut16[cg],
+                                   g_pq_lut16[cb],
                                    peak_n, &r8, &g8, &b8);
             } else {
                 /* Plain SDR 16-bit -> 8-bit (keep the high byte). */
@@ -565,11 +579,98 @@ int drmtap_convert_rgb16(const void *src, void *dst,
     return 0;
 }
 
+/* IEEE 754 binary16 -> binary32. */
+static float half_to_float(uint16_t h) {
+    uint32_t sign = (uint32_t)(h & 0x8000u) << 16;
+    uint32_t exp = (h >> 10) & 0x1Fu;
+    uint32_t mant = h & 0x3FFu;
+    uint32_t bits;
+    if (exp == 0) {
+        if (mant == 0) {
+            bits = sign;                       /* +/-0 */
+        } else {                               /* subnormal */
+            exp = 127u - 15u + 1u;
+            while ((mant & 0x400u) == 0) { mant <<= 1; exp--; }
+            mant &= 0x3FFu;
+            bits = sign | (exp << 23) | (mant << 13);
+        }
+    } else if (exp == 0x1Fu) {                 /* Inf / NaN */
+        bits = sign | 0x7F800000u | (mant << 13);
+    } else {
+        bits = sign | ((exp - 15u + 127u) << 23) | (mant << 13);
+    }
+    float out;
+    memcpy(&out, &bits, sizeof(out));
+    return out;
+}
+
+/* Linear light [0,1] -> 8-bit sRGB via the shared OETF LUT (caller runs the
+ * pthread_once). Clamps out-of-range (HDR highlights, NaN) into [0,255]. */
+static uint8_t srgb8_from_linear(float f) {
+    if (!(f > 0.0f)) {           /* <= 0 or NaN */
+        return 0;
+    }
+    if (f >= 1.0f) {
+        return 255;
+    }
+    int i = (int)(f * (float)(DRMTAP_SRGB_LUT_N - 1) + 0.5f);
+    return g_srgb_lut[i];
+}
+
+/* Convert a half-float scanout (XRGB16161616F and its BGR/alpha siblings, fourcc
+ * 'XR4H' etc., 8 bytes/pixel) to 8-bit XRGB8888. FP16 scanouts carry LINEAR light,
+ * so each half is decoded to linear and re-encoded through the sRGB OETF -- unlike
+ * the integer 16-bit path, which treats its samples as already sRGB-encoded. HDR
+ * values above 1.0 clip to white: a faithful HDR tone-map needs the FP16 colorimetry
+ * the caller does not carry here, so this favors a correct, viewable SDR-range
+ * result over a speculative remap (and is still far better than the raw 16-bit bytes
+ * a consumer would otherwise misread as XRGB8888). */
+int drmtap_convert_rgb16f(const void *src, void *dst,
+                          uint32_t width, uint32_t height,
+                          uint32_t src_stride, uint32_t dst_stride, int bgr) {
+    if (!src || !dst || width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    size_t src_row = (size_t)width * 8u;
+    size_t dst_row = (size_t)width * 4u;
+    if (src_row > UINT32_MAX || dst_row > UINT32_MAX ||
+        src_stride < src_row || dst_stride < dst_row) {
+        return -EINVAL;
+    }
+    pthread_once(&g_hdr_once, hdr_lut_init);   /* fills g_srgb_lut */
+    /* Memory order of the 16-bit quad is B,G,R,X for the RGB variants (XR4H/AR4H)
+     * and R,G,B,X for the BGR variants (XB4H/AB4H) -- identical to the integer
+     * drmtap_convert_rgb16 path, so red sits at unit 2 unless bgr. */
+    int ri = bgr ? 0 : 2;
+    int bi = bgr ? 2 : 0;
+    for (uint32_t y = 0; y < height; y++) {
+        const uint16_t *s = (const uint16_t *)
+            ((const uint8_t *)src + (size_t)y * src_stride);
+        uint32_t *d = (uint32_t *)((uint8_t *)dst + (size_t)y * dst_stride);
+        for (uint32_t x = 0; x < width; x++) {
+            const uint16_t *px = s + (size_t)x * 4;
+            uint8_t r8 = srgb8_from_linear(half_to_float(px[ri]));
+            uint8_t g8 = srgb8_from_linear(half_to_float(px[1]));
+            uint8_t b8 = srgb8_from_linear(half_to_float(px[bi]));
+            d[x] = (0xFFu << 24) | ((uint32_t)r8 << 16) |
+                   ((uint32_t)g8 << 8) | b8;
+        }
+    }
+    return 0;
+}
+
 int drmtap_convert_format(const void *src, void *dst,
                           uint32_t width, uint32_t height,
                           uint32_t src_stride, uint32_t dst_stride,
                           uint32_t src_format, uint32_t dst_format) {
     if (!src || !dst || width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    /* Every format this converter handles (AR30/XR30 source, XRGB8888 dest, and
+     * the same-format copy) is 4 bytes/pixel, so a stride narrower than width*4
+     * would read or write past each row. Reject like drmtap_convert_rgb16 does. */
+    if ((size_t)src_stride < (size_t)width * 4u ||
+        (size_t)dst_stride < (size_t)width * 4u) {
         return -EINVAL;
     }
 
@@ -596,14 +697,20 @@ int drmtap_convert_format(const void *src, void *dst,
     #define DRM_FMT_ABGR8888    0x34324241u
     #define DRM_FMT_XRGB2101010 0x30335258u
     #define DRM_FMT_ARGB2101010 0x30335241u
+    #define DRM_FMT_XBGR2101010 0x30334258u
+    #define DRM_FMT_ABGR2101010 0x30334241u
 
-    /* AR30/XR30 → XRGB8888/ARGB8888 */
+    /* X/AR30 (RGB) and X/AB30 (BGR) 10-bit → XRGB8888/ARGB8888 */
     if ((src_format == DRM_FMT_XRGB2101010 ||
-         src_format == DRM_FMT_ARGB2101010) &&
+         src_format == DRM_FMT_ARGB2101010 ||
+         src_format == DRM_FMT_XBGR2101010 ||
+         src_format == DRM_FMT_ABGR2101010) &&
         (dst_format == DRM_FMT_XRGB8888 ||
          dst_format == DRM_FMT_ARGB8888)) {
+        int bgr = (src_format == DRM_FMT_XBGR2101010 ||
+                   src_format == DRM_FMT_ABGR2101010);
         convert_ar30_to_xrgb8888(src, dst, width, height,
-                                 src_stride, dst_stride);
+                                 src_stride, dst_stride, bgr);
         return 0;
     }
 

--- a/tests/test_deswizzle.c
+++ b/tests/test_deswizzle.c
@@ -228,7 +228,20 @@ static void test_convert_ar30_to_xrgb8888(void) {
     uint8_t b2 = (uint8_t)(dst[2] & 0xFF);
     TEST_ASSERT(b2 == 255);
 
-    printf("  PASS: AR30 → XRGB8888 conversion\n");
+    /* BGR variant XBGR2101010 (XB30, 0x30334258) = [2:A][10:B][10:G][10:R], so a
+     * pure-red pixel has R in the LOW 10 bits; the output red byte must be 255 and
+     * blue 0 (locks in the RGB/BGR swap of convert_ar30_to_xrgb8888). */
+    uint32_t bsrc[2], bdst[2];
+    bsrc[0] = (3u << 30) | (0u << 20) | (0u << 10) | 1023u;   /* R=1023 (low bits) */
+    bsrc[1] = (3u << 30) | (1023u << 20) | (0u << 10) | 0u;   /* B=1023 (high bits) */
+    TEST_ASSERT(drmtap_convert_format(bsrc, bdst, 2, 1, 8, 8,
+                                      0x30334258u, 0x34325258u) == 0);
+    TEST_ASSERT(((bdst[0] >> 16) & 0xFF) == 255);  /* pixel0 red = 255 */
+    TEST_ASSERT((bdst[0] & 0xFF) == 0);            /* pixel0 blue = 0 */
+    TEST_ASSERT((bdst[1] & 0xFF) == 255);          /* pixel1 blue = 255 */
+    TEST_ASSERT(((bdst[1] >> 16) & 0xFF) == 0);    /* pixel1 red = 0 */
+
+    printf("  PASS: AR30/AB30 → XRGB8888 conversion\n");
 }
 
 static void test_convert_abgr_to_argb(void) {

--- a/tests/test_hdr.c
+++ b/tests/test_hdr.c
@@ -146,7 +146,20 @@ static void test_rgb16(void) {
     TEST_ASSERT(((o_rgb >> 8) & 0xFF) == 0x22 &&
                 ((o_bgr >> 8) & 0xFF) == 0x22);   /* G is px[1] either way */
     TEST_ASSERT((o_rgb & 0xFF) == 0x11 && (o_bgr & 0xFF) == 0x33);  /* B swaps */
-    printf("  PASS: rgb16 HDR tone-map + SDR reduce + channel order\n");
+
+    /* Half-float FP16 (XR4H) channel order: half(1.0)=0x3C00, half(0.0)=0x0000.
+     * Memory order matches the integer path (B,G,R,X for the RGB variant), so a
+     * pure-red pixel must land in the output red byte, not blue. This locks in the
+     * ri/bi order of drmtap_convert_rgb16f. */
+    uint16_t fp[4] = {0x0000, 0x0000, 0x3C00, 0xFFFF};  /* B=0, G=0, R=1.0 */
+    uint32_t f_rgb = 0, f_bgr = 0;
+    TEST_ASSERT(drmtap_convert_rgb16f(fp, &f_rgb, 1, 1, 8, 4, 0 /*RGB*/) == 0);
+    TEST_ASSERT(drmtap_convert_rgb16f(fp, &f_bgr, 1, 1, 8, 4, 1 /*BGR*/) == 0);
+    TEST_ASSERT(((f_rgb >> 16) & 0xFF) == 0xFF);  /* RGB: R = px[2] = 1.0 */
+    TEST_ASSERT((f_rgb & 0xFF) == 0x00);          /* RGB: B = px[0] = 0.0 */
+    TEST_ASSERT(((f_bgr >> 16) & 0xFF) == 0x00);  /* BGR: R = px[0] = 0.0 */
+    TEST_ASSERT((f_bgr & 0xFF) == 0xFF);          /* BGR: B = px[2] = 1.0 */
+    printf("  PASS: rgb16/rgb16f HDR tone-map + SDR reduce + channel order\n");
 }
 
 int main(void) {


### PR DESCRIPTION
Two DRM/KMS capture correctness fixes, both learned from studying Sunshine's kmsgrab (technique only, clean reimplementation - Sunshine is GPL, this is MIT).

- **Drop implicit DRM master** after opening the card node, in both the library and the privileged helper. libdrmtap only reads scanout and never modesets, but if it opened the node while no client held master the kernel granted it implicitly, blocking a compositor from reacquiring master on a VT switch (black/frozen display). drmDropMaster is a no-op when we did not hold it.
- **Honor the DRM_MODE_FB_MODIFIERS flag** before trusting fb2->modifier. drmModeGetFB2 leaves the modifier undefined when the flag is clear, so a driver tiling the scanout without advertising a modifier was imported as if linear and corrupted (the recurring 10-bit XR30 class). When the flag is clear the modifier is now DRM_FORMAT_MOD_INVALID, so the EGL import omits the modifier attribute and the driver infers the layout; the CPU fallback still treats an unknown modifier as linear, and the helper routes it to the export path with the dumb-map fallback intact.

Both configs build, 8/8 tests pass. No API/ABI change.