### PR TITLE
0.4.15: fail closed on undecodable scanouts, sync the cursor DMA-BUF read, tighten the EGL import retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 
 ### Added
 
+- drmtap_list_devices(): enumerate every DRM device with KMS resources, with its
+  card node, render node, driver and active-display count. A context is bound to
+  ONE device, so drmtap_list_displays() could only ever advertise the displays of
+  the card drmtap_open() settled on, and the monitors of every other GPU were
+  invisible. This is the discovery step a multi-GPU consumer needs to open one
+  context per device. Connector state is not re-probed, so enumerating does not
+  disturb a live display. The drmtap_device layout is frozen for the same reason
+  drmtap_dmabuf_desc is.
 - drmtap_render_node(): the render node of the DRM device a context is bound to.
   On a split deployment the privileged exporter calls it on its capture context
   and hands the path to the unprivileged converter, so drmtap_open_render()
@@ -22,6 +30,13 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 
 ### Fixed
 
+- Device auto-detection now picks the GPU driving the MOST displays instead of
+  the first card with any active CRTC, which was really just "lowest minor
+  wins". Loading vkms next to a real GPU demonstrates the old behaviour: vkms
+  registers as card0 with a single 1024x768 virtual output, so auto-detect
+  captured that and not the three real monitors on card1. It stays a heuristic
+  for the single-context case; a caller that wants every display enumerates with
+  drmtap_list_devices().
 - drmtap_open_render(NULL) no longer takes the first openable render node, which
   was the wrong device on a multi-GPU host: the scanout is exported by the card
   that drives the display, and importing it into another vendor render node can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Notable changes to libdrmtap. Loosely follows Keep a Changelog; the project uses
 semantic versioning. The C library, the `libdrmtap-sys` crate and the meson
 project share one version; the `libdrmtap` wrapper crate is versioned separately.
 
-## [0.4.15] - 2026-07-23
+## [0.4.15] - 2026-07-24
 
 ### Added
 
@@ -55,7 +55,6 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
   different device now tears down and rebuilds its GL context rather than
   sampling another GPU display, and EGL availability is cached per device too, so
   a compute GPU without EGL next to one with it is answered correctly.
-
 - A CCS-compressed (or otherwise undecodable) scanout reaching the CPU deswizzle
   path no longer returns the raw compressed bytes relabelled linear as a valid
   frame. Two defects combined: gpu_auto_process suppressed the deswizzle -ENOTSUP,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ Notable changes to libdrmtap. Loosely follows Keep a Changelog; the project uses
 semantic versioning. The C library, the `libdrmtap-sys` crate and the meson
 project share one version; the `libdrmtap` wrapper crate is versioned separately.
 
+## [0.4.15] - 2026-07-23
+
+### Fixed
+
+- A CCS-compressed (or otherwise undecodable) scanout reaching the CPU deswizzle
+  path no longer returns the raw compressed bytes relabelled linear as a valid
+  frame. Two defects combined: gpu_auto_process suppressed the deswizzle -ENOTSUP,
+  set the modifier to linear and returned success; and do_grab (the body of both
+  drmtap_grab and drmtap_grab_mapped) discarded gpu_auto_process return value at its
+  direct-mmap, helper-V2 and helper-V3 call sites. Either alone forwarded a corrupt
+  frame instead of failing over. gpu_auto_process now returns -ENOTSUP, and do_grab
+  propagates a non-zero process result (releasing the frame first) at all three
+  sites, so the caller ends the stream and falls back. The symmetric case is closed
+  too: a real (non-linear, non-INVALID) tiling modifier on a driver with no CPU
+  deswizzle and no working EGL now also returns -ENOTSUP instead of the raw tiled
+  bytes relabelled linear. do_grab error exits are uniform (every path leaves the
+  frame owning nothing), so a defensive double-release is a harmless no-op.
+- The cursor DMA-BUF read is now bracketed with the DMA_BUF_IOCTL_SYNC START/END
+  pair the main frame path already uses, in both the direct path and the privileged
+  helper. DMA-BUF CPU access is not guaranteed coherent, so a non-coherent exporter
+  (ARM / Tegra / Jetson) could return stale or partially updated cursor pixels, which
+  a content-hash consumer then suppressed and the remote cursor froze.
+- The EGL XRGB8888 import-retry is now restricted to a single-plane 8-bit RGB source
+  (XRGB8888 / ARGB8888). Reinterpreting anything else as XRGB8888 returned corruption
+  as success: a BGR order swapped red and blue, and a multi-plane / CCS-compressed
+  buffer dropped its auxiliary planes so the shader sampled compressed data. Such an
+  import now fails so the caller falls back, instead of retrying into a wrong layout.
+  The final no-modifier retry is now also gated to a LINEAR source: dropping a real
+  tiling modifier made EGL sample tiled bytes as linear and return corruption as
+  success. (Extends the 0.4.14 high-bit-depth and plane-0-offset retry fixes.)
+
 ## [0.4.14] - 2026-07-22
 
 ### Fixed
@@ -236,6 +267,7 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 - amdgpu EGL detile fix, privileged-helper hardening, and a batch of full-audit
   fixes.
 
+[0.4.15]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.15
 [0.4.14]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.14
 [0.4.13]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.13
 [0.4.12]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,40 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 
 ## [0.4.15] - 2026-07-23
 
+### Added
+
+- drmtap_render_node(): the render node of the DRM device a context is bound to.
+  On a split deployment the privileged exporter calls it on its capture context
+  and hands the path to the unprivileged converter, so drmtap_open_render()
+  binds to the GPU that exported the frame rather than to whichever node
+  auto-selection happened to reach. Deliberately a separate accessor and not a
+  new field in drmtap_dmabuf_desc: that struct is written by drmtap_grab_desc()
+  into caller-owned storage, so growing it would corrupt a consumer built
+  against an older header but running against a newer .so, which is exactly the
+  dlopen-by-soname deployment this library targets. The descriptor layout stays
+  frozen, and a consumer that dlopens can treat an absent symbol as an older
+  library.
+
 ### Fixed
+
+- drmtap_open_render(NULL) no longer takes the first openable render node, which
+  was the wrong device on a multi-GPU host: the scanout is exported by the card
+  that drives the display, and importing it into another vendor render node can
+  fail permanently on an incompatible tiling modifier. Auto-selection now
+  prefers the render node of a card with a connected and enabled connector, then
+  a card with a connected connector, and only then falls back to the historical
+  first-openable scan. The ranking is read from sysfs so it needs no rights on
+  the KMS cards, which the unprivileged converter may not have. Verified on a
+  Jetson Orin, where card1 is tegra with no connectors and card2 is nvidia-drm
+  driving the connected DP-1: selection moved from renderD128 to renderD129, the
+  node that actually exports the scanout.
+- The EGL display is now resolved and cached per DRM device instead of once per
+  process. A single process-wide display is bound to whichever GPU converted
+  first, so on a multi-GPU host it kept serving imports of scanouts exported by
+  the other card, which can fail permanently. A capture thread that moves to a
+  different device now tears down and rebuilds its GL context rather than
+  sampling another GPU display, and EGL availability is cached per device too, so
+  a compute GPU without EGL next to one with it is answered correctly.
 
 - A CCS-compressed (or otherwise undecodable) scanout reaching the CPU deswizzle
   path no longer returns the raw compressed bytes relabelled linear as a valid

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 |---|---|
 | VMs (virtio_gpu, Parallels, QEMU) | ✅ Verified |
 | Multi-monitor (per-CRTC) | ✅ Implemented |
+| Multi-GPU (enumerate every card + bind convert to the exporting GPU) | ✅ Implemented |
+| Split capture (privileged export + unprivileged convert) | ✅ Implemented |
 | Zero-copy DMA-BUF output (V3) | ✅ Implemented |
 | Mapped RGBA output | ✅ Verified |
 | Continuous capture (polling loop) | ✅ Verified |
@@ -93,6 +95,12 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 > `virtio_gpu` (QEMU/Parallels VMs), Intel Meteor Lake (`i915`, dual 3840x2160,
 > EGL CCS detiling), and NVIDIA Jetson Orin Nano (`nvidia-drm`, aarch64, Wayland).
 > The AMD (`amdgpu`) backend is verified on real hardware (RX Vega 64, gfx9, via the EGL detile path — see [#26](https://github.com/fxd0h/libdrmtap/issues/26)).
+> **Multi-GPU render-node selection is verified on the Jetson Orin's two DRM
+> devices** (`tegra`/renderD128 with no connectors + `nvidia-drm`/renderD129
+> driving the display): the converter now binds renderD129, the node that
+> exported the scanout. The multi-card display *merge* (one monitor per GPU on two
+> display-driving GPUs) is implemented but not yet verified end-to-end for lack of
+> such hardware.
 > If you test on real hardware, please [report results](https://github.com/fxd0h/libdrmtap/issues).
 >
 > ℹ️ **virgl note**: Plain `virtio-gpu` is captured with a direct linear map. A
@@ -274,7 +282,7 @@ Every existing project is either a complete application, a plugin, or PipeWire-b
 │      (RustDesk, Sunshine, VNC, custom)          │
 ├─────────────────────────────────────────────────┤
 │              libdrmtap.h                        │
-│          Public API — ~10 functions             │
+│          Public API — ~20 functions             │
 ├─────────────────────────────────────────────────┤
 │                                                 │
 │  ┌────────────┐  ┌─────────┐  ┌──────────────┐  │
@@ -314,7 +322,7 @@ libdrmtap uses a **dual-path** approach for GPU-tiled framebuffers:
 | Manage permissions transparently | Inject keyboard/mouse input |
 | Support Intel, AMD, Nvidia, VMs | Replace Wayland's screen sharing protocols |
 | Provide cursor position + shape | Implement a VNC/RDP server |
-| Enumerate displays and monitors | |
+| Enumerate displays and monitors across multiple GPUs | |
 | Detect changed regions (dirty rects) | |
 
 **Wayland positioning**: For interactive desktop sharing where user consent matters, use Wayland protocols (`ext-image-capture-source-v1`, PipeWire). For unattended system-level capture (servers, kiosks, CI, remote management, **login screens**), use libdrmtap. We complement Wayland — we don't compete with it.

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.14"
+version = "0.4.15"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/cursor.c
+++ b/bindings/rust/libdrmtap-sys/csrc/cursor.c
@@ -31,6 +31,7 @@
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <linux/dma-buf.h>  /* struct dma_buf_sync, DMA_BUF_IOCTL_SYNC */
 
 #include "drmtap_internal.h"
 
@@ -211,6 +212,16 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                 void *mapped = mmap(NULL, map_size, PROT_READ, MAP_SHARED,
                                     prime_fd, 0);
                 if (mapped != MAP_FAILED) {
+                    /* Bracket the CPU read with a DMA-BUF sync, exactly as the
+                     * main frame path does. DMA-BUF CPU access is not guaranteed
+                     * coherent, so a non-coherent exporter (ARM / Tegra / Jetson)
+                     * can otherwise hand back stale or partially-updated cursor
+                     * pixels -- which the caller's content hash then suppresses,
+                     * freezing the remote cursor. */
+                    struct dma_buf_sync sync = {
+                        .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
+                    };
+                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
                     size_t tight = (size_t)fb2->width * fb2->height * 4;
                     cursor->pixels = malloc(tight);
                     if (cursor->pixels) {
@@ -223,6 +234,8 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                                    (size_t)fb2->width * 4);
                         }
                     }
+                    sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
                     munmap(mapped, map_size);
                 }
             }

--- a/bindings/rust/libdrmtap-sys/csrc/cursor.c
+++ b/bindings/rust/libdrmtap-sys/csrc/cursor.c
@@ -221,7 +221,20 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                     struct dma_buf_sync sync = {
                         .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
                     };
-                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
+                    /* Track whether START actually took, and only issue the
+                     * matching END if it did -- an unpaired END would unbalance
+                     * the exporter's CPU-access accounting. A failure is logged
+                     * and the read still proceeds: it degrades to the previous
+                     * (unsynchronised) behaviour rather than dropping the cursor
+                     * on an exporter that does not implement the ioctl, and a
+                     * stale cursor is cosmetic, not corruption. */
+                    int sync_started =
+                        drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync) == 0;
+                    if (!sync_started) {
+                        drmtap_debug_log(ctx,
+                            "cursor: DMA_BUF_SYNC_START failed (%s); reading "
+                            "without cache invalidation", strerror(errno));
+                    }
                     size_t tight = (size_t)fb2->width * fb2->height * 4;
                     cursor->pixels = malloc(tight);
                     if (cursor->pixels) {
@@ -234,8 +247,14 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                                    (size_t)fb2->width * 4);
                         }
                     }
-                    sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
-                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
+                    if (sync_started) {
+                        sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+                        if (drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync) != 0) {
+                            drmtap_debug_log(ctx,
+                                "cursor: DMA_BUF_SYNC_END failed (%s)",
+                                strerror(errno));
+                        }
+                    }
                     munmap(mapped, map_size);
                 }
             }

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -1103,6 +1103,9 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                 "auto-process: CCS modifier 0x%lx needs GPU deswizzle "
                 "(EGL/DMA-BUF), CPU deswizzle not possible -- failing closed",
                 (unsigned long)modifier);
+            drmtap_set_error(ctx,
+                "compressed scanout (modifier 0x%lx) needs a GPU deswizzle, "
+                "which is unavailable on this path", (unsigned long)modifier);
             return -ENOTSUP;
         }
         if (ret == 0) {
@@ -1158,6 +1161,9 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     drmtap_debug_log(ctx, "auto-process: unknown driver '%s' mod=0x%lx cannot "
                      "deswizzle and EGL unavailable -- failing closed",
                      driver, (unsigned long)modifier);
+    drmtap_set_error(ctx,
+        "tiled scanout (driver '%s', modifier 0x%lx) has no CPU deswizzle and "
+        "EGL detile is unavailable", driver, (unsigned long)modifier);
     return -ENOTSUP;
 }
 

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -663,11 +663,11 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             }
 
             drmModeFreeFB2(fb2);
-            /* For a virgl frame the GPU readback is the only way to get real
-             * pixels; if it failed, propagate the error rather than handing the
-             * caller a black frame. Non-virgl frames keep the prior best-effort
-             * behaviour (pret is ignored). */
-            if (is_virgl && pret != 0) {
+            /* Propagate ANY processing failure -- a virgl readback that produced no
+             * pixels, or an unconvertible CCS/compressed scanout that returned
+             * -ENOTSUP -- instead of handing the caller a black or still-compressed
+             * frame reported as valid. (Previously only virgl failures propagated.) */
+            if (pret != 0) {
                 /* Release everything this frame acquired (the DMA-BUF fd, the
                  * mmap and priv) — a failed grab is not released by the caller,
                  * so returning here without cleanup would leak them each grab. */
@@ -698,7 +698,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         frame->_priv = priv;
 
         if (do_mmap) {
-            gpu_auto_process(ctx, pixel_buf, frame, 0);
+            int pr = gpu_auto_process(ctx, pixel_buf, frame, 0);
+            if (pr != 0) {
+                /* Propagate a processing failure (e.g. an unconvertible CCS
+                 * scanout that returned -ENOTSUP) instead of handing back the
+                 * undecoded pixels reported as a valid frame. The caller does
+                 * not release a frame on error, so release priv here (V2 borrows
+                 * ctx->pixel_buf, so this frees priv only). */
+                drmModeFreeFB2(fb2);
+                drmtap_frame_release(ctx, frame);
+                return pr;
+            }
         }
 
         drmModeFreeFB2(fb2);
@@ -805,7 +815,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             drmtap_debug_log(ctx, "mapped %zu bytes at %p", size, mapped);
 
             /* Auto-deswizzle tiled framebuffers + format convert */
-            gpu_auto_process(ctx, mapped, frame, 0);
+            int pr = gpu_auto_process(ctx, mapped, frame, 0);
+            if (pr != 0) {
+                /* Propagate a processing failure (e.g. an unconvertible CCS
+                 * scanout that returned -ENOTSUP) instead of handing back the
+                 * still-tiled/compressed mmap reported as a valid frame. The
+                 * caller does not release a frame on error, so release the fd,
+                 * mmap (with its matching SYNC_END) and priv here. */
+                drmModeFreeFB2(fb2);
+                drmtap_frame_release(ctx, frame);
+                return pr;
+            }
         }
     }
 
@@ -825,6 +845,12 @@ cleanup:
         drmtap_gem_close(ctx, priv->gem_handle);
     }
     free(priv);
+    /* Leave the frame owning nothing on this error exit too, matching the
+     * drmtap_frame_release() the propagation sites use: priv is now freed, so a
+     * caller that defensively releases on a non-zero return gets a harmless no-op
+     * instead of a double-free through a dangling frame->_priv. */
+    frame->_priv = NULL;
+    frame->dma_buf_fd = -1;
     return ret;
 }
 
@@ -1066,18 +1092,18 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                                    frame->stride, frame->stride, modifier,
                                    (size_t)frame->stride * frame->height);
         if (ret == -ENOTSUP) {
-            /* CCS-compressed modifier — CPU deswizzle impossible.
-             * This happens in helper mode where dma_buf_fd is unavailable
-             * and the pixel data came from dumb_mmap (still compressed).
-             * Fall through to return raw data as-is with LINEAR modifier
-             * so the caller doesn't crash trying to deswizzle. */
+            /* CCS-compressed (or otherwise unsupported) modifier -- the CPU
+             * deswizzle cannot decode it and no EGL path produced linear pixels
+             * (helper V2 dumb-map, or EGL import/failure). Returning the raw
+             * compressed bytes relabelled LINEAR would hand the caller a corrupt
+             * frame reported as valid (drmtap_convert_dmabuf would forward garbage
+             * instead of failing over). Fail closed so the caller ends the stream
+             * and falls back (e.g. to PipeWire) instead. */
             drmtap_debug_log(ctx,
                 "auto-process: CCS modifier 0x%lx needs GPU deswizzle "
-                "(EGL/DMA-BUF), CPU deswizzle not possible — "
-                "returning raw pixels",
+                "(EGL/DMA-BUF), CPU deswizzle not possible -- failing closed",
                 (unsigned long)modifier);
-            frame->modifier = 0; /* DRM_FORMAT_MOD_LINEAR */
-            return 0;
+            return -ENOTSUP;
         }
         if (ret == 0) {
             frame->data = ctx->deswizzle_buf;
@@ -1122,9 +1148,17 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         return ret;
     }
 
-    drmtap_debug_log(ctx, "auto-process: unknown driver '%s' mod=0x%lx",
+    /* Real tiling modifier (non-LINEAR, non-INVALID -- a genuinely tiled scanout;
+     * linear/unknown-layout buffers already returned above) on a driver we have no
+     * CPU deswizzle for, and EGL did not detile it (unavailable, or it failed).
+     * Returning the raw tiled mapping relabelled linear would hand the caller
+     * corruption reported as valid -- the same failure the CCS branch now guards.
+     * Fail closed instead, symmetric with it, so the caller ends the stream and
+     * falls back (do_grab propagates this; e.g. rustdesk demotes to PipeWire). */
+    drmtap_debug_log(ctx, "auto-process: unknown driver '%s' mod=0x%lx cannot "
+                     "deswizzle and EGL unavailable -- failing closed",
                      driver, (unsigned long)modifier);
-    return 0;
+    return -ENOTSUP;
 }
 
 /* ========================================================================= */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -451,14 +451,30 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
     struct dma_buf_sync csync = {
         .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
     };
-    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
+    /* Track whether START took, and only issue the matching END if it did -- an
+     * unpaired END would unbalance the exporter's CPU-access accounting. On
+     * failure the read still proceeds: it degrades to the previous
+     * (unsynchronised) behaviour rather than dropping the cursor on an exporter
+     * that does not implement the ioctl, and a stale cursor is cosmetic. */
+    int csync_started = drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync) == 0;
+    if (!csync_started) {
+        fprintf(stderr,
+                "drmtap-helper: cursor DMA_BUF_SYNC_START failed: %s\n",
+                strerror(errno));
+    }
     for (uint32_t y = 0; y < ch; y++) {
         memcpy(packed + (size_t)y * cw * 4,
                (const uint8_t *)mapped + (size_t)y * cstride,
                (size_t)cw * 4);
     }
-    csync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
-    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
+    if (csync_started) {
+        csync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+        if (drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync) != 0) {
+            fprintf(stderr,
+                    "drmtap-helper: cursor DMA_BUF_SYNC_END failed: %s\n",
+                    strerror(errno));
+        }
+    }
     munmap(mapped, map_size);
     close(prime_fd);
     helper_gem_close(drm_fd, chandle);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap-helper.c
@@ -53,6 +53,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>  /* DRM_FORMAT_MOD_INVALID */
+#include <linux/dma-buf.h>  /* struct dma_buf_sync, DMA_BUF_IOCTL_SYNC */
 
 #ifdef HAVE_LIBCAP
 #include <sys/capability.h>
@@ -233,6 +234,26 @@ static int install_seccomp(void) {
         if (rc != 0) {
             seccomp_release(ctx);
             fprintf(stderr, "drmtap-helper: seccomp ioctl rule failed: %s\n",
+                    strerror(-rc));
+            return -1;
+        }
+    }
+
+    /* Also allow exactly DMA_BUF_IOCTL_SYNC (type 'b', not DRM's 'd', so it is
+     * NOT covered by the rule above). The cursor path brackets its DMA-BUF CPU
+     * read with this ioctl for cache coherence on non-coherent exporters
+     * (ARM / Tegra / Jetson). Matched by exact request value, not by type byte,
+     * to keep the widened surface to this single stable-ABI ioctl -- without it
+     * the SYNC call would fall through to SCMP_ACT_KILL_PROCESS and take the
+     * helper down on the first cursor poll under seccomp. */
+    {
+        int rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ioctl), 1,
+                                  SCMP_A1(SCMP_CMP_EQ,
+                                          (scmp_datum_t)DMA_BUF_IOCTL_SYNC));
+        if (rc != 0) {
+            seccomp_release(ctx);
+            fprintf(stderr,
+                    "drmtap-helper: seccomp dma-buf ioctl rule failed: %s\n",
                     strerror(-rc));
             return -1;
         }
@@ -420,11 +441,24 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
      * and heap churn. */
     static uint8_t packed[256 * 256 * 4];
     size_t tight = (size_t)cw * ch * 4;
+    /* Bracket the CPU read with a DMA-BUF sync, exactly as cursor.c and the
+     * frame path do. DMA-BUF CPU access is not guaranteed coherent, so a
+     * non-coherent exporter (ARM / Tegra / Jetson) can otherwise hand back
+     * stale cursor pixels -- which the client's content hash then suppresses,
+     * freezing the remote cursor. (DMA_BUF_IOCTL_SYNC is a 'b'-type ioctl, NOT
+     * the 'd' DRM type the other helper ioctls use, so install_seccomp() adds a
+     * dedicated allow rule for it -- otherwise this call would be KILLed.) */
+    struct dma_buf_sync csync = {
+        .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
+    };
+    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
     for (uint32_t y = 0; y < ch; y++) {
         memcpy(packed + (size_t)y * cw * 4,
                (const uint8_t *)mapped + (size_t)y * cstride,
                (size_t)cw * 4);
     }
+    csync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
     munmap(mapped, map_size);
     close(prime_fd);
     helper_gem_close(drm_fd, chandle);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -116,11 +116,24 @@ static int open_drm_auto(drmtap_ctx *ctx) {
     }
 
     /* Two-pass scan of /dev/dri/card0..card15:
-     *   Pass 1: find a device with an ACTIVE CRTC (monitor connected)
+     *   Pass 1: find the device driving the MOST displays (active CRTCs)
      *   Pass 2: fallback to any device with KMS resources
+     *
+     * A context covers ONE device, so on a multi-GPU host this pick decides
+     * which displays are capturable at all; drmtap_list_devices() is the way to
+     * reach the others. Until 0.4.15 this took the FIRST card with any active
+     * CRTC, which is just "lowest minor wins" and can be badly wrong: load vkms
+     * next to a real GPU and it registers as card0 with one 1024x768 virtual
+     * output, so auto-detect captured that instead of the three real monitors on
+     * card1. Ranking by active-CRTC count makes the single-card choice land on
+     * the GPU actually driving the desktop. It remains a heuristic — a caller
+     * that wants every display must enumerate devices.
      */
     int fallback_fd = -1;
     char fallback_path[64] = {0};
+    int best_fd = -1;
+    int best_active = 0;
+    char best_path[64] = {0};
 
     for (int i = 0; i < 16; i++) {
         snprintf(path, sizeof(path), "/dev/dri/card%d", i);
@@ -138,27 +151,34 @@ static int open_drm_auto(drmtap_ctx *ctx) {
             continue;
         }
 
-        /* Check for active CRTCs (monitor driving a display) */
-        int has_active = 0;
+        /* Count active CRTCs (monitors this device is driving) */
+        int active = 0;
         for (int j = 0; j < res->count_crtcs; j++) {
             drmModeCrtc *crtc = drmModeGetCrtc(fd, res->crtcs[j]);
             if (crtc) {
                 if (crtc->mode_valid && crtc->buffer_id > 0) {
                     drmtap_debug_log(ctx, "  CRTC %u active (%dx%d)",
                                      crtc->crtc_id, crtc->width, crtc->height);
-                    has_active = 1;
+                    active++;
                 }
                 drmModeFreeCrtc(crtc);
-                if (has_active) break;
             }
         }
         drmModeFreeResources(res);
 
-        if (has_active) {
-            /* Found the GPU driving a monitor — use this one */
-            if (fallback_fd >= 0) close(fallback_fd);
-            snprintf(ctx->device_path, sizeof(ctx->device_path), "%s", path);
-            return fd;
+        if (active > 0) {
+            /* Keep the best candidate so far; ties keep the lower minor. */
+            if (active > best_active) {
+                if (best_fd >= 0) {
+                    close(best_fd);
+                }
+                best_fd = fd;
+                best_active = active;
+                snprintf(best_path, sizeof(best_path), "%s", path);
+            } else {
+                close(fd);
+            }
+            continue;
         }
 
         /* Keep as fallback (first device with KMS but no active CRTC) */
@@ -169,6 +189,17 @@ static int open_drm_auto(drmtap_ctx *ctx) {
         } else {
             close(fd);
         }
+    }
+
+    /* The GPU driving the most displays wins. */
+    if (best_fd >= 0) {
+        if (fallback_fd >= 0) {
+            close(fallback_fd);
+        }
+        snprintf(ctx->device_path, sizeof(ctx->device_path), "%s", best_path);
+        drmtap_debug_log(ctx, "using %s (%d active display(s))", best_path,
+                         best_active);
+        return best_fd;
     }
 
     /* No device with active CRTC found — use fallback if available */
@@ -329,6 +360,80 @@ fail:
     }
     free(ctx);
     return NULL;
+}
+
+int drmtap_list_devices(drmtap_device *out, int max_count) {
+    if (!out || max_count <= 0) {
+        return -EINVAL;
+    }
+
+    int found = 0;
+    for (int i = 0; i < 16 && found < max_count; i++) {
+        char path[64];
+        snprintf(path, sizeof(path), "/dev/dri/card%d", i);
+        int fd = open(path, O_RDWR | O_CLOEXEC);
+        if (fd < 0) {
+            continue;
+        }
+
+        /* Opening a card node while nobody holds master grants US implicit
+         * master, which would block a compositor from acquiring it on a VT
+         * switch. Enumeration never modesets, so give it straight back — same
+         * reasoning as drmtap_open, and the gate is the capability, not the uid
+         * (drmModeGetResources works without master either way). */
+        if (drmtap_have_cap_sys_admin()) {
+            drmDropMaster(fd);
+        }
+
+        drmModeRes *res = drmModeGetResources(fd);
+        if (!res) {
+            close(fd);   /* render-only or no KMS: not a capturable device */
+            continue;
+        }
+
+        drmtap_device *dev = &out[found];
+        memset(dev, 0, sizeof(*dev));
+        snprintf(dev->path, sizeof(dev->path), "%s", path);
+
+        /* Count CRTCs actually scanning out. Deliberately NOT walking the
+         * connectors: drmModeGetConnector re-probes the link (DDC), and doing
+         * that across every card of every GPU just to enumerate can disturb a
+         * live display. An active CRTC is also the exact thing a capture needs. */
+        for (int j = 0; j < res->count_crtcs; j++) {
+            drmModeCrtc *crtc = drmModeGetCrtc(fd, res->crtcs[j]);
+            if (!crtc) {
+                continue;
+            }
+            if (crtc->mode_valid && crtc->buffer_id > 0) {
+                dev->display_count++;
+            }
+            drmModeFreeCrtc(crtc);
+        }
+        drmModeFreeResources(res);
+
+        drmVersionPtr ver = drmGetVersion(fd);
+        if (ver) {
+            if (ver->name) {
+                snprintf(dev->driver, sizeof(dev->driver), "%s", ver->name);
+            }
+            drmFreeVersion(ver);
+        }
+
+        drmDevicePtr dd = NULL;
+        if (drmGetDevice2(fd, 0, &dd) == 0 && dd) {
+            if ((dd->available_nodes & (1 << DRM_NODE_RENDER)) &&
+                dd->nodes[DRM_NODE_RENDER]) {
+                snprintf(dev->render_node, sizeof(dev->render_node), "%s",
+                         dd->nodes[DRM_NODE_RENDER]);
+            }
+            drmFreeDevice(&dd);
+        }
+
+        close(fd);
+        found++;
+    }
+
+    return found;
 }
 
 /* ── Render-node selection on a multi-GPU box ─────────────────────────────

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -330,6 +331,179 @@ fail:
     return NULL;
 }
 
+/* ── Render-node selection on a multi-GPU box ─────────────────────────────
+ *
+ * "The first openable /dev/dri/renderD*" is the wrong default when more than
+ * one GPU is present: the scanout DMA-BUF is exported by the card that drives
+ * the display, and importing it into a DIFFERENT vendor's render node can fail
+ * outright (incompatible tiling modifiers) — permanently, since the choice is
+ * made once at open. A Jetson Orin shows this concretely: card1 is `tegra`
+ * (renderD128, NO connectors) while card2 is `nvidia-drm` (renderD129) and owns
+ * the connected DP-1, so the old scan picked exactly the node that does not own
+ * the scanout.
+ *
+ * The unprivileged converter cannot simply open the KMS cards to find out which
+ * one drives a display — it may hold no rights on them — so the ranking is read
+ * from sysfs, which needs no privilege: a card whose connector is `connected`
+ * AND `enabled` is actively scanning out and wins; merely `connected` is the
+ * runner-up; a card with no outputs (a compute/offload GPU) is never preferred.
+ * When sysfs is unavailable (a container without /sys) this yields nothing and
+ * the caller falls back to the historical first-openable scan.
+ *
+ * A caller that KNOWS the exporting device should not rely on this heuristic at
+ * all — drmtap_render_node() on the capture context names the exact node.
+ */
+
+/* Read the first line of a small sysfs file into `buf` (NUL-terminated).
+ * Returns 0 on success. */
+static int read_sysfs_line(const char *path, char *buf, size_t len) {
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return -1;
+    }
+    ssize_t n = read(fd, buf, len - 1);
+    close(fd);
+    if (n <= 0) {
+        return -1;
+    }
+    buf[n] = '\0';
+    char *nl = strchr(buf, '\n');
+    if (nl) {
+        *nl = '\0';
+    }
+    return 0;
+}
+
+/* Name of the KMS card ("card1") backing render node `render_name`
+ * ("renderD128"), via /sys/class/drm/<render>/device/drm/. Returns 0 on
+ * success. */
+static int card_for_render_node(const char *render_name, char *out,
+                                size_t out_len) {
+    char dir_path[320];
+    snprintf(dir_path, sizeof(dir_path), "/sys/class/drm/%s/device/drm",
+             render_name);
+    DIR *dir = opendir(dir_path);
+    if (!dir) {
+        return -1;
+    }
+    int found = -1;
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        /* The directory holds the sibling nodes of the same device: cardN,
+         * renderDM and (on older kernels) controlDK. Take the primary node —
+         * "card" with no "-CONNECTOR" suffix. */
+        if (strncmp(ent->d_name, "card", 4) != 0 || !ent->d_name[4] ||
+            strchr(ent->d_name, '-') != NULL) {
+            continue;
+        }
+        size_t len = strlen(ent->d_name);
+        if (len >= out_len) {
+            continue;  /* not a name we could have produced; ignore it */
+        }
+        memcpy(out, ent->d_name, len + 1);
+        found = 0;
+        break;
+    }
+    closedir(dir);
+    return found;
+}
+
+/* How strongly card `card_name` looks like the device driving a display:
+ * 2 = has a connected AND enabled connector (actively scanning out),
+ * 1 = has a connected connector, 0 = none (or sysfs unreadable). */
+static int card_output_rank(const char *card_name) {
+    DIR *dir = opendir("/sys/class/drm");
+    if (!dir) {
+        return 0;
+    }
+    size_t card_len = strlen(card_name);
+    int rank = 0;
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        /* Connectors are exposed as "<card>-<CONNECTOR>", e.g. card1-DP-1. */
+        if (strncmp(ent->d_name, card_name, card_len) != 0 ||
+            ent->d_name[card_len] != '-') {
+            continue;
+        }
+        char path[320], val[32];
+        snprintf(path, sizeof(path), "/sys/class/drm/%s/status", ent->d_name);
+        /* "disconnected" also ends in "connected" — compare from the start. */
+        if (read_sysfs_line(path, val, sizeof(val)) != 0 ||
+            strcmp(val, "connected") != 0) {
+            continue;
+        }
+        if (rank < 1) {
+            rank = 1;
+        }
+        snprintf(path, sizeof(path), "/sys/class/drm/%s/enabled", ent->d_name);
+        if (read_sysfs_line(path, val, sizeof(val)) == 0 &&
+            strcmp(val, "enabled") == 0) {
+            rank = 2;
+            break;
+        }
+    }
+    closedir(dir);
+    return rank;
+}
+
+/* Best-ranked render node path into `out`. Returns 0 when one was picked. */
+static int pick_scanout_render_node(char *out, size_t out_len) {
+    DIR *dir = opendir("/sys/class/drm");
+    if (!dir) {
+        return -1;
+    }
+    int best_rank = 0;
+    char best[64] = {0};
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        if (strncmp(ent->d_name, "renderD", 7) != 0) {
+            continue;
+        }
+        char card[64];
+        if (card_for_render_node(ent->d_name, card, sizeof(card)) != 0) {
+            continue;
+        }
+        size_t len = strlen(ent->d_name);
+        if (len >= sizeof(best)) {
+            continue;
+        }
+        int rank = card_output_rank(card);
+        if (rank > best_rank) {
+            best_rank = rank;
+            memcpy(best, ent->d_name, len + 1);
+            if (rank >= 2) {
+                break;  /* actively scanning out — nothing can outrank it */
+            }
+        }
+    }
+    closedir(dir);
+    if (best_rank == 0) {
+        return -1;
+    }
+    snprintf(out, out_len, "/dev/dri/%s", best);
+    return 0;
+}
+
+const char *drmtap_render_node(drmtap_ctx *ctx) {
+    if (!ctx || ctx->drm_fd < 0) {
+        return NULL;
+    }
+    if (ctx->render_node[0]) {
+        return ctx->render_node;
+    }
+    drmDevicePtr dev = NULL;
+    if (drmGetDevice2(ctx->drm_fd, 0, &dev) != 0 || !dev) {
+        return NULL;
+    }
+    if ((dev->available_nodes & (1 << DRM_NODE_RENDER)) &&
+        dev->nodes[DRM_NODE_RENDER]) {
+        snprintf(ctx->render_node, sizeof(ctx->render_node), "%s",
+                 dev->nodes[DRM_NODE_RENDER]);
+    }
+    drmFreeDevice(&dev);
+    return ctx->render_node[0] ? ctx->render_node : NULL;
+}
+
 drmtap_ctx *drmtap_open_render(const char *render_node) {
     drmtap_ctx *ctx = calloc(1, sizeof(drmtap_ctx));
     if (!ctx) {
@@ -364,7 +538,29 @@ drmtap_ctx *drmtap_open_render(const char *render_node) {
             goto fail;
         }
     } else {
-        /* Auto-detect: first openable render node. DRM render minors span the
+        /* Auto-detect. Prefer the render node of the card that actually drives
+         * a display (see pick_scanout_render_node): on a multi-GPU box that is
+         * the device exporting the scanout we will be asked to import, and the
+         * only one guaranteed to understand its tiling modifier. */
+        char preferred[96];
+        if (pick_scanout_render_node(preferred, sizeof(preferred)) == 0) {
+            int fd = open(preferred, O_RDWR | O_CLOEXEC);
+            if (fd >= 0) {
+                snprintf(ctx->device_path, sizeof(ctx->device_path), "%s",
+                         preferred);
+                ctx->drm_fd = fd;
+                drmtap_debug_log(ctx, "render node %s selected: its card "
+                                 "drives a display", preferred);
+            } else {
+                drmtap_debug_log(ctx, "render node %s drives a display but "
+                                 "could not be opened (%s); scanning",
+                                 preferred, strerror(errno));
+            }
+        }
+    }
+
+    if (ctx->drm_fd < 0 && !(render_node && render_node[0])) {
+        /* Fallback: first openable render node. DRM render minors span the
          * whole 128..191 range (up to 64 nodes on a multi-GPU box), so scan all
          * of it — a valid device can sit above renderD143. No KMS probing here
          * on purpose: a render node has no resources. */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -492,7 +492,7 @@ static int card_for_render_node(const char *render_name, char *out,
         return -1;
     }
     int found = -1;
-    struct dirent *ent;
+    const struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
         /* The directory holds the sibling nodes of the same device: cardN,
          * renderDM and (on older kernels) controlDK. Take the primary node —
@@ -523,7 +523,7 @@ static int card_output_rank(const char *card_name) {
     }
     size_t card_len = strlen(card_name);
     int rank = 0;
-    struct dirent *ent;
+    const struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
         /* Connectors are exposed as "<card>-<CONNECTOR>", e.g. card1-DP-1. */
         if (strncmp(ent->d_name, card_name, card_len) != 0 ||
@@ -559,7 +559,7 @@ static int pick_scanout_render_node(char *out, size_t out_len) {
     }
     int best_rank = 0;
     char best[64] = {0};
-    struct dirent *ent;
+    const struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
         if (strncmp(ent->d_name, "renderD", 7) != 0) {
             continue;

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -312,11 +312,43 @@ int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
  * privileged helper, or enumerate displays, and it needs no elevated
  * capability. Grab entry points return -ENOTSUP on this context.
  *
+ * On a multi-GPU host the node matters: a scanout DMA-BUF exported by one GPU
+ * can be impossible to import into another vendor's render node (incompatible
+ * tiling modifiers), and the choice is made once, here. Pass the exporting
+ * device's node explicitly whenever it is known — drmtap_render_node() on the
+ * capture context names it. With NULL, auto-selection prefers the render node
+ * of a card that is actively driving a display (read from sysfs, so it needs no
+ * rights on the KMS cards) over a compute/offload GPU with no outputs, and only
+ * falls back to "the first openable node" when nothing can be ranked.
+ *
  * @param render_node Render node path (e.g. "/dev/dri/renderD128"),
- *                    or NULL to auto-select the first usable one.
+ *                    or NULL to auto-select (see above).
  * @return Context handle, or NULL on error (call drmtap_error(NULL) for message)
  */
 drmtap_ctx *drmtap_open_render(const char *render_node);
+
+/**
+ * @brief Render node (/dev/dri/renderD*) of the device backing @p ctx.
+ *
+ * The deterministic answer to "which render node can import THIS context's
+ * scanout": the privileged exporter calls it on its capture context and passes
+ * the string to the unprivileged converter's drmtap_open_render(), so a
+ * multi-GPU host converts on the GPU that exported the frame instead of
+ * whichever node happened to be picked by auto-selection.
+ *
+ * Deliberately NOT part of drmtap_dmabuf_desc: that struct is written by
+ * drmtap_grab_desc() into caller-owned storage, so growing it would corrupt a
+ * consumer built against an older header but running against a newer .so (the
+ * dlopen-by-soname deployment this library is designed for). Carrying the node
+ * as its own accessor keeps the descriptor layout frozen; a consumer that
+ * dlopens can simply treat an absent symbol as "old library, keep the previous
+ * behaviour".
+ *
+ * @param ctx Context (typically a capture context from drmtap_open)
+ * @return Node path owned by @p ctx and valid until drmtap_close(), or NULL if
+ *         the device exposes no render node (e.g. a display-only KMS device)
+ */
+const char *drmtap_render_node(drmtap_ctx *ctx);
 
 /**
  * @brief Convert an externally-supplied scanout frame to linear RGBA.

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -328,6 +328,45 @@ int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
 drmtap_ctx *drmtap_open_render(const char *render_node);
 
 /**
+ * @brief A capturable DRM device, as reported by drmtap_list_devices().
+ *
+ * Layout is FROZEN: like drmtap_dmabuf_desc it is written into caller-owned
+ * storage, so a future addition must come as a new accessor, never as a new
+ * field here (a bigger struct written by a newer .so would overrun a consumer
+ * built against an older header).
+ */
+typedef struct {
+    char path[64];          /**< KMS card node, e.g. "/dev/dri/card1" */
+    char render_node[64];   /**< Render node, or "" if the device has none */
+    char driver[32];        /**< Kernel driver, e.g. "i915", "nvidia-drm" */
+    uint32_t display_count; /**< CRTCs actively scanning out on this device */
+} drmtap_device;
+
+/**
+ * @brief Enumerate every DRM device with KMS resources.
+ *
+ * A drmtap context is bound to ONE device, so on a multi-GPU host a single
+ * context can never advertise the displays of the other cards: drmtap_open()
+ * settles on the first card with an active CRTC and drmtap_list_displays() then
+ * only ever sees that one. This is the discovery step a multi-GPU consumer
+ * needs — open one context per device (drmtap_open with the reported @c path)
+ * and enumerate each, instead of silently capturing a single card.
+ *
+ * Devices with no active display are reported too, with display_count 0, so the
+ * caller can still open one and see its connected-but-dark connectors; sorting
+ * or filtering on display_count is left to the caller. Each card is opened
+ * briefly to read its KMS resources, so this needs the same rights as
+ * drmtap_open (it is meant for the privileged/exporter side); cards that cannot
+ * be opened are skipped rather than failing the whole enumeration. Connector
+ * state is NOT re-probed, so calling this does not disturb a live display.
+ *
+ * @param out       Caller array to fill
+ * @param max_count Capacity of @p out
+ * @return Number of devices written (0 or more), or negative errno on error
+ */
+int drmtap_list_devices(drmtap_device *out, int max_count);
+
+/**
  * @brief Render node (/dev/dri/renderD*) of the device backing @p ctx.
  *
  * The deterministic answer to "which render node can import THIS context's

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 14
+#define DRMTAP_VERSION_PATCH 15
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -38,6 +38,9 @@ struct drmtap_ctx {
     int drm_fd;
     char device_path[256];
     char driver_name[64];
+    /* Render node of THIS device, resolved lazily by drmtap_render_node().
+     * Empty until first asked (the device has none, or it was never queried). */
+    char render_node[256];
 
     /* Selected display */
     uint32_t crtc_id;

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -698,34 +698,6 @@ static void ensure_linear_texture(egl_state_t *state, uint32_t w, uint32_t h) {
     state->tex_height = h;
 }
 
-/* True for a scanout fourcc carrying more than 8 bits per channel: the 10-bit
- * XR30 family and the 16-bit XR48 family (integer and half-float). Such a buffer
- * must NOT be reinterpreted as XRGB8888 during import retry -- that would sample it
- * at the wrong bit depth (and, for the 16-bit formats, the wrong row width) and
- * hand back a garbage frame reported as success. */
-static int egl_fourcc_high_bit_depth(uint32_t fourcc) {
-    switch (fourcc) {
-    /* 10-bit 2:10:10:10 */
-    case fourcc_code('X', 'R', '3', '0'):
-    case fourcc_code('X', 'B', '3', '0'):
-    case fourcc_code('A', 'R', '3', '0'):
-    case fourcc_code('A', 'B', '3', '0'):
-    /* 16-bit integer */
-    case fourcc_code('X', 'R', '4', '8'):
-    case fourcc_code('X', 'B', '4', '8'):
-    case fourcc_code('A', 'R', '4', '8'):
-    case fourcc_code('A', 'B', '4', '8'):
-    /* 16-bit half-float */
-    case fourcc_code('X', 'R', '4', 'H'):
-    case fourcc_code('X', 'B', '4', 'H'):
-    case fourcc_code('A', 'R', '4', 'H'):
-    case fourcc_code('A', 'B', '4', 'H'):
-        return 1;
-    default:
-        return 0;
-    }
-}
-
 /* Import a DMA-BUF as an EGLImage, retrying with progressively simpler
  * attribute sets (XRGB8888 keeping the modifier, then XRGB8888 alone) the way
  * some drivers need. CCS auxiliary planes come from ctx->fb2_*. Returns
@@ -812,16 +784,27 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
                          first_err, (const char *)&fourcc,
                          (unsigned long)modifier);
 
-        /* The XRGB8888 retries below reinterpret the buffer as 8-bit while keeping
-         * the source stride. That only makes sense for a genuine 8-bit scanout whose
-         * exact fourcc the driver does not recognize. For a high-bit-depth source
-         * (10-bit XR30 / 16-bit XR48 family) it would sample the wrong bit depth and
-         * return corruption as success, so fail the import instead: the caller then
-         * reduces the real bit depth from the raw mapping on the CPU. */
-        if (egl_fourcc_high_bit_depth(fourcc)) {
-            drmtap_debug_log(ctx, "egl: no XRGB8888 retry for high-bit-depth "
-                             "fourcc %.4s (would corrupt); failing import so the "
-                             "CPU reduce path runs", (const char *)&fourcc);
+        /* The XRGB8888 retries below reinterpret the buffer as a single 8-bit RGB
+         * plane at the source stride. That is only safe for a single-plane 8-bit
+         * RGB scanout (XRGB8888 / ARGB8888) whose exact fourcc a driver refuses.
+         * For anything else it samples the wrong layout and returns corruption as
+         * success:
+         *   - a high-bit-depth source (10-bit XR30 / 16-bit XR48 family): wrong bit depth;
+         *   - a BGR order (XBGR / ABGR): swapped red and blue;
+         *   - a multi-plane / CCS-compressed buffer: the retry emits only plane 0, so
+         *     the auxiliary (compression) planes are dropped and the shader samples
+         *     compressed data as pixels.
+         * In every such case, fail the import so the caller falls back (CPU reduce,
+         * or ending the stream) rather than forwarding a corrupt frame. */
+        int retry_safe = (ctx->fb2_num_planes <= 1) &&
+                         (fourcc == DRM_FORMAT_XRGB8888 ||
+                          fourcc == DRM_FORMAT_ARGB8888);
+        if (!retry_safe) {
+            drmtap_debug_log(ctx, "egl: no XRGB8888 retry for fourcc %.4s "
+                             "planes=%d modifier=0x%lx (would corrupt); failing "
+                             "import so the caller falls back",
+                             (const char *)&fourcc, ctx->fb2_num_planes,
+                             (unsigned long)modifier);
             return EGL_NO_IMAGE_KHR;
         }
 
@@ -855,8 +838,16 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
             state.display, EGL_NO_CONTEXT,
             EGL_LINUX_DMA_BUF_EXT, NULL, retry_attribs);
 
-        if (image == EGL_NO_IMAGE_KHR) {
-            /* Last resort: try XRGB8888 without modifier */
+        if (image == EGL_NO_IMAGE_KHR && modifier == DRM_FORMAT_MOD_LINEAR) {
+            /* Last resort: XRGB8888 with NO modifier attributes, for a driver
+             * that rejects the explicit-modifier form but accepts the implicit
+             * one. Gated to a LINEAR source on purpose: dropping a REAL tiling
+             * modifier would make EGL sample the tiled bytes as linear and return
+             * corruption reported as success, so an explicitly-tiled buffer stops
+             * at the modifier retry above and lets the caller fall back. (A LINEAR
+             * source has no tiling to lose; an INVALID modifier already took the
+             * no-modifier path in the retry above, so repeating it here is
+             * pointless -- the same call would fail identically.) */
             ri = 0;
             retry_attribs[ri++] = EGL_WIDTH;
             retry_attribs[ri++] = (EGLint)width;
@@ -872,7 +863,7 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
             retry_attribs[ri++] = (EGLint)stride;
             retry_attribs[ri++] = EGL_NONE;
 
-            drmtap_debug_log(ctx, "egl: retrying XRGB8888 no-modifier");
+            drmtap_debug_log(ctx, "egl: retrying XRGB8888 no-modifier (linear)");
             image = pfn_eglCreateImageKHR(
                 state.display, EGL_NO_CONTEXT,
                 EGL_LINUX_DMA_BUF_EXT, NULL, retry_attribs);

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -227,9 +227,23 @@ static int load_gl_libraries(void) {
 /* EGL context (lazily initialized per drmtap_ctx)                           */
 /* ========================================================================= */
 
-/* Global EGL display (one per process, shared across threads) */
-static EGLDisplay g_egl_display = EGL_NO_DISPLAY;
-static int g_egl_display_initialized = 0;
+/* ── EGL displays, one PER DRM DEVICE (shared across threads) ──
+ * A single process-wide EGLDisplay is wrong on a multi-GPU host: the display is
+ * bound to the device it was created from, so whichever GPU happened to convert
+ * first would keep serving imports of scanouts exported by the other one — which
+ * can fail permanently (incompatible tiling modifiers). Keyed by the context's
+ * device path; entries are never torn down (see the CRITICAL note in
+ * drmtap_gpu_egl_available: terminating a display kills other threads' live
+ * detile contexts). An occupied slot memoizes a NEGATIVE outcome too — its
+ * display stays EGL_NO_DISPLAY — so a device with no usable EGL is not
+ * re-probed on every frame. */
+#define DRMTAP_EGL_DISPLAY_SLOTS 4
+static struct {
+    char        device_path[256];
+    EGLDisplay  display;          /* EGL_NO_DISPLAY = this device has no EGL */
+} g_egl_displays[DRMTAP_EGL_DISPLAY_SLOTS];
+static int g_egl_display_count = 0;
+static pthread_mutex_t g_egl_display_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* ── Import-once EGLImage cache (keyed by KMS fb_id) ── */
 /* The compositor scans out of a small pool of framebuffers (double/triple
@@ -258,7 +272,8 @@ typedef struct {
 
 /* Per-thread EGL context and GL resources */
 typedef struct {
-    EGLDisplay display;   /* cached copy of g_egl_display */
+    EGLDisplay display;        /* the display of `device_path`'s device */
+    char device_path[256];     /* DRM device this thread's GL state belongs to */
     EGLContext context;
     GLuint program;
     GLuint fbo;
@@ -289,7 +304,7 @@ static _Thread_local egl_state_t state = {0};
 /* Backstop for a capture thread that exits WITHOUT calling drmtap_close (an
  * error/panic path): a pthread TSD destructor frees this thread's EGL context at
  * thread exit, while its context can still be made current. The shared
- * g_egl_display is never terminated, so this is safe. */
+ * per-device displays are never terminated, so this is safe. */
 static pthread_key_t g_egl_tsd_key;
 static int g_egl_tsd_key_ok = 0;   /* set once the key is created successfully */
 static pthread_once_t g_egl_tsd_once = PTHREAD_ONCE_INIT;
@@ -511,6 +526,49 @@ static EGLDisplay get_egl_display_for_card(const char *card_path) {
     return display;
 }
 
+/* The INITIALIZED EGLDisplay for @ctx's DRM device, or EGL_NO_DISPLAY if that
+ * device has none. Memoized per device path; never terminated. Callers must
+ * have loaded the EGL procs (load_egl_procs) first. */
+static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
+    const char *path = (ctx && ctx->device_path[0]) ? ctx->device_path : "";
+
+    pthread_mutex_lock(&g_egl_display_lock);
+    for (int i = 0; i < g_egl_display_count; i++) {
+        if (strcmp(g_egl_displays[i].device_path, path) == 0) {
+            EGLDisplay cached = g_egl_displays[i].display;
+            pthread_mutex_unlock(&g_egl_display_lock);
+            return cached;
+        }
+    }
+
+    EGLDisplay display = get_egl_display_for_card(path);
+    if (display != EGL_NO_DISPLAY) {
+        EGLint major = 0, minor = 0;
+        if (eglInitialize(display, &major, &minor)) {
+            drmtap_debug_log(NULL, "EGL: display for %s initialized: %p (%d.%d)",
+                             path, (void *)display, major, minor);
+        } else {
+            drmtap_debug_log(NULL, "EGL: eglInitialize for %s failed: 0x%x",
+                             path, eglGetError());
+            display = EGL_NO_DISPLAY;
+        }
+    }
+
+    if (g_egl_display_count < DRMTAP_EGL_DISPLAY_SLOTS) {
+        int slot = g_egl_display_count;
+        snprintf(g_egl_displays[slot].device_path,
+                 sizeof(g_egl_displays[slot].device_path), "%s", path);
+        g_egl_displays[slot].display = display;
+        g_egl_display_count = slot + 1;
+    } else {
+        /* More distinct devices than slots: still correct (eglInitialize is
+         * idempotent per the spec), just re-resolved each time. */
+        drmtap_debug_log(NULL, "EGL: display table full, %s not memoized", path);
+    }
+    pthread_mutex_unlock(&g_egl_display_lock);
+    return display;
+}
+
 /* ========================================================================= */
 /* EGL state management                                                      */
 /* ========================================================================= */
@@ -521,25 +579,17 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
         return -ENOTSUP;
     }
 
-    /* Initialize global display once (thread-safe: eglInitialize is 
-     * idempotent per EGL spec — second call on same display is a no-op) */
-    if (!g_egl_display_initialized) {
-        g_egl_display = get_egl_display_for_card(ctx->device_path);
-        if (g_egl_display == EGL_NO_DISPLAY) {
-            drmtap_debug_log(ctx, "egl: no EGL display available");
-            return -ENODEV;
-        }
-        EGLint major, minor;
-        if (!eglInitialize(g_egl_display, &major, &minor)) {
-            drmtap_debug_log(ctx, "egl: eglInitialize failed: 0x%x",
-                             eglGetError());
-            return -EIO;
-        }
-        g_egl_display_initialized = 1;
-        drmtap_debug_log(NULL, "EGL: global display initialized: %p (%d.%d)",
-                (void*)g_egl_display, major, minor);
+    /* The display belongs to THIS context's device, not to the process (see the
+     * per-device table above). eglInitialize is idempotent per the EGL spec, so
+     * concurrent first-use from several threads is safe. */
+    state->display = egl_display_for_ctx(ctx);
+    if (state->display == EGL_NO_DISPLAY) {
+        drmtap_debug_log(ctx, "egl: no EGL display available for %s",
+                         ctx->device_path);
+        return -ENODEV;
     }
-    state->display = g_egl_display;
+    snprintf(state->device_path, sizeof(state->device_path), "%s",
+             ctx->device_path);
 
     eglBindAPI(EGL_OPENGL_ES_API);
 
@@ -657,13 +707,14 @@ static void egl_cleanup(egl_state_t *st) {
         glDeleteProgram(st->program);
     }
     /* Release the context from this thread before destroying it. MUST NOT
-     * eglTerminate(st->display): g_egl_display is shared across all capture
-     * threads; terminating it invalidates other threads' live detile contexts
-     * (see the CRITICAL note in drmtap_gpu_egl_available). */
+     * eglTerminate(st->display): that display is shared by every capture thread
+     * using the same DRM device; terminating it invalidates those threads' live
+     * detile contexts (see the CRITICAL note in drmtap_gpu_egl_available). */
     eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                    EGL_NO_CONTEXT);
     eglDestroyContext(st->display, st->context);
     st->context = EGL_NO_CONTEXT;
+    st->device_path[0] = '\0';
     st->program = 0;
     st->fbo = 0;
     st->linear_texture = 0;
@@ -926,34 +977,30 @@ int drmtap_gpu_egl_available(drmtap_ctx *ctx) {
         return 0;
     }
     /* EGL availability is a static property of the GPU, but this is called on
-     * every captured frame. Cache it once.
+     * every captured frame — so it must stay cheap. It is a property PER DEVICE
+     * (a compute GPU with no EGL next to one with it), so the answer comes from
+     * the per-device display table, which memoizes both outcomes; after the
+     * first call this is a locked string compare.
      *
-     * CRITICAL: this must NOT call eglTerminate() on the display. The display
-     * returned by get_egl_display_for_card() is the SAME shared EGLDisplay used
-     * by the live detile contexts. Terminating it here — while another capture
-     * thread is mid-eglCreateImage — invalidates that thread's display and makes
-     * its detile fail with EGL_NOT_INITIALIZED, so it falls back to returning the
-     * raw tiled/compressed buffer (garbage/color corruption). Concurrent captures
+     * CRITICAL: this must NOT call eglTerminate() on the display. That display
+     * is the SAME one used by the live detile contexts on this device.
+     * Terminating it here — while another capture thread is mid-eglCreateImage —
+     * invalidates that thread's display and makes its detile fail with
+     * EGL_NOT_INITIALIZED, so it falls back to returning the raw
+     * tiled/compressed buffer (garbage/color corruption). Concurrent captures
      * (e.g. two monitors viewed at once) hit this constantly. */
-    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
-    static int cached = -1;
-    pthread_mutex_lock(&lk);
-    if (cached < 0) {
-        if (load_egl_procs() < 0) {
-            cached = 0;
-        } else {
-            EGLDisplay display = get_egl_display_for_card(ctx->device_path);
-            if (display == EGL_NO_DISPLAY) {
-                cached = 0;
-            } else {
-                EGLint major, minor;
-                cached = eglInitialize(display, &major, &minor) ? 1 : 0;
-                /* Intentionally no eglTerminate(display) — see above. */
-            }
-        }
+    static pthread_mutex_t procs_lk = PTHREAD_MUTEX_INITIALIZER;
+    static int procs_ok = -1;
+    pthread_mutex_lock(&procs_lk);
+    if (procs_ok < 0) {
+        procs_ok = load_egl_procs() < 0 ? 0 : 1;
     }
-    pthread_mutex_unlock(&lk);
-    return cached;
+    pthread_mutex_unlock(&procs_lk);
+    if (!procs_ok) {
+        return 0;
+    }
+    /* Intentionally no eglTerminate() on the returned display — see above. */
+    return egl_display_for_ctx(ctx) != EGL_NO_DISPLAY;
 }
 
 /**
@@ -1022,6 +1069,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     int ret;
 
     drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
+    /* The GL context, its shaders and the cached EGLImages all belong to ONE
+     * EGLDisplay, i.e. one DRM device. If this thread previously converted for
+     * a different device, none of that state can serve the new one — tear it
+     * down and rebuild rather than sample another GPU's display. (Comparing the
+     * device path, not the display handle, keeps this off the lock on the
+     * per-frame path.) */
+    if (state.initialized && strcmp(state.device_path, ctx->device_path) != 0) {
+        drmtap_debug_log(ctx, "egl: thread moved from %s to %s, rebuilding the "
+                         "GL context on the new device",
+                         state.device_path, ctx->device_path);
+        egl_cleanup(&state);
+    }
     if (!state.initialized) {
         ret = egl_init(ctx, &state);
         drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);

--- a/bindings/rust/libdrmtap-sys/src/lib.rs
+++ b/bindings/rust/libdrmtap-sys/src/lib.rs
@@ -110,6 +110,10 @@ extern "C" {
 
     // Split capture (privileged export + unprivileged convert)
     pub fn drmtap_open_render(render_node: *const c_char) -> *mut drmtap_ctx;
+    /// Render node of the device backing `ctx`, for handing to
+    /// `drmtap_open_render` on the converting side of a split so it binds to the
+    /// GPU that exported the frame. Owned by `ctx`; NULL if it has none.
+    pub fn drmtap_render_node(ctx: *mut drmtap_ctx) -> *const c_char;
     pub fn drmtap_grab_desc(
         ctx: *mut drmtap_ctx,
         desc: *mut drmtap_dmabuf_desc,

--- a/bindings/rust/libdrmtap-sys/src/lib.rs
+++ b/bindings/rust/libdrmtap-sys/src/lib.rs
@@ -25,6 +25,22 @@ pub struct drmtap_config {
     pub debug: c_int,
 }
 
+/// A capturable DRM device, as reported by `drmtap_list_devices`. Layout is
+/// frozen: it is written into caller-owned storage, so a future addition must
+/// come as a new accessor rather than a new field here.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct drmtap_device {
+    /// KMS card node, e.g. `/dev/dri/card1`
+    pub path: [c_char; 64],
+    /// Render node, or an empty string if the device has none
+    pub render_node: [c_char; 64],
+    /// Kernel driver, e.g. `i915`, `nvidia-drm`
+    pub driver: [c_char; 32],
+    /// CRTCs actively scanning out on this device
+    pub display_count: u32,
+}
+
 /// Information about a connected display
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -110,6 +126,10 @@ extern "C" {
 
     // Split capture (privileged export + unprivileged convert)
     pub fn drmtap_open_render(render_node: *const c_char) -> *mut drmtap_ctx;
+    /// Enumerate every DRM device with KMS resources. A context is bound to one
+    /// device, so this is how a multi-GPU consumer finds the other cards instead
+    /// of only ever advertising the displays of the first one.
+    pub fn drmtap_list_devices(out: *mut drmtap_device, max_count: c_int) -> c_int;
     /// Render node of the device backing `ctx`, for handing to
     /// `drmtap_open_render` on the converting side of a split so it binds to the
     /// GPU that exported the frame. Owned by `ctx`; NULL if it has none.

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.14", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.4.15", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -180,6 +180,30 @@ void drmtap_cursor_release(drmtap_ctx *ctx, drmtap_cursor_info *cursor);
 // Returns 1 if display configuration changed since last call, 0 if unchanged.
 int drmtap_displays_changed(drmtap_ctx *ctx);
 
+// --- Split capture: privileged export + unprivileged convert (0.4.9) ---
+// Run the DRM export and the GPU detile/convert in DIFFERENT processes, so the
+// EGL/GLES + vendor GPU stack never loads into the privileged one. The exporter
+// (drmtap_open) grabs a dma-buf fd + descriptor; the fd is passed out of band
+// (e.g. SCM_RIGHTS) to an unprivileged converter (drmtap_open_render) that
+// EGL-detiles it to linear RGBA. drmtap_grab_desc emits the full plane layout +
+// HDR state that drmtap_frame_info cannot carry (CCS aux planes, eotf), so a
+// split consumer must use it, not drmtap_grab alone.
+int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
+                     drmtap_frame_info *frame);
+drmtap_ctx *drmtap_open_render(const char *render_node); // NULL = auto-select
+int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
+                          drmtap_frame_info *frame);
+
+// --- Multi-GPU (0.4.15) ---
+// A context is bound to ONE device. On a multi-GPU host, enumerate every card
+// and open one context per device; and bind the converter to the render node of
+// the GPU that EXPORTED the scanout (cross-vendor import can fail permanently on
+// an incompatible tiling modifier). drmtap_render_node names the exporter's node
+// for the converter; it is a separate accessor, NOT a drmtap_dmabuf_desc field,
+// so the descriptor layout the caller writes stays frozen across .so versions.
+int drmtap_list_devices(drmtap_device *out, int max_count);
+const char *drmtap_render_node(drmtap_ctx *ctx); // NULL if the device has none
+
 // --- HDR (implemented as in-capture tone-mapping to SDR, #16) ---
 // HDR is handled automatically rather than exposed as a passthrough API: the
 // helper reads the connector HDR_OUTPUT_METADATA (EOTF + peak) and, when the

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -450,7 +450,7 @@ Three layers, published on crates.io:
 └─────────────────────────────────────────────────┘
 ```
 
-> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.13,
+> ⚠️ **Testing status**: Both crates are published (libdrmtap-sys 0.4.15,
 > libdrmtap 0.3.4) and verified to build/test in CI on Ubuntu 22.04/24.04.
 > Capture is verified on Intel i915/xe (dual-4K Meteor Lake), Nvidia/Tegra
 > (Jetson Orin Nano, aarch64), virtio-gpu, and AMD amdgpu (RX Vega 64, gfx9,

--- a/docs/research/05_api_and_architecture.md
+++ b/docs/research/05_api_and_architecture.md
@@ -514,8 +514,8 @@ Adding `libdrmtap-sys` is standard practice for them. They `cargo add libdrmtap`
 
 | Area | What shipped | Status |
 |---|---|---|
-| Core | `libdrmtap` C library 0.4.13 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
-| Rust | `libdrmtap-sys` 0.4.13 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
+| Core | `libdrmtap` C library 0.4.15 (`.so`/`.a` + `drmtap.h` + `pkg-config`) | ✅ Done |
+| Rust | `libdrmtap-sys` 0.4.15 (FFI; embeds + statically compiles C sources & helper) | ✅ Published on crates.io |
 | Rust | `libdrmtap` 0.3.4 (safe wrapper) | ✅ Published on crates.io |
 | GPU | EGL/GLES2 GPU-universal detiling backend | ✅ Implemented |
 | HW | Intel i915/xe + Nvidia/Tegra + virtio-gpu + AMD amdgpu validation | ✅ Verified (AMD on RX Vega 64, gfx9) |

--- a/docs/research/07_potential_adopters.md
+++ b/docs/research/07_potential_adopters.md
@@ -16,7 +16,7 @@
 
 ### Integration path for each:
 
-**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.13 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
+**RustDesk**: `cargo add libdrmtap-sys` — both crates published on crates.io (`libdrmtap-sys` 0.4.15 + `libdrmtap` 0.3.4). RustDesk adds it as an optional backend alongside PipeWire. Priority: `DRM/KMS → PipeWire → X11`. **Now in review**: upstream PR [rustdesk/rustdesk#15420](https://github.com/rustdesk/rustdesk/pull/15420) adds a `drm` capture backend to `scrap` on top of `libdrmtap-sys` and is under maintainer review (in progress — not merged). A self-contained reference backend also lives in `contrib/integrations/rustdesk/`.
 
 **Sunshine**: Replace internal KMS code with `#include <drmtap.h>`. They already use DMA-BUF → VAAPI pipeline, so `drmtap_grab()` (zero-copy) slots in directly.
 

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -451,14 +451,30 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
     struct dma_buf_sync csync = {
         .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
     };
-    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
+    /* Track whether START took, and only issue the matching END if it did -- an
+     * unpaired END would unbalance the exporter's CPU-access accounting. On
+     * failure the read still proceeds: it degrades to the previous
+     * (unsynchronised) behaviour rather than dropping the cursor on an exporter
+     * that does not implement the ioctl, and a stale cursor is cosmetic. */
+    int csync_started = drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync) == 0;
+    if (!csync_started) {
+        fprintf(stderr,
+                "drmtap-helper: cursor DMA_BUF_SYNC_START failed: %s\n",
+                strerror(errno));
+    }
     for (uint32_t y = 0; y < ch; y++) {
         memcpy(packed + (size_t)y * cw * 4,
                (const uint8_t *)mapped + (size_t)y * cstride,
                (size_t)cw * 4);
     }
-    csync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
-    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
+    if (csync_started) {
+        csync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+        if (drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync) != 0) {
+            fprintf(stderr,
+                    "drmtap-helper: cursor DMA_BUF_SYNC_END failed: %s\n",
+                    strerror(errno));
+        }
+    }
     munmap(mapped, map_size);
     close(prime_fd);
     helper_gem_close(drm_fd, chandle);

--- a/helper/drmtap-helper.c
+++ b/helper/drmtap-helper.c
@@ -53,6 +53,7 @@
 #include <xf86drm.h>
 #include <xf86drmMode.h>
 #include <drm_fourcc.h>  /* DRM_FORMAT_MOD_INVALID */
+#include <linux/dma-buf.h>  /* struct dma_buf_sync, DMA_BUF_IOCTL_SYNC */
 
 #ifdef HAVE_LIBCAP
 #include <sys/capability.h>
@@ -233,6 +234,26 @@ static int install_seccomp(void) {
         if (rc != 0) {
             seccomp_release(ctx);
             fprintf(stderr, "drmtap-helper: seccomp ioctl rule failed: %s\n",
+                    strerror(-rc));
+            return -1;
+        }
+    }
+
+    /* Also allow exactly DMA_BUF_IOCTL_SYNC (type 'b', not DRM's 'd', so it is
+     * NOT covered by the rule above). The cursor path brackets its DMA-BUF CPU
+     * read with this ioctl for cache coherence on non-coherent exporters
+     * (ARM / Tegra / Jetson). Matched by exact request value, not by type byte,
+     * to keep the widened surface to this single stable-ABI ioctl -- without it
+     * the SYNC call would fall through to SCMP_ACT_KILL_PROCESS and take the
+     * helper down on the first cursor poll under seccomp. */
+    {
+        int rc = seccomp_rule_add(ctx, SCMP_ACT_ALLOW, SCMP_SYS(ioctl), 1,
+                                  SCMP_A1(SCMP_CMP_EQ,
+                                          (scmp_datum_t)DMA_BUF_IOCTL_SYNC));
+        if (rc != 0) {
+            seccomp_release(ctx);
+            fprintf(stderr,
+                    "drmtap-helper: seccomp dma-buf ioctl rule failed: %s\n",
                     strerror(-rc));
             return -1;
         }
@@ -420,11 +441,24 @@ static int cursor_and_send(int sock, int drm_fd, uint32_t target_crtc) {
      * and heap churn. */
     static uint8_t packed[256 * 256 * 4];
     size_t tight = (size_t)cw * ch * 4;
+    /* Bracket the CPU read with a DMA-BUF sync, exactly as cursor.c and the
+     * frame path do. DMA-BUF CPU access is not guaranteed coherent, so a
+     * non-coherent exporter (ARM / Tegra / Jetson) can otherwise hand back
+     * stale cursor pixels -- which the client's content hash then suppresses,
+     * freezing the remote cursor. (DMA_BUF_IOCTL_SYNC is a 'b'-type ioctl, NOT
+     * the 'd' DRM type the other helper ioctls use, so install_seccomp() adds a
+     * dedicated allow rule for it -- otherwise this call would be KILLed.) */
+    struct dma_buf_sync csync = {
+        .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
+    };
+    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
     for (uint32_t y = 0; y < ch; y++) {
         memcpy(packed + (size_t)y * cw * 4,
                (const uint8_t *)mapped + (size_t)y * cstride,
                (size_t)cw * 4);
     }
+    csync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &csync);
     munmap(mapped, map_size);
     close(prime_fd);
     helper_gem_close(drm_fd, chandle);

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -312,11 +312,43 @@ int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
  * privileged helper, or enumerate displays, and it needs no elevated
  * capability. Grab entry points return -ENOTSUP on this context.
  *
+ * On a multi-GPU host the node matters: a scanout DMA-BUF exported by one GPU
+ * can be impossible to import into another vendor's render node (incompatible
+ * tiling modifiers), and the choice is made once, here. Pass the exporting
+ * device's node explicitly whenever it is known — drmtap_render_node() on the
+ * capture context names it. With NULL, auto-selection prefers the render node
+ * of a card that is actively driving a display (read from sysfs, so it needs no
+ * rights on the KMS cards) over a compute/offload GPU with no outputs, and only
+ * falls back to "the first openable node" when nothing can be ranked.
+ *
  * @param render_node Render node path (e.g. "/dev/dri/renderD128"),
- *                    or NULL to auto-select the first usable one.
+ *                    or NULL to auto-select (see above).
  * @return Context handle, or NULL on error (call drmtap_error(NULL) for message)
  */
 drmtap_ctx *drmtap_open_render(const char *render_node);
+
+/**
+ * @brief Render node (/dev/dri/renderD*) of the device backing @p ctx.
+ *
+ * The deterministic answer to "which render node can import THIS context's
+ * scanout": the privileged exporter calls it on its capture context and passes
+ * the string to the unprivileged converter's drmtap_open_render(), so a
+ * multi-GPU host converts on the GPU that exported the frame instead of
+ * whichever node happened to be picked by auto-selection.
+ *
+ * Deliberately NOT part of drmtap_dmabuf_desc: that struct is written by
+ * drmtap_grab_desc() into caller-owned storage, so growing it would corrupt a
+ * consumer built against an older header but running against a newer .so (the
+ * dlopen-by-soname deployment this library is designed for). Carrying the node
+ * as its own accessor keeps the descriptor layout frozen; a consumer that
+ * dlopens can simply treat an absent symbol as "old library, keep the previous
+ * behaviour".
+ *
+ * @param ctx Context (typically a capture context from drmtap_open)
+ * @return Node path owned by @p ctx and valid until drmtap_close(), or NULL if
+ *         the device exposes no render node (e.g. a display-only KMS device)
+ */
+const char *drmtap_render_node(drmtap_ctx *ctx);
 
 /**
  * @brief Convert an externally-supplied scanout frame to linear RGBA.

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -328,6 +328,45 @@ int drmtap_grab_desc(drmtap_ctx *ctx, drmtap_dmabuf_desc *desc,
 drmtap_ctx *drmtap_open_render(const char *render_node);
 
 /**
+ * @brief A capturable DRM device, as reported by drmtap_list_devices().
+ *
+ * Layout is FROZEN: like drmtap_dmabuf_desc it is written into caller-owned
+ * storage, so a future addition must come as a new accessor, never as a new
+ * field here (a bigger struct written by a newer .so would overrun a consumer
+ * built against an older header).
+ */
+typedef struct {
+    char path[64];          /**< KMS card node, e.g. "/dev/dri/card1" */
+    char render_node[64];   /**< Render node, or "" if the device has none */
+    char driver[32];        /**< Kernel driver, e.g. "i915", "nvidia-drm" */
+    uint32_t display_count; /**< CRTCs actively scanning out on this device */
+} drmtap_device;
+
+/**
+ * @brief Enumerate every DRM device with KMS resources.
+ *
+ * A drmtap context is bound to ONE device, so on a multi-GPU host a single
+ * context can never advertise the displays of the other cards: drmtap_open()
+ * settles on the first card with an active CRTC and drmtap_list_displays() then
+ * only ever sees that one. This is the discovery step a multi-GPU consumer
+ * needs — open one context per device (drmtap_open with the reported @c path)
+ * and enumerate each, instead of silently capturing a single card.
+ *
+ * Devices with no active display are reported too, with display_count 0, so the
+ * caller can still open one and see its connected-but-dark connectors; sorting
+ * or filtering on display_count is left to the caller. Each card is opened
+ * briefly to read its KMS resources, so this needs the same rights as
+ * drmtap_open (it is meant for the privileged/exporter side); cards that cannot
+ * be opened are skipped rather than failing the whole enumeration. Connector
+ * state is NOT re-probed, so calling this does not disturb a live display.
+ *
+ * @param out       Caller array to fill
+ * @param max_count Capacity of @p out
+ * @return Number of devices written (0 or more), or negative errno on error
+ */
+int drmtap_list_devices(drmtap_device *out, int max_count);
+
+/**
  * @brief Render node (/dev/dri/renderD*) of the device backing @p ctx.
  *
  * The deterministic answer to "which render node can import THIS context's

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 14
+#define DRMTAP_VERSION_PATCH 15
 
 /**
  * @brief Get the library version as a packed integer.

--- a/libdrmtap.map
+++ b/libdrmtap.map
@@ -16,6 +16,7 @@
         drmtap_version;
         drmtap_open;
         drmtap_open_render;
+        drmtap_list_devices;
         drmtap_render_node;
         drmtap_close;
         drmtap_list_displays;

--- a/libdrmtap.map
+++ b/libdrmtap.map
@@ -16,6 +16,7 @@
         drmtap_version;
         drmtap_open;
         drmtap_open_render;
+        drmtap_render_node;
         drmtap_close;
         drmtap_list_displays;
         drmtap_displays_changed;

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.14',
+    version: '0.4.15',
     license: 'MIT',
     default_options: [
         'c_std=c11',

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -31,6 +31,7 @@
 
 #include <xf86drm.h>
 #include <xf86drmMode.h>
+#include <linux/dma-buf.h>  /* struct dma_buf_sync, DMA_BUF_IOCTL_SYNC */
 
 #include "drmtap_internal.h"
 
@@ -211,6 +212,16 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                 void *mapped = mmap(NULL, map_size, PROT_READ, MAP_SHARED,
                                     prime_fd, 0);
                 if (mapped != MAP_FAILED) {
+                    /* Bracket the CPU read with a DMA-BUF sync, exactly as the
+                     * main frame path does. DMA-BUF CPU access is not guaranteed
+                     * coherent, so a non-coherent exporter (ARM / Tegra / Jetson)
+                     * can otherwise hand back stale or partially-updated cursor
+                     * pixels -- which the caller's content hash then suppresses,
+                     * freezing the remote cursor. */
+                    struct dma_buf_sync sync = {
+                        .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
+                    };
+                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
                     size_t tight = (size_t)fb2->width * fb2->height * 4;
                     cursor->pixels = malloc(tight);
                     if (cursor->pixels) {
@@ -223,6 +234,8 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                                    (size_t)fb2->width * 4);
                         }
                     }
+                    sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
                     munmap(mapped, map_size);
                 }
             }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -221,7 +221,20 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                     struct dma_buf_sync sync = {
                         .flags = DMA_BUF_SYNC_START | DMA_BUF_SYNC_READ
                     };
-                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
+                    /* Track whether START actually took, and only issue the
+                     * matching END if it did -- an unpaired END would unbalance
+                     * the exporter's CPU-access accounting. A failure is logged
+                     * and the read still proceeds: it degrades to the previous
+                     * (unsynchronised) behaviour rather than dropping the cursor
+                     * on an exporter that does not implement the ioctl, and a
+                     * stale cursor is cosmetic, not corruption. */
+                    int sync_started =
+                        drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync) == 0;
+                    if (!sync_started) {
+                        drmtap_debug_log(ctx,
+                            "cursor: DMA_BUF_SYNC_START failed (%s); reading "
+                            "without cache invalidation", strerror(errno));
+                    }
                     size_t tight = (size_t)fb2->width * fb2->height * 4;
                     cursor->pixels = malloc(tight);
                     if (cursor->pixels) {
@@ -234,8 +247,14 @@ int drmtap_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
                                    (size_t)fb2->width * 4);
                         }
                     }
-                    sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
-                    drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync);
+                    if (sync_started) {
+                        sync.flags = DMA_BUF_SYNC_END | DMA_BUF_SYNC_READ;
+                        if (drmIoctl(prime_fd, DMA_BUF_IOCTL_SYNC, &sync) != 0) {
+                            drmtap_debug_log(ctx,
+                                "cursor: DMA_BUF_SYNC_END failed (%s)",
+                                strerror(errno));
+                        }
+                    }
                     munmap(mapped, map_size);
                 }
             }

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -1103,6 +1103,9 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                 "auto-process: CCS modifier 0x%lx needs GPU deswizzle "
                 "(EGL/DMA-BUF), CPU deswizzle not possible -- failing closed",
                 (unsigned long)modifier);
+            drmtap_set_error(ctx,
+                "compressed scanout (modifier 0x%lx) needs a GPU deswizzle, "
+                "which is unavailable on this path", (unsigned long)modifier);
             return -ENOTSUP;
         }
         if (ret == 0) {
@@ -1158,6 +1161,9 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
     drmtap_debug_log(ctx, "auto-process: unknown driver '%s' mod=0x%lx cannot "
                      "deswizzle and EGL unavailable -- failing closed",
                      driver, (unsigned long)modifier);
+    drmtap_set_error(ctx,
+        "tiled scanout (driver '%s', modifier 0x%lx) has no CPU deswizzle and "
+        "EGL detile is unavailable", driver, (unsigned long)modifier);
     return -ENOTSUP;
 }
 

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -663,11 +663,11 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             }
 
             drmModeFreeFB2(fb2);
-            /* For a virgl frame the GPU readback is the only way to get real
-             * pixels; if it failed, propagate the error rather than handing the
-             * caller a black frame. Non-virgl frames keep the prior best-effort
-             * behaviour (pret is ignored). */
-            if (is_virgl && pret != 0) {
+            /* Propagate ANY processing failure -- a virgl readback that produced no
+             * pixels, or an unconvertible CCS/compressed scanout that returned
+             * -ENOTSUP -- instead of handing the caller a black or still-compressed
+             * frame reported as valid. (Previously only virgl failures propagated.) */
+            if (pret != 0) {
                 /* Release everything this frame acquired (the DMA-BUF fd, the
                  * mmap and priv) — a failed grab is not released by the caller,
                  * so returning here without cleanup would leak them each grab. */
@@ -698,7 +698,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         frame->_priv = priv;
 
         if (do_mmap) {
-            gpu_auto_process(ctx, pixel_buf, frame, 0);
+            int pr = gpu_auto_process(ctx, pixel_buf, frame, 0);
+            if (pr != 0) {
+                /* Propagate a processing failure (e.g. an unconvertible CCS
+                 * scanout that returned -ENOTSUP) instead of handing back the
+                 * undecoded pixels reported as a valid frame. The caller does
+                 * not release a frame on error, so release priv here (V2 borrows
+                 * ctx->pixel_buf, so this frees priv only). */
+                drmModeFreeFB2(fb2);
+                drmtap_frame_release(ctx, frame);
+                return pr;
+            }
         }
 
         drmModeFreeFB2(fb2);
@@ -805,7 +815,17 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             drmtap_debug_log(ctx, "mapped %zu bytes at %p", size, mapped);
 
             /* Auto-deswizzle tiled framebuffers + format convert */
-            gpu_auto_process(ctx, mapped, frame, 0);
+            int pr = gpu_auto_process(ctx, mapped, frame, 0);
+            if (pr != 0) {
+                /* Propagate a processing failure (e.g. an unconvertible CCS
+                 * scanout that returned -ENOTSUP) instead of handing back the
+                 * still-tiled/compressed mmap reported as a valid frame. The
+                 * caller does not release a frame on error, so release the fd,
+                 * mmap (with its matching SYNC_END) and priv here. */
+                drmModeFreeFB2(fb2);
+                drmtap_frame_release(ctx, frame);
+                return pr;
+            }
         }
     }
 
@@ -825,6 +845,12 @@ cleanup:
         drmtap_gem_close(ctx, priv->gem_handle);
     }
     free(priv);
+    /* Leave the frame owning nothing on this error exit too, matching the
+     * drmtap_frame_release() the propagation sites use: priv is now freed, so a
+     * caller that defensively releases on a non-zero return gets a harmless no-op
+     * instead of a double-free through a dangling frame->_priv. */
+    frame->_priv = NULL;
+    frame->dma_buf_fd = -1;
     return ret;
 }
 
@@ -1066,18 +1092,18 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                                    frame->stride, frame->stride, modifier,
                                    (size_t)frame->stride * frame->height);
         if (ret == -ENOTSUP) {
-            /* CCS-compressed modifier — CPU deswizzle impossible.
-             * This happens in helper mode where dma_buf_fd is unavailable
-             * and the pixel data came from dumb_mmap (still compressed).
-             * Fall through to return raw data as-is with LINEAR modifier
-             * so the caller doesn't crash trying to deswizzle. */
+            /* CCS-compressed (or otherwise unsupported) modifier -- the CPU
+             * deswizzle cannot decode it and no EGL path produced linear pixels
+             * (helper V2 dumb-map, or EGL import/failure). Returning the raw
+             * compressed bytes relabelled LINEAR would hand the caller a corrupt
+             * frame reported as valid (drmtap_convert_dmabuf would forward garbage
+             * instead of failing over). Fail closed so the caller ends the stream
+             * and falls back (e.g. to PipeWire) instead. */
             drmtap_debug_log(ctx,
                 "auto-process: CCS modifier 0x%lx needs GPU deswizzle "
-                "(EGL/DMA-BUF), CPU deswizzle not possible — "
-                "returning raw pixels",
+                "(EGL/DMA-BUF), CPU deswizzle not possible -- failing closed",
                 (unsigned long)modifier);
-            frame->modifier = 0; /* DRM_FORMAT_MOD_LINEAR */
-            return 0;
+            return -ENOTSUP;
         }
         if (ret == 0) {
             frame->data = ctx->deswizzle_buf;
@@ -1122,9 +1148,17 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         return ret;
     }
 
-    drmtap_debug_log(ctx, "auto-process: unknown driver '%s' mod=0x%lx",
+    /* Real tiling modifier (non-LINEAR, non-INVALID -- a genuinely tiled scanout;
+     * linear/unknown-layout buffers already returned above) on a driver we have no
+     * CPU deswizzle for, and EGL did not detile it (unavailable, or it failed).
+     * Returning the raw tiled mapping relabelled linear would hand the caller
+     * corruption reported as valid -- the same failure the CCS branch now guards.
+     * Fail closed instead, symmetric with it, so the caller ends the stream and
+     * falls back (do_grab propagates this; e.g. rustdesk demotes to PipeWire). */
+    drmtap_debug_log(ctx, "auto-process: unknown driver '%s' mod=0x%lx cannot "
+                     "deswizzle and EGL unavailable -- failing closed",
                      driver, (unsigned long)modifier);
-    return 0;
+    return -ENOTSUP;
 }
 
 /* ========================================================================= */

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -116,11 +116,24 @@ static int open_drm_auto(drmtap_ctx *ctx) {
     }
 
     /* Two-pass scan of /dev/dri/card0..card15:
-     *   Pass 1: find a device with an ACTIVE CRTC (monitor connected)
+     *   Pass 1: find the device driving the MOST displays (active CRTCs)
      *   Pass 2: fallback to any device with KMS resources
+     *
+     * A context covers ONE device, so on a multi-GPU host this pick decides
+     * which displays are capturable at all; drmtap_list_devices() is the way to
+     * reach the others. Until 0.4.15 this took the FIRST card with any active
+     * CRTC, which is just "lowest minor wins" and can be badly wrong: load vkms
+     * next to a real GPU and it registers as card0 with one 1024x768 virtual
+     * output, so auto-detect captured that instead of the three real monitors on
+     * card1. Ranking by active-CRTC count makes the single-card choice land on
+     * the GPU actually driving the desktop. It remains a heuristic — a caller
+     * that wants every display must enumerate devices.
      */
     int fallback_fd = -1;
     char fallback_path[64] = {0};
+    int best_fd = -1;
+    int best_active = 0;
+    char best_path[64] = {0};
 
     for (int i = 0; i < 16; i++) {
         snprintf(path, sizeof(path), "/dev/dri/card%d", i);
@@ -138,27 +151,34 @@ static int open_drm_auto(drmtap_ctx *ctx) {
             continue;
         }
 
-        /* Check for active CRTCs (monitor driving a display) */
-        int has_active = 0;
+        /* Count active CRTCs (monitors this device is driving) */
+        int active = 0;
         for (int j = 0; j < res->count_crtcs; j++) {
             drmModeCrtc *crtc = drmModeGetCrtc(fd, res->crtcs[j]);
             if (crtc) {
                 if (crtc->mode_valid && crtc->buffer_id > 0) {
                     drmtap_debug_log(ctx, "  CRTC %u active (%dx%d)",
                                      crtc->crtc_id, crtc->width, crtc->height);
-                    has_active = 1;
+                    active++;
                 }
                 drmModeFreeCrtc(crtc);
-                if (has_active) break;
             }
         }
         drmModeFreeResources(res);
 
-        if (has_active) {
-            /* Found the GPU driving a monitor — use this one */
-            if (fallback_fd >= 0) close(fallback_fd);
-            snprintf(ctx->device_path, sizeof(ctx->device_path), "%s", path);
-            return fd;
+        if (active > 0) {
+            /* Keep the best candidate so far; ties keep the lower minor. */
+            if (active > best_active) {
+                if (best_fd >= 0) {
+                    close(best_fd);
+                }
+                best_fd = fd;
+                best_active = active;
+                snprintf(best_path, sizeof(best_path), "%s", path);
+            } else {
+                close(fd);
+            }
+            continue;
         }
 
         /* Keep as fallback (first device with KMS but no active CRTC) */
@@ -169,6 +189,17 @@ static int open_drm_auto(drmtap_ctx *ctx) {
         } else {
             close(fd);
         }
+    }
+
+    /* The GPU driving the most displays wins. */
+    if (best_fd >= 0) {
+        if (fallback_fd >= 0) {
+            close(fallback_fd);
+        }
+        snprintf(ctx->device_path, sizeof(ctx->device_path), "%s", best_path);
+        drmtap_debug_log(ctx, "using %s (%d active display(s))", best_path,
+                         best_active);
+        return best_fd;
     }
 
     /* No device with active CRTC found — use fallback if available */
@@ -329,6 +360,80 @@ fail:
     }
     free(ctx);
     return NULL;
+}
+
+int drmtap_list_devices(drmtap_device *out, int max_count) {
+    if (!out || max_count <= 0) {
+        return -EINVAL;
+    }
+
+    int found = 0;
+    for (int i = 0; i < 16 && found < max_count; i++) {
+        char path[64];
+        snprintf(path, sizeof(path), "/dev/dri/card%d", i);
+        int fd = open(path, O_RDWR | O_CLOEXEC);
+        if (fd < 0) {
+            continue;
+        }
+
+        /* Opening a card node while nobody holds master grants US implicit
+         * master, which would block a compositor from acquiring it on a VT
+         * switch. Enumeration never modesets, so give it straight back — same
+         * reasoning as drmtap_open, and the gate is the capability, not the uid
+         * (drmModeGetResources works without master either way). */
+        if (drmtap_have_cap_sys_admin()) {
+            drmDropMaster(fd);
+        }
+
+        drmModeRes *res = drmModeGetResources(fd);
+        if (!res) {
+            close(fd);   /* render-only or no KMS: not a capturable device */
+            continue;
+        }
+
+        drmtap_device *dev = &out[found];
+        memset(dev, 0, sizeof(*dev));
+        snprintf(dev->path, sizeof(dev->path), "%s", path);
+
+        /* Count CRTCs actually scanning out. Deliberately NOT walking the
+         * connectors: drmModeGetConnector re-probes the link (DDC), and doing
+         * that across every card of every GPU just to enumerate can disturb a
+         * live display. An active CRTC is also the exact thing a capture needs. */
+        for (int j = 0; j < res->count_crtcs; j++) {
+            drmModeCrtc *crtc = drmModeGetCrtc(fd, res->crtcs[j]);
+            if (!crtc) {
+                continue;
+            }
+            if (crtc->mode_valid && crtc->buffer_id > 0) {
+                dev->display_count++;
+            }
+            drmModeFreeCrtc(crtc);
+        }
+        drmModeFreeResources(res);
+
+        drmVersionPtr ver = drmGetVersion(fd);
+        if (ver) {
+            if (ver->name) {
+                snprintf(dev->driver, sizeof(dev->driver), "%s", ver->name);
+            }
+            drmFreeVersion(ver);
+        }
+
+        drmDevicePtr dd = NULL;
+        if (drmGetDevice2(fd, 0, &dd) == 0 && dd) {
+            if ((dd->available_nodes & (1 << DRM_NODE_RENDER)) &&
+                dd->nodes[DRM_NODE_RENDER]) {
+                snprintf(dev->render_node, sizeof(dev->render_node), "%s",
+                         dd->nodes[DRM_NODE_RENDER]);
+            }
+            drmFreeDevice(&dd);
+        }
+
+        close(fd);
+        found++;
+    }
+
+    return found;
 }
 
 /* ── Render-node selection on a multi-GPU box ─────────────────────────────

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -330,6 +331,179 @@ fail:
     return NULL;
 }
 
+/* ── Render-node selection on a multi-GPU box ─────────────────────────────
+ *
+ * "The first openable /dev/dri/renderD*" is the wrong default when more than
+ * one GPU is present: the scanout DMA-BUF is exported by the card that drives
+ * the display, and importing it into a DIFFERENT vendor's render node can fail
+ * outright (incompatible tiling modifiers) — permanently, since the choice is
+ * made once at open. A Jetson Orin shows this concretely: card1 is `tegra`
+ * (renderD128, NO connectors) while card2 is `nvidia-drm` (renderD129) and owns
+ * the connected DP-1, so the old scan picked exactly the node that does not own
+ * the scanout.
+ *
+ * The unprivileged converter cannot simply open the KMS cards to find out which
+ * one drives a display — it may hold no rights on them — so the ranking is read
+ * from sysfs, which needs no privilege: a card whose connector is `connected`
+ * AND `enabled` is actively scanning out and wins; merely `connected` is the
+ * runner-up; a card with no outputs (a compute/offload GPU) is never preferred.
+ * When sysfs is unavailable (a container without /sys) this yields nothing and
+ * the caller falls back to the historical first-openable scan.
+ *
+ * A caller that KNOWS the exporting device should not rely on this heuristic at
+ * all — drmtap_render_node() on the capture context names the exact node.
+ */
+
+/* Read the first line of a small sysfs file into `buf` (NUL-terminated).
+ * Returns 0 on success. */
+static int read_sysfs_line(const char *path, char *buf, size_t len) {
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        return -1;
+    }
+    ssize_t n = read(fd, buf, len - 1);
+    close(fd);
+    if (n <= 0) {
+        return -1;
+    }
+    buf[n] = '\0';
+    char *nl = strchr(buf, '\n');
+    if (nl) {
+        *nl = '\0';
+    }
+    return 0;
+}
+
+/* Name of the KMS card ("card1") backing render node `render_name`
+ * ("renderD128"), via /sys/class/drm/<render>/device/drm/. Returns 0 on
+ * success. */
+static int card_for_render_node(const char *render_name, char *out,
+                                size_t out_len) {
+    char dir_path[320];
+    snprintf(dir_path, sizeof(dir_path), "/sys/class/drm/%s/device/drm",
+             render_name);
+    DIR *dir = opendir(dir_path);
+    if (!dir) {
+        return -1;
+    }
+    int found = -1;
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        /* The directory holds the sibling nodes of the same device: cardN,
+         * renderDM and (on older kernels) controlDK. Take the primary node —
+         * "card" with no "-CONNECTOR" suffix. */
+        if (strncmp(ent->d_name, "card", 4) != 0 || !ent->d_name[4] ||
+            strchr(ent->d_name, '-') != NULL) {
+            continue;
+        }
+        size_t len = strlen(ent->d_name);
+        if (len >= out_len) {
+            continue;  /* not a name we could have produced; ignore it */
+        }
+        memcpy(out, ent->d_name, len + 1);
+        found = 0;
+        break;
+    }
+    closedir(dir);
+    return found;
+}
+
+/* How strongly card `card_name` looks like the device driving a display:
+ * 2 = has a connected AND enabled connector (actively scanning out),
+ * 1 = has a connected connector, 0 = none (or sysfs unreadable). */
+static int card_output_rank(const char *card_name) {
+    DIR *dir = opendir("/sys/class/drm");
+    if (!dir) {
+        return 0;
+    }
+    size_t card_len = strlen(card_name);
+    int rank = 0;
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        /* Connectors are exposed as "<card>-<CONNECTOR>", e.g. card1-DP-1. */
+        if (strncmp(ent->d_name, card_name, card_len) != 0 ||
+            ent->d_name[card_len] != '-') {
+            continue;
+        }
+        char path[320], val[32];
+        snprintf(path, sizeof(path), "/sys/class/drm/%s/status", ent->d_name);
+        /* "disconnected" also ends in "connected" — compare from the start. */
+        if (read_sysfs_line(path, val, sizeof(val)) != 0 ||
+            strcmp(val, "connected") != 0) {
+            continue;
+        }
+        if (rank < 1) {
+            rank = 1;
+        }
+        snprintf(path, sizeof(path), "/sys/class/drm/%s/enabled", ent->d_name);
+        if (read_sysfs_line(path, val, sizeof(val)) == 0 &&
+            strcmp(val, "enabled") == 0) {
+            rank = 2;
+            break;
+        }
+    }
+    closedir(dir);
+    return rank;
+}
+
+/* Best-ranked render node path into `out`. Returns 0 when one was picked. */
+static int pick_scanout_render_node(char *out, size_t out_len) {
+    DIR *dir = opendir("/sys/class/drm");
+    if (!dir) {
+        return -1;
+    }
+    int best_rank = 0;
+    char best[64] = {0};
+    struct dirent *ent;
+    while ((ent = readdir(dir)) != NULL) {
+        if (strncmp(ent->d_name, "renderD", 7) != 0) {
+            continue;
+        }
+        char card[64];
+        if (card_for_render_node(ent->d_name, card, sizeof(card)) != 0) {
+            continue;
+        }
+        size_t len = strlen(ent->d_name);
+        if (len >= sizeof(best)) {
+            continue;
+        }
+        int rank = card_output_rank(card);
+        if (rank > best_rank) {
+            best_rank = rank;
+            memcpy(best, ent->d_name, len + 1);
+            if (rank >= 2) {
+                break;  /* actively scanning out — nothing can outrank it */
+            }
+        }
+    }
+    closedir(dir);
+    if (best_rank == 0) {
+        return -1;
+    }
+    snprintf(out, out_len, "/dev/dri/%s", best);
+    return 0;
+}
+
+const char *drmtap_render_node(drmtap_ctx *ctx) {
+    if (!ctx || ctx->drm_fd < 0) {
+        return NULL;
+    }
+    if (ctx->render_node[0]) {
+        return ctx->render_node;
+    }
+    drmDevicePtr dev = NULL;
+    if (drmGetDevice2(ctx->drm_fd, 0, &dev) != 0 || !dev) {
+        return NULL;
+    }
+    if ((dev->available_nodes & (1 << DRM_NODE_RENDER)) &&
+        dev->nodes[DRM_NODE_RENDER]) {
+        snprintf(ctx->render_node, sizeof(ctx->render_node), "%s",
+                 dev->nodes[DRM_NODE_RENDER]);
+    }
+    drmFreeDevice(&dev);
+    return ctx->render_node[0] ? ctx->render_node : NULL;
+}
+
 drmtap_ctx *drmtap_open_render(const char *render_node) {
     drmtap_ctx *ctx = calloc(1, sizeof(drmtap_ctx));
     if (!ctx) {
@@ -364,7 +538,29 @@ drmtap_ctx *drmtap_open_render(const char *render_node) {
             goto fail;
         }
     } else {
-        /* Auto-detect: first openable render node. DRM render minors span the
+        /* Auto-detect. Prefer the render node of the card that actually drives
+         * a display (see pick_scanout_render_node): on a multi-GPU box that is
+         * the device exporting the scanout we will be asked to import, and the
+         * only one guaranteed to understand its tiling modifier. */
+        char preferred[96];
+        if (pick_scanout_render_node(preferred, sizeof(preferred)) == 0) {
+            int fd = open(preferred, O_RDWR | O_CLOEXEC);
+            if (fd >= 0) {
+                snprintf(ctx->device_path, sizeof(ctx->device_path), "%s",
+                         preferred);
+                ctx->drm_fd = fd;
+                drmtap_debug_log(ctx, "render node %s selected: its card "
+                                 "drives a display", preferred);
+            } else {
+                drmtap_debug_log(ctx, "render node %s drives a display but "
+                                 "could not be opened (%s); scanning",
+                                 preferred, strerror(errno));
+            }
+        }
+    }
+
+    if (ctx->drm_fd < 0 && !(render_node && render_node[0])) {
+        /* Fallback: first openable render node. DRM render minors span the
          * whole 128..191 range (up to 64 nodes on a multi-GPU box), so scan all
          * of it — a valid device can sit above renderD143. No KMS probing here
          * on purpose: a render node has no resources. */

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -492,7 +492,7 @@ static int card_for_render_node(const char *render_name, char *out,
         return -1;
     }
     int found = -1;
-    struct dirent *ent;
+    const struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
         /* The directory holds the sibling nodes of the same device: cardN,
          * renderDM and (on older kernels) controlDK. Take the primary node —
@@ -523,7 +523,7 @@ static int card_output_rank(const char *card_name) {
     }
     size_t card_len = strlen(card_name);
     int rank = 0;
-    struct dirent *ent;
+    const struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
         /* Connectors are exposed as "<card>-<CONNECTOR>", e.g. card1-DP-1. */
         if (strncmp(ent->d_name, card_name, card_len) != 0 ||
@@ -559,7 +559,7 @@ static int pick_scanout_render_node(char *out, size_t out_len) {
     }
     int best_rank = 0;
     char best[64] = {0};
-    struct dirent *ent;
+    const struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
         if (strncmp(ent->d_name, "renderD", 7) != 0) {
             continue;

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -38,6 +38,9 @@ struct drmtap_ctx {
     int drm_fd;
     char device_path[256];
     char driver_name[64];
+    /* Render node of THIS device, resolved lazily by drmtap_render_node().
+     * Empty until first asked (the device has none, or it was never queried). */
+    char render_node[256];
 
     /* Selected display */
     uint32_t crtc_id;

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -698,34 +698,6 @@ static void ensure_linear_texture(egl_state_t *state, uint32_t w, uint32_t h) {
     state->tex_height = h;
 }
 
-/* True for a scanout fourcc carrying more than 8 bits per channel: the 10-bit
- * XR30 family and the 16-bit XR48 family (integer and half-float). Such a buffer
- * must NOT be reinterpreted as XRGB8888 during import retry -- that would sample it
- * at the wrong bit depth (and, for the 16-bit formats, the wrong row width) and
- * hand back a garbage frame reported as success. */
-static int egl_fourcc_high_bit_depth(uint32_t fourcc) {
-    switch (fourcc) {
-    /* 10-bit 2:10:10:10 */
-    case fourcc_code('X', 'R', '3', '0'):
-    case fourcc_code('X', 'B', '3', '0'):
-    case fourcc_code('A', 'R', '3', '0'):
-    case fourcc_code('A', 'B', '3', '0'):
-    /* 16-bit integer */
-    case fourcc_code('X', 'R', '4', '8'):
-    case fourcc_code('X', 'B', '4', '8'):
-    case fourcc_code('A', 'R', '4', '8'):
-    case fourcc_code('A', 'B', '4', '8'):
-    /* 16-bit half-float */
-    case fourcc_code('X', 'R', '4', 'H'):
-    case fourcc_code('X', 'B', '4', 'H'):
-    case fourcc_code('A', 'R', '4', 'H'):
-    case fourcc_code('A', 'B', '4', 'H'):
-        return 1;
-    default:
-        return 0;
-    }
-}
-
 /* Import a DMA-BUF as an EGLImage, retrying with progressively simpler
  * attribute sets (XRGB8888 keeping the modifier, then XRGB8888 alone) the way
  * some drivers need. CCS auxiliary planes come from ctx->fb2_*. Returns
@@ -812,16 +784,27 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
                          first_err, (const char *)&fourcc,
                          (unsigned long)modifier);
 
-        /* The XRGB8888 retries below reinterpret the buffer as 8-bit while keeping
-         * the source stride. That only makes sense for a genuine 8-bit scanout whose
-         * exact fourcc the driver does not recognize. For a high-bit-depth source
-         * (10-bit XR30 / 16-bit XR48 family) it would sample the wrong bit depth and
-         * return corruption as success, so fail the import instead: the caller then
-         * reduces the real bit depth from the raw mapping on the CPU. */
-        if (egl_fourcc_high_bit_depth(fourcc)) {
-            drmtap_debug_log(ctx, "egl: no XRGB8888 retry for high-bit-depth "
-                             "fourcc %.4s (would corrupt); failing import so the "
-                             "CPU reduce path runs", (const char *)&fourcc);
+        /* The XRGB8888 retries below reinterpret the buffer as a single 8-bit RGB
+         * plane at the source stride. That is only safe for a single-plane 8-bit
+         * RGB scanout (XRGB8888 / ARGB8888) whose exact fourcc a driver refuses.
+         * For anything else it samples the wrong layout and returns corruption as
+         * success:
+         *   - a high-bit-depth source (10-bit XR30 / 16-bit XR48 family): wrong bit depth;
+         *   - a BGR order (XBGR / ABGR): swapped red and blue;
+         *   - a multi-plane / CCS-compressed buffer: the retry emits only plane 0, so
+         *     the auxiliary (compression) planes are dropped and the shader samples
+         *     compressed data as pixels.
+         * In every such case, fail the import so the caller falls back (CPU reduce,
+         * or ending the stream) rather than forwarding a corrupt frame. */
+        int retry_safe = (ctx->fb2_num_planes <= 1) &&
+                         (fourcc == DRM_FORMAT_XRGB8888 ||
+                          fourcc == DRM_FORMAT_ARGB8888);
+        if (!retry_safe) {
+            drmtap_debug_log(ctx, "egl: no XRGB8888 retry for fourcc %.4s "
+                             "planes=%d modifier=0x%lx (would corrupt); failing "
+                             "import so the caller falls back",
+                             (const char *)&fourcc, ctx->fb2_num_planes,
+                             (unsigned long)modifier);
             return EGL_NO_IMAGE_KHR;
         }
 
@@ -855,8 +838,16 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
             state.display, EGL_NO_CONTEXT,
             EGL_LINUX_DMA_BUF_EXT, NULL, retry_attribs);
 
-        if (image == EGL_NO_IMAGE_KHR) {
-            /* Last resort: try XRGB8888 without modifier */
+        if (image == EGL_NO_IMAGE_KHR && modifier == DRM_FORMAT_MOD_LINEAR) {
+            /* Last resort: XRGB8888 with NO modifier attributes, for a driver
+             * that rejects the explicit-modifier form but accepts the implicit
+             * one. Gated to a LINEAR source on purpose: dropping a REAL tiling
+             * modifier would make EGL sample the tiled bytes as linear and return
+             * corruption reported as success, so an explicitly-tiled buffer stops
+             * at the modifier retry above and lets the caller fall back. (A LINEAR
+             * source has no tiling to lose; an INVALID modifier already took the
+             * no-modifier path in the retry above, so repeating it here is
+             * pointless -- the same call would fail identically.) */
             ri = 0;
             retry_attribs[ri++] = EGL_WIDTH;
             retry_attribs[ri++] = (EGLint)width;
@@ -872,7 +863,7 @@ static EGLImageKHR egl_import_dmabuf(drmtap_ctx *ctx, int dma_buf_fd,
             retry_attribs[ri++] = (EGLint)stride;
             retry_attribs[ri++] = EGL_NONE;
 
-            drmtap_debug_log(ctx, "egl: retrying XRGB8888 no-modifier");
+            drmtap_debug_log(ctx, "egl: retrying XRGB8888 no-modifier (linear)");
             image = pfn_eglCreateImageKHR(
                 state.display, EGL_NO_CONTEXT,
                 EGL_LINUX_DMA_BUF_EXT, NULL, retry_attribs);

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -227,9 +227,23 @@ static int load_gl_libraries(void) {
 /* EGL context (lazily initialized per drmtap_ctx)                           */
 /* ========================================================================= */
 
-/* Global EGL display (one per process, shared across threads) */
-static EGLDisplay g_egl_display = EGL_NO_DISPLAY;
-static int g_egl_display_initialized = 0;
+/* ── EGL displays, one PER DRM DEVICE (shared across threads) ──
+ * A single process-wide EGLDisplay is wrong on a multi-GPU host: the display is
+ * bound to the device it was created from, so whichever GPU happened to convert
+ * first would keep serving imports of scanouts exported by the other one — which
+ * can fail permanently (incompatible tiling modifiers). Keyed by the context's
+ * device path; entries are never torn down (see the CRITICAL note in
+ * drmtap_gpu_egl_available: terminating a display kills other threads' live
+ * detile contexts). An occupied slot memoizes a NEGATIVE outcome too — its
+ * display stays EGL_NO_DISPLAY — so a device with no usable EGL is not
+ * re-probed on every frame. */
+#define DRMTAP_EGL_DISPLAY_SLOTS 4
+static struct {
+    char        device_path[256];
+    EGLDisplay  display;          /* EGL_NO_DISPLAY = this device has no EGL */
+} g_egl_displays[DRMTAP_EGL_DISPLAY_SLOTS];
+static int g_egl_display_count = 0;
+static pthread_mutex_t g_egl_display_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* ── Import-once EGLImage cache (keyed by KMS fb_id) ── */
 /* The compositor scans out of a small pool of framebuffers (double/triple
@@ -258,7 +272,8 @@ typedef struct {
 
 /* Per-thread EGL context and GL resources */
 typedef struct {
-    EGLDisplay display;   /* cached copy of g_egl_display */
+    EGLDisplay display;        /* the display of `device_path`'s device */
+    char device_path[256];     /* DRM device this thread's GL state belongs to */
     EGLContext context;
     GLuint program;
     GLuint fbo;
@@ -289,7 +304,7 @@ static _Thread_local egl_state_t state = {0};
 /* Backstop for a capture thread that exits WITHOUT calling drmtap_close (an
  * error/panic path): a pthread TSD destructor frees this thread's EGL context at
  * thread exit, while its context can still be made current. The shared
- * g_egl_display is never terminated, so this is safe. */
+ * per-device displays are never terminated, so this is safe. */
 static pthread_key_t g_egl_tsd_key;
 static int g_egl_tsd_key_ok = 0;   /* set once the key is created successfully */
 static pthread_once_t g_egl_tsd_once = PTHREAD_ONCE_INIT;
@@ -511,6 +526,49 @@ static EGLDisplay get_egl_display_for_card(const char *card_path) {
     return display;
 }
 
+/* The INITIALIZED EGLDisplay for @ctx's DRM device, or EGL_NO_DISPLAY if that
+ * device has none. Memoized per device path; never terminated. Callers must
+ * have loaded the EGL procs (load_egl_procs) first. */
+static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
+    const char *path = (ctx && ctx->device_path[0]) ? ctx->device_path : "";
+
+    pthread_mutex_lock(&g_egl_display_lock);
+    for (int i = 0; i < g_egl_display_count; i++) {
+        if (strcmp(g_egl_displays[i].device_path, path) == 0) {
+            EGLDisplay cached = g_egl_displays[i].display;
+            pthread_mutex_unlock(&g_egl_display_lock);
+            return cached;
+        }
+    }
+
+    EGLDisplay display = get_egl_display_for_card(path);
+    if (display != EGL_NO_DISPLAY) {
+        EGLint major = 0, minor = 0;
+        if (eglInitialize(display, &major, &minor)) {
+            drmtap_debug_log(NULL, "EGL: display for %s initialized: %p (%d.%d)",
+                             path, (void *)display, major, minor);
+        } else {
+            drmtap_debug_log(NULL, "EGL: eglInitialize for %s failed: 0x%x",
+                             path, eglGetError());
+            display = EGL_NO_DISPLAY;
+        }
+    }
+
+    if (g_egl_display_count < DRMTAP_EGL_DISPLAY_SLOTS) {
+        int slot = g_egl_display_count;
+        snprintf(g_egl_displays[slot].device_path,
+                 sizeof(g_egl_displays[slot].device_path), "%s", path);
+        g_egl_displays[slot].display = display;
+        g_egl_display_count = slot + 1;
+    } else {
+        /* More distinct devices than slots: still correct (eglInitialize is
+         * idempotent per the spec), just re-resolved each time. */
+        drmtap_debug_log(NULL, "EGL: display table full, %s not memoized", path);
+    }
+    pthread_mutex_unlock(&g_egl_display_lock);
+    return display;
+}
+
 /* ========================================================================= */
 /* EGL state management                                                      */
 /* ========================================================================= */
@@ -521,25 +579,17 @@ static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
         return -ENOTSUP;
     }
 
-    /* Initialize global display once (thread-safe: eglInitialize is 
-     * idempotent per EGL spec — second call on same display is a no-op) */
-    if (!g_egl_display_initialized) {
-        g_egl_display = get_egl_display_for_card(ctx->device_path);
-        if (g_egl_display == EGL_NO_DISPLAY) {
-            drmtap_debug_log(ctx, "egl: no EGL display available");
-            return -ENODEV;
-        }
-        EGLint major, minor;
-        if (!eglInitialize(g_egl_display, &major, &minor)) {
-            drmtap_debug_log(ctx, "egl: eglInitialize failed: 0x%x",
-                             eglGetError());
-            return -EIO;
-        }
-        g_egl_display_initialized = 1;
-        drmtap_debug_log(NULL, "EGL: global display initialized: %p (%d.%d)",
-                (void*)g_egl_display, major, minor);
+    /* The display belongs to THIS context's device, not to the process (see the
+     * per-device table above). eglInitialize is idempotent per the EGL spec, so
+     * concurrent first-use from several threads is safe. */
+    state->display = egl_display_for_ctx(ctx);
+    if (state->display == EGL_NO_DISPLAY) {
+        drmtap_debug_log(ctx, "egl: no EGL display available for %s",
+                         ctx->device_path);
+        return -ENODEV;
     }
-    state->display = g_egl_display;
+    snprintf(state->device_path, sizeof(state->device_path), "%s",
+             ctx->device_path);
 
     eglBindAPI(EGL_OPENGL_ES_API);
 
@@ -657,13 +707,14 @@ static void egl_cleanup(egl_state_t *st) {
         glDeleteProgram(st->program);
     }
     /* Release the context from this thread before destroying it. MUST NOT
-     * eglTerminate(st->display): g_egl_display is shared across all capture
-     * threads; terminating it invalidates other threads' live detile contexts
-     * (see the CRITICAL note in drmtap_gpu_egl_available). */
+     * eglTerminate(st->display): that display is shared by every capture thread
+     * using the same DRM device; terminating it invalidates those threads' live
+     * detile contexts (see the CRITICAL note in drmtap_gpu_egl_available). */
     eglMakeCurrent(st->display, EGL_NO_SURFACE, EGL_NO_SURFACE,
                    EGL_NO_CONTEXT);
     eglDestroyContext(st->display, st->context);
     st->context = EGL_NO_CONTEXT;
+    st->device_path[0] = '\0';
     st->program = 0;
     st->fbo = 0;
     st->linear_texture = 0;
@@ -926,34 +977,30 @@ int drmtap_gpu_egl_available(drmtap_ctx *ctx) {
         return 0;
     }
     /* EGL availability is a static property of the GPU, but this is called on
-     * every captured frame. Cache it once.
+     * every captured frame — so it must stay cheap. It is a property PER DEVICE
+     * (a compute GPU with no EGL next to one with it), so the answer comes from
+     * the per-device display table, which memoizes both outcomes; after the
+     * first call this is a locked string compare.
      *
-     * CRITICAL: this must NOT call eglTerminate() on the display. The display
-     * returned by get_egl_display_for_card() is the SAME shared EGLDisplay used
-     * by the live detile contexts. Terminating it here — while another capture
-     * thread is mid-eglCreateImage — invalidates that thread's display and makes
-     * its detile fail with EGL_NOT_INITIALIZED, so it falls back to returning the
-     * raw tiled/compressed buffer (garbage/color corruption). Concurrent captures
+     * CRITICAL: this must NOT call eglTerminate() on the display. That display
+     * is the SAME one used by the live detile contexts on this device.
+     * Terminating it here — while another capture thread is mid-eglCreateImage —
+     * invalidates that thread's display and makes its detile fail with
+     * EGL_NOT_INITIALIZED, so it falls back to returning the raw
+     * tiled/compressed buffer (garbage/color corruption). Concurrent captures
      * (e.g. two monitors viewed at once) hit this constantly. */
-    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
-    static int cached = -1;
-    pthread_mutex_lock(&lk);
-    if (cached < 0) {
-        if (load_egl_procs() < 0) {
-            cached = 0;
-        } else {
-            EGLDisplay display = get_egl_display_for_card(ctx->device_path);
-            if (display == EGL_NO_DISPLAY) {
-                cached = 0;
-            } else {
-                EGLint major, minor;
-                cached = eglInitialize(display, &major, &minor) ? 1 : 0;
-                /* Intentionally no eglTerminate(display) — see above. */
-            }
-        }
+    static pthread_mutex_t procs_lk = PTHREAD_MUTEX_INITIALIZER;
+    static int procs_ok = -1;
+    pthread_mutex_lock(&procs_lk);
+    if (procs_ok < 0) {
+        procs_ok = load_egl_procs() < 0 ? 0 : 1;
     }
-    pthread_mutex_unlock(&lk);
-    return cached;
+    pthread_mutex_unlock(&procs_lk);
+    if (!procs_ok) {
+        return 0;
+    }
+    /* Intentionally no eglTerminate() on the returned display — see above. */
+    return egl_display_for_ctx(ctx) != EGL_NO_DISPLAY;
 }
 
 /**
@@ -1022,6 +1069,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     int ret;
 
     drmtap_debug_log(NULL, "EGL: state.initialized=%d", state.initialized);
+    /* The GL context, its shaders and the cached EGLImages all belong to ONE
+     * EGLDisplay, i.e. one DRM device. If this thread previously converted for
+     * a different device, none of that state can serve the new one — tear it
+     * down and rebuild rather than sample another GPU's display. (Comparing the
+     * device path, not the display handle, keeps this off the lock on the
+     * per-frame path.) */
+    if (state.initialized && strcmp(state.device_path, ctx->device_path) != 0) {
+        drmtap_debug_log(ctx, "egl: thread moved from %s to %s, rebuilding the "
+                         "GL context on the new device",
+                         state.device_path, ctx->device_path);
+        egl_cleanup(&state);
+    }
     if (!state.initialized) {
         ret = egl_init(ctx, &state);
         drmtap_debug_log(NULL, "EGL: egl_init returned %d", ret);


### PR DESCRIPTION
Follow-up to the 0.4.14 audit. Three defect classes, all of which returned corrupt or stale pixels while reporting success.

## 1. Undecodable scanouts now fail closed, and the failure is actually propagated

`gpu_auto_process()` used to suppress the CPU-deswizzle `-ENOTSUP` for a CCS-compressed framebuffer, relabel the modifier linear and return success, so the caller forwarded still-compressed bytes as a valid frame. It now returns `-ENOTSUP`.

That alone was not enough: `do_grab()` (the body of both `drmtap_grab` and `drmtap_grab_mapped`) **discarded** the `gpu_auto_process` return at its three call sites (direct mmap, helper V2, helper V3 -- the V3 site propagated only for virgl). All three now propagate a non-zero result, releasing the frame first, since a failed grab is not released by the caller.

The symmetric hole is closed too: a real (non-linear, non-INVALID) tiling modifier on a driver with no CPU deswizzle and no working EGL also returns `-ENOTSUP` instead of the raw tiled mapping. And every `do_grab` error exit now leaves the frame owning nothing, so a defensive double-release is a harmless no-op rather than a double-free through a dangling `frame->_priv`.

## 2. Cursor DMA-BUF read is now cache-coherent -- and the helper's seccomp filter allows it

The cursor mmap read is bracketed with the `DMA_BUF_IOCTL_SYNC` START/END pair the frame path already uses, in **both** `src/cursor.c` and the privileged helper. DMA-BUF CPU access is not guaranteed coherent, so a non-coherent exporter (ARM / Tegra) could hand back stale or partially updated cursor pixels, which a content-hash consumer then suppresses -- freezing the remote cursor.

**The helper needed a seccomp change for this and it is easy to miss:** `install_seccomp()` allows the `ioctl` syscall only when the request's type byte is DRM's `'d'`. `DMA_BUF_IOCTL_SYNC` is type `'b'` (`0x40086200`), so it did **not** match and fell through to `SCMP_ACT_KILL_PROCESS` -- the helper would have been SIGSYS-killed on the first cursor poll under seccomp. An exact-value allow rule is added for that one ioctl (exact rather than type-masked, to keep the widened surface minimal).

## 3. EGL import retries no longer reinterpret a buffer into the wrong layout

The XRGB8888 import retry is restricted to a single-plane 8-bit RGB source (XRGB8888 / ARGB8888). Reinterpreting anything else returned corruption as success: a BGR order swapped red and blue, and a multi-plane / CCS buffer dropped its auxiliary planes so the shader sampled compressed data as pixels. The final no-modifier retry is additionally gated to a LINEAR source -- dropping a real tiling modifier made EGL sample tiled bytes as linear, again reported as success.

## Testing

- Build clean with `-Werror`; 8/8 meson tests; the `libdrmtap-sys` crate builds (library + embedded helper); version coherence check passes; vendored `csrc/` re-synced.
- The seccomp rule was validated with a standalone reproducer that installs the same filter: with only the DRM-type rule the process dies with `SIGSYS` ("Bad system call"), with the new exact rule it survives.
- Frame and cursor capture verified on real aarch64 Tegra hardware (Jetson Orin, GDM Wayland): 1024x600 XR24 zero-copy frame, and the cursor plane read back as a clean 256x256 arrow / I-beam / animated spinner. An A/B against a build with the cursor sync removed showed no visible difference on that SoC, i.e. the bracket is spec-correct defensive coding there rather than a visible fix -- it matters on a genuinely non-coherent exporter.

Please review thoroughly, with attention to the release/ownership paths in `do_grab` (no double-free, double-close or leak on the new error returns) and to the seccomp rule.