### PR TITLE
Build and test the real EGL backend, and say why the fast path cannot read a scanout (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,10 @@ jobs:
 
       - name: Assert the built .so carries the EGL detile path
         run: |
-          so="$(ls build-release/libdrmtap.so.0.*.*)"
+          # -type f on purpose: the versioned .so sits next to meson's
+          # libdrmtap.so.0.4.15.p/ build directory, and a glob matches that too.
+          so="$(find build-release -maxdepth 1 -type f -name 'libdrmtap.so.0.*' | head -1)"
+          test -n "$so" || { echo "::error::no versioned libdrmtap.so in build-release"; exit 1; }
           echo "checking $so"
           # EGL is reached by lazy dlopen, on purpose, so that a privileged consumer never links the
           # vendor GL stack. There is therefore NO DT_NEEDED entry and no undefined egl* symbol to

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
             meson ninja-build gcc \
             libdrm-dev \
             libva-dev libva-drm2 \
-            libseccomp-dev libcap-dev
+            libseccomp-dev libcap-dev \
+            libegl-dev libgles2-mesa-dev
           # Try to get vkms module (may not exist on Azure kernel)
           sudo apt-get install -y linux-modules-extra-$(uname -r) 2>/dev/null || true
 
@@ -60,6 +61,7 @@ jobs:
           meson setup build \
             -Dbuildtype=debug \
             -Db_sanitize=address,undefined \
+            -Degl=enabled \
             -Dwerror=true
           meson compile -C build
 
@@ -75,8 +77,25 @@ jobs:
         run: |
           meson setup build-release \
             -Dbuildtype=release \
+            -Degl=enabled \
             -Dwerror=true
           meson compile -C build-release
+
+      - name: Assert the built .so carries the EGL detile path
+        run: |
+          so="$(ls build-release/libdrmtap.so.0.*.*)"
+          echo "checking $so"
+          # EGL is reached by lazy dlopen, on purpose, so that a privileged consumer never links the
+          # vendor GL stack. There is therefore NO DT_NEEDED entry and no undefined egl* symbol to
+          # look for: the obvious ELF check reports "no EGL" on a perfectly good library. What a
+          # stub build really lacks is the dlopen target name and the import call itself.
+          for sym in "libEGL.so.1" "eglCreateImageKHR"; do
+            if ! strings "$so" | grep -qF "$sym"; then
+              echo "::error::$so has no $sym: this is a CPU-only stub, the shipped detile path is missing"
+              exit 1
+            fi
+          done
+          echo "::notice::EGL detile path present in $so"
 
   static-analysis:
     name: Static Analysis
@@ -93,11 +112,12 @@ jobs:
             meson ninja-build gcc \
             libdrm-dev libva-dev libva-drm2 \
             libseccomp-dev libcap-dev \
+            libegl-dev libgles2-mesa-dev \
             cppcheck
 
       - name: Build
         run: |
-          meson setup build -Dbuildtype=debug
+          meson setup build -Dbuildtype=debug -Degl=enabled
           meson compile -C build
 
       - name: cppcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 
 ## [Unreleased]
 
+### Fixed
+
+- drmtap_grab_mapped_fast() said nothing useful when it could not read the
+  scanout (issue #36, a Radeon Vega 64 on amdgpu where the tiled VRAM scanout
+  refuses a CPU mmap). Three separate silences: the no-mapping-and-no-EGL exit
+  returned -ENOMEM without ever calling drmtap_set_error, so drmtap_error() was
+  empty and the only symptom was a wall of cache-miss lines; the per-frame miss
+  line said "cold start" on a device where every frame is a miss BY DESIGN,
+  because the EGL fd fallback has no CPU mapping to cache; and the fallback
+  itself was never announced. Now the reason is logged once with the errno, the
+  per-frame line distinguishes an uncachable scanout from a genuine cold start,
+  and the no-EGL exit names the cause and the remedy. The failing mmap is no
+  longer retried per frame either: whether a scanout BO is CPU-mappable is a
+  property of the driver and the placement, so a context learns it once.
+  The capture itself has worked since 0.4.14, which added the mmap-to-EGL
+  fallback; on 0.4.13 that path returned -ENOMEM on every frame, which is why
+  the reporter saw black.
+
 ### Changed
 
 - New meson option `egl` (feature, default `auto`, so the historical behaviour is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Notable changes to libdrmtap. Loosely follows Keep a Changelog; the project uses
 semantic versioning. The C library, the `libdrmtap-sys` crate and the meson
 project share one version; the `libdrmtap` wrapper crate is versioned separately.
 
+## [Unreleased]
+
+### Changed
+
+- New meson option `egl` (feature, default `auto`, so the historical behaviour is
+  unchanged). `enabled` hard-fails when the egl/glesv2 pkg-config files or
+  headers are missing, instead of quietly building the CPU-only stub. CI now
+  passes `-Degl=enabled` on every C build and installs libegl-dev plus
+  libgles2-mesa-dev, because it had neither: every C job was building and testing
+  the stub, so the GPU detiling backend that real deployments run had no
+  automated coverage at all, and nothing would have reported it. The release job
+  additionally asserts the built .so carries the dlopen target name and an EGL
+  entry point, since the backend is reached by lazy dlopen and therefore leaves
+  no DT_NEEDED entry for the obvious ELF check to find.
+
 ## [0.4.15] - 2026-07-24
 
 ### Added

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -1299,6 +1299,7 @@ void drmtap_fast_cleanup(drmtap_ctx *ctx) {
     ctx->fast_plane_id = 0;
     ctx->fast_last_fb_id = 0;
     ctx->fast_initialized = 0;
+    ctx->fast_no_cpu_map = 0;
 }
 
 // Find or allocate a slot for the given fb_id
@@ -1367,6 +1368,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             ctx->fast_slots[i].prime_fd = -1;
         }
         ctx->fast_last_fb_id = 0;
+        ctx->fast_no_cpu_map = 0;
         ctx->fast_initialized = 1;
         drmtap_debug_log(ctx, "fast2: initialized plane=%u", ctx->fast_plane_id);
     }
@@ -1374,6 +1376,10 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     /* Step 2: Refresh fb_id (cheap ioctl, ~0.05ms) */
     drmModePlane *plane = drmModeGetPlane(ctx->drm_fd, ctx->fast_plane_id);
     if (!plane || plane->fb_id == 0) {
+        drmtap_set_error(ctx, plane
+            ? "fast2: plane %u has no framebuffer bound (display asleep or a modeset in flight)"
+            : "fast2: plane %u disappeared (a modeset changed the plane layout)",
+            ctx->fast_plane_id);
         if (plane) drmModeFreePlane(plane);
         drmtap_fast_cleanup(ctx);
         return -ENODEV;
@@ -1472,9 +1478,14 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         return 0;   /* new frame */
     }
 
-    /* ═══ CACHE MISS ═══ First time seeing this fb_id — full setup */
-    drmtap_debug_log(ctx, "fast2: CACHE MISS fb=%u slot=%d (cold start)",
-                     fb_id, slot);
+    /* ═══ CACHE MISS ═══ First time seeing this fb_id — full setup.
+     * On a device whose scanout cannot be CPU-mapped this is EVERY frame, and
+     * it is not a cold start: the EGL fd path below has no CPU mapping to cache,
+     * so there is never anything to hit. Say which one it is, or the log reads
+     * like a cache that is broken rather than one that does not apply. */
+    drmtap_debug_log(ctx, "fast2: CACHE MISS fb=%u slot=%d (%s)", fb_id, slot,
+                     ctx->fast_no_cpu_map ? "uncached: scanout is not CPU-mappable"
+                                          : "cold start");
 
     drmModeFB2 *fb2 = drmModeGetFB2(ctx->drm_fd, fb_id);
     if (!fb2) {
@@ -1517,6 +1528,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                               O_RDONLY | O_CLOEXEC, &prime_fd);
     if (ret < 0) {
         ret = -errno;
+        drmtap_set_error(ctx, "fast2: exporting fb=%u as a DMA-BUF failed: %s",
+                         fb_id, strerror(errno));
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);
         return ret;
@@ -1534,17 +1547,33 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         }
     }
 
-    if (mapped == MAP_FAILED) {
+    /* Skip the mmap once this context has learned it cannot work here: it is a
+     * property of the driver and the buffer placement, not of one frame, so
+     * retrying it per frame only costs a failing syscall. */
+    if (mapped == MAP_FAILED && !ctx->fast_no_cpu_map) {
         dmabuf_sync_start(prime_fd);
         mapped = mmap(NULL, size, PROT_READ, MAP_SHARED,
                       prime_fd, fb2->offsets[0]);
-    }
-
-    /* Test hook (drmtap_force_mmap_fail): drop a successful mapping so the EGL fd
-     * fallback below is exercised on a GPU whose scanout IS cpu-mappable. */
-    if (mapped != MAP_FAILED && drmtap_force_mmap_fail()) {
-        munmap(mapped, size);
-        mapped = MAP_FAILED;
+        /* Test hook (drmtap_force_mmap_fail): drop a successful mapping so the
+         * EGL fd fallback is exercised on a GPU whose scanout IS CPU-mappable.
+         * Inside this block on purpose, so a forced failure takes exactly the
+         * same path as a real one, sticky flag and log line included. */
+        if (mapped != MAP_FAILED && drmtap_force_mmap_fail()) {
+            munmap(mapped, size);
+            mapped = MAP_FAILED;
+            errno = ENOTSUP;
+        }
+        if (mapped == MAP_FAILED) {
+            /* Log the reason ONCE, at the transition. Without this the fast path
+             * looks identical to a working one that simply never hits, which is
+             * exactly how it was reported: pages of "CACHE MISS ... cold start"
+             * and no explanation. */
+            drmtap_debug_log(ctx,
+                "fast2: scanout fb=%u is not CPU-mappable (%s); serving every frame "
+                "through the EGL fd path, no slot is cached",
+                fb_id, strerror(errno));
+            ctx->fast_no_cpu_map = 1;
+        }
     }
 
     if (mapped == MAP_FAILED) {
@@ -1589,6 +1618,15 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             return 0;
         }
 #endif
+        /* Neither a CPU mapping nor EGL: there is no way to read this scanout.
+         * Say so through drmtap_error, not only the debug log -- a caller that
+         * sees the failure otherwise has nothing to go on, which is how this
+         * arrived as a bug report full of log lines instead of a message. */
+        drmtap_set_error(ctx,
+            "fast2: scanout fb=%u cannot be CPU-mapped and no EGL backend is "
+            "available (built without egl/glesv2, or no usable render node). "
+            "This GPU needs the EGL detile path; use drmtap_grab_mapped() or "
+            "build with -Degl=enabled.", fb_id);
         close(prime_fd);
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -88,6 +88,13 @@ struct drmtap_ctx {
     uint32_t fast_plane_id;         /* cached primary plane id */
     uint32_t fast_last_fb_id;       /* fb_id from last capture (change detect) */
     int      fast_initialized;      /* 1 = plane found, slots ready */
+    /* 1 = this device's scanout refused a CPU mmap, so the fast path serves
+     * every frame through the EGL fd fallback and caches no slot. Sticky per
+     * context: whether a scanout BO is CPU-mappable is a property of the driver
+     * and the placement (amdgpu GFX9+ keeps it in VRAM), not of one frame, so
+     * retrying the mmap on every frame only buys a failing syscall. Also makes
+     * the per-frame "miss" honest in the log: nothing was ever cached to hit. */
+    int      fast_no_cpu_map;
 
     /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
      * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;

--- a/meson.build
+++ b/meson.build
@@ -116,9 +116,17 @@ lib_sources += files('src/gpu_nvidia.c')
 # dirs in as plain compile args. dl IS a real link dep (dlopen) and stays.
 dl_dep = cc.find_library('dl', required: false)
 lib_sources += files('src/gpu_egl.c')
-have_egl = egl_dep.found() and glesv2_dep.found() \
+egl_opt = get_option('egl')
+have_egl = not egl_opt.disabled() \
+    and egl_dep.found() and glesv2_dep.found() \
     and cc.has_header('EGL/egl.h') and cc.has_header('EGL/eglext.h') \
     and cc.has_header('GLES2/gl2.h') and cc.has_header('GLES2/gl2ext.h')
+# -Degl=enabled means "this build must ship the real detiling backend": fail here
+# rather than hand back a .so that looks fine and cannot detile a tiled scanout.
+if egl_opt.enabled() and not have_egl
+    error('egl=enabled but the egl/glesv2 pkg-config files or headers are missing '
+          + '(install libegl-dev and libgles2-mesa-dev)')
+endif
 if have_egl
     # Add the pkg-config include dirs (if any) as compile args, without making
     # egl/glesv2 dependencies of the target — so they stay out of the .pc.

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,14 @@
 #   'disabled': do not build the helper at all.
 option('helper', type: 'feature', value: 'auto',
     description: 'Build the privileged drmtap-helper (requires libseccomp + libcap)')
+
+# The EGL/GLES2 detiling backend is the SHIPPED hot path: a tiled or compressed
+# scanout is detiled on the GPU there, and without it libdrmtap falls back to the
+# CPU deswizzle or fails. It is opt-out for the same reason the helper is, some
+# build hosts genuinely have no EGL headers, but a build that silently produces
+# the stub is a trap: nothing downstream notices until a real scanout arrives.
+#   'enabled' : hard-fail if the egl/glesv2 headers are missing.
+#   'auto'    : use them if present, build the stub otherwise (historical default).
+#   'disabled': build the stub even where the headers exist.
+option('egl', type: 'feature', value: 'auto',
+    description: 'Build the EGL/GLES2 GPU detiling backend (requires egl + glesv2 headers)')

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -1299,6 +1299,7 @@ void drmtap_fast_cleanup(drmtap_ctx *ctx) {
     ctx->fast_plane_id = 0;
     ctx->fast_last_fb_id = 0;
     ctx->fast_initialized = 0;
+    ctx->fast_no_cpu_map = 0;
 }
 
 // Find or allocate a slot for the given fb_id
@@ -1367,6 +1368,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             ctx->fast_slots[i].prime_fd = -1;
         }
         ctx->fast_last_fb_id = 0;
+        ctx->fast_no_cpu_map = 0;
         ctx->fast_initialized = 1;
         drmtap_debug_log(ctx, "fast2: initialized plane=%u", ctx->fast_plane_id);
     }
@@ -1374,6 +1376,10 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     /* Step 2: Refresh fb_id (cheap ioctl, ~0.05ms) */
     drmModePlane *plane = drmModeGetPlane(ctx->drm_fd, ctx->fast_plane_id);
     if (!plane || plane->fb_id == 0) {
+        drmtap_set_error(ctx, plane
+            ? "fast2: plane %u has no framebuffer bound (display asleep or a modeset in flight)"
+            : "fast2: plane %u disappeared (a modeset changed the plane layout)",
+            ctx->fast_plane_id);
         if (plane) drmModeFreePlane(plane);
         drmtap_fast_cleanup(ctx);
         return -ENODEV;
@@ -1472,9 +1478,14 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         return 0;   /* new frame */
     }
 
-    /* ═══ CACHE MISS ═══ First time seeing this fb_id — full setup */
-    drmtap_debug_log(ctx, "fast2: CACHE MISS fb=%u slot=%d (cold start)",
-                     fb_id, slot);
+    /* ═══ CACHE MISS ═══ First time seeing this fb_id — full setup.
+     * On a device whose scanout cannot be CPU-mapped this is EVERY frame, and
+     * it is not a cold start: the EGL fd path below has no CPU mapping to cache,
+     * so there is never anything to hit. Say which one it is, or the log reads
+     * like a cache that is broken rather than one that does not apply. */
+    drmtap_debug_log(ctx, "fast2: CACHE MISS fb=%u slot=%d (%s)", fb_id, slot,
+                     ctx->fast_no_cpu_map ? "uncached: scanout is not CPU-mappable"
+                                          : "cold start");
 
     drmModeFB2 *fb2 = drmModeGetFB2(ctx->drm_fd, fb_id);
     if (!fb2) {
@@ -1517,6 +1528,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                               O_RDONLY | O_CLOEXEC, &prime_fd);
     if (ret < 0) {
         ret = -errno;
+        drmtap_set_error(ctx, "fast2: exporting fb=%u as a DMA-BUF failed: %s",
+                         fb_id, strerror(errno));
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);
         return ret;
@@ -1534,17 +1547,33 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         }
     }
 
-    if (mapped == MAP_FAILED) {
+    /* Skip the mmap once this context has learned it cannot work here: it is a
+     * property of the driver and the buffer placement, not of one frame, so
+     * retrying it per frame only costs a failing syscall. */
+    if (mapped == MAP_FAILED && !ctx->fast_no_cpu_map) {
         dmabuf_sync_start(prime_fd);
         mapped = mmap(NULL, size, PROT_READ, MAP_SHARED,
                       prime_fd, fb2->offsets[0]);
-    }
-
-    /* Test hook (drmtap_force_mmap_fail): drop a successful mapping so the EGL fd
-     * fallback below is exercised on a GPU whose scanout IS cpu-mappable. */
-    if (mapped != MAP_FAILED && drmtap_force_mmap_fail()) {
-        munmap(mapped, size);
-        mapped = MAP_FAILED;
+        /* Test hook (drmtap_force_mmap_fail): drop a successful mapping so the
+         * EGL fd fallback is exercised on a GPU whose scanout IS CPU-mappable.
+         * Inside this block on purpose, so a forced failure takes exactly the
+         * same path as a real one, sticky flag and log line included. */
+        if (mapped != MAP_FAILED && drmtap_force_mmap_fail()) {
+            munmap(mapped, size);
+            mapped = MAP_FAILED;
+            errno = ENOTSUP;
+        }
+        if (mapped == MAP_FAILED) {
+            /* Log the reason ONCE, at the transition. Without this the fast path
+             * looks identical to a working one that simply never hits, which is
+             * exactly how it was reported: pages of "CACHE MISS ... cold start"
+             * and no explanation. */
+            drmtap_debug_log(ctx,
+                "fast2: scanout fb=%u is not CPU-mappable (%s); serving every frame "
+                "through the EGL fd path, no slot is cached",
+                fb_id, strerror(errno));
+            ctx->fast_no_cpu_map = 1;
+        }
     }
 
     if (mapped == MAP_FAILED) {
@@ -1589,6 +1618,15 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             return 0;
         }
 #endif
+        /* Neither a CPU mapping nor EGL: there is no way to read this scanout.
+         * Say so through drmtap_error, not only the debug log -- a caller that
+         * sees the failure otherwise has nothing to go on, which is how this
+         * arrived as a bug report full of log lines instead of a message. */
+        drmtap_set_error(ctx,
+            "fast2: scanout fb=%u cannot be CPU-mapped and no EGL backend is "
+            "available (built without egl/glesv2, or no usable render node). "
+            "This GPU needs the EGL detile path; use drmtap_grab_mapped() or "
+            "build with -Degl=enabled.", fb_id);
         close(prime_fd);
         drmtap_gem_close(ctx, fb2->handles[0]);
         drmModeFreeFB2(fb2);

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -88,6 +88,13 @@ struct drmtap_ctx {
     uint32_t fast_plane_id;         /* cached primary plane id */
     uint32_t fast_last_fb_id;       /* fb_id from last capture (change detect) */
     int      fast_initialized;      /* 1 = plane found, slots ready */
+    /* 1 = this device's scanout refused a CPU mmap, so the fast path serves
+     * every frame through the EGL fd fallback and caches no slot. Sticky per
+     * context: whether a scanout BO is CPU-mappable is a property of the driver
+     * and the placement (amdgpu GFX9+ keeps it in VRAM), not of one frame, so
+     * retrying the mmap on every frame only buys a failing syscall. Also makes
+     * the per-frame "miss" honest in the log: nothing was ever cached to hit. */
+    int      fast_no_cpu_map;
 
     /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
      * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;


### PR DESCRIPTION
Two things, both about the same blind spot: a build that quietly loses the GPU
detiling backend, and a fast path that quietly cannot read the scanout.

## CI was testing the stub, not the shipped backend

The C jobs installed libdrm, libva, libseccomp and libcap, but never the EGL
headers. meson treats egl and glesv2 as optional, so every C build in CI produced
the CPU-only stub: the GPU detiling backend that real deployments run had no
automated coverage, and nothing in the pipeline said so.

- new meson option `egl`, shaped like the existing `helper` one. default `auto`,
  so a build host without the headers behaves exactly as before; `enabled`
  hard-fails naming the two packages.
- CI installs libegl-dev and libgles2-mesa-dev and passes `-Degl=enabled`.
- the release job asserts the built .so carries the EGL path. The obvious ELF
  check does not work here: the backend is reached by lazy dlopen precisely so
  the GPU stack never lands in a privileged consumer, so there is no DT_NEEDED
  entry and no undefined egl symbol, and looking for those reports "no EGL" on a
  perfectly good library. It looks for the dlopen target name and an EGL entry
  point instead.

Verified all four ways locally: enabled with headers configures the backend on,
enabled without them fails with the package names, auto without them still
degrades to the stub, and the stub .so really does lack both strings.

## Issue #36: a wall of cache misses and a black frame

Reported on a Radeon Vega 64. The log is right and the code was silent about all
of it: on that GPU the tiled scanout lives in VRAM and amdgpu refuses a CPU mmap,
and on 0.4.13 the fast path had no fallback for that, so it returned -ENOMEM on
every frame. Nothing was ever cached, which is exactly why there is never a
CACHE HIT in the reporter's log. That exit never called `drmtap_set_error`
either, so a caller had nothing to print and had to send a log dump.

The capture has worked since 0.4.14, which added the mmap-to-EGL fallback. What
was still wrong is everything around it:

- the no-mapping-and-no-EGL exit sets an error naming the cause and the remedy.
- the fallback logs the reason once, with the errno, at the transition.
- the per-frame miss line distinguishes an uncachable scanout from a genuine
  cold start. On such a device every frame IS a miss by design, because the EGL
  fd path has no CPU mapping to cache, and the old line read like a broken cache
  rather than one that does not apply.
- a context that has learned the scanout is not CPU-mappable stops retrying the
  mmap per frame.
- the two other silent exits on that path (a failed PRIME export, a plane with
  no framebuffer bound) set an error too.
- the `DRMTAP_FORCE_MMAP_FAIL` test hook moved inside the mmap block, so a forced
  failure takes the same path as a real one, sticky flag and log line included.

Verified on i915 with the hook against the live scanout: the forced-failure run
logs the reason once and then the uncached line per frame, and the pixels come
out byte-identical to the normal mmap path (same sampled checksum), with the
dumped frame a correct desktop rather than black.

No ABI change and no version bump. The rustdesk pin stays on v0.4.15.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR addresses two related blind spots: CI was silently building and testing only the CPU-stub because EGL headers were never installed, and the fast-path capture function provided no actionable diagnostics when a tiled VRAM scanout (e.g., Radeon Vega 64 on amdgpu) refused a CPU mmap.

- **CI/build**: Adds a `egl` meson feature option (default `auto`, identical to the old behaviour; `enabled` hard-fails with the package names), installs `libegl-dev`/`libgles2-mesa-dev` in all C jobs, passes `-Degl=enabled`, and adds a release-job assertion that checks the shipped `.so` contains the dlopen target string and an EGL entry point (rather than looking for `DT_NEEDED`, which is deliberately absent due to lazy dlopen).
- **Fast-path diagnostics (`drm_grab.c`)**: Introduces a `fast_no_cpu_map` sticky flag on the context that stops retrying a known-failing mmap every frame; logs the transition once at the first failure with the errno; distinguishes the per-frame CACHE MISS label between a genuine cold start and a scanout that is permanently uncacheable; and adds `drmtap_set_error` calls to three previously silent exits (no-fb-bound plane, PRIME export failure, and the no-EGL fallback path).
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge. The fast-path changes are well-scoped: the sticky flag is correctly reset on both the initialization path and cleanup, the EGL fallback contract is unchanged, and the three new error-message calls plug genuine silent exits rather than modifying existing return paths.

The core fast_no_cpu_map logic correctly resets in drmtap_fast_cleanup (called on plane-disappear) and in the !fast_initialized init block, so a display sleep/wake cycle correctly re-probes whether the new buffer placement is CPU-mappable. The errno = ENOTSUP in the force-mmap-fail hook is deliberate and well-commented. No new ABI surface. The one subtle point is that on the very first mmap-failure frame the CACHE MISS label still reads 'cold start' because fast_no_cpu_map is 0 until after the mmap block runs, though the immediately following drmtap_debug_log line on that same frame explains the cause. It is a cosmetic log ordering artifact rather than a functional issue.

**Files Needing Attention:** src/drm_grab.c — the mmap-skip block and the EGL fallback path are the most behaviorally new sections; worth a second read to confirm the dmabuf_sync_start/close ordering on the transition frame aligns with the driver expectations (it does, but the sync-without-end on mmap failure predates this PR and is inherited unchanged).
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/drm_grab.c | Core logic change: adds fast_no_cpu_map sticky flag to skip per-frame mmap retries, three new drmtap_set_error calls on previously silent exits, one-time transition log, and a per-frame CACHE MISS label that distinguishes uncacheable from cold-start. |
| src/drmtap_internal.h | Adds fast_no_cpu_map field to drmtap_ctx with a detailed comment explaining its semantics and lifetime. |
| .github/workflows/ci.yml | Adds libegl-dev/libgles2-mesa-dev to APT installs and -Degl=enabled to every meson setup call; adds a release-job step using strings+grep to assert the shipped .so contains the dlopen target and an EGL entry point. |
| meson.build | Threads the new egl feature option into the existing have_egl detection: disabled() short-circuits to false, enabled() with missing headers calls error() with actionable package names, auto falls through to the original dep+header checks unchanged. |
| meson_options.txt | Adds the egl feature option shaped identically to the existing helper option, with inline comments explaining the auto/enabled/disabled semantics. |
| bindings/rust/libdrmtap-sys/csrc/drm_grab.c | Identical changes to src/drm_grab.c — the Rust crate embeds the C sources directly and both copies are kept in sync by this PR. |
| bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h | Identical to src/drmtap_internal.h change — fast_no_cpu_map field added to the embedded copy. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[drmtap_grab_mapped_fast] --> B{fast_initialized?}
    B -- no --> C[Init slots, fast_no_cpu_map = 0]
    C --> D[Get plane]
    B -- yes --> D
    D --> E{plane and fb_id != 0?}
    E -- no --> F[drmtap_set_error plane disappeared / no FB, return -ENODEV]
    E -- yes --> G{fb_id unchanged?}
    G -- yes --> H[CACHE HIT, return 0]
    G -- no --> I[CACHE MISS log: cold start OR uncached]
    I --> J[drmModeGetFB2 + PRIME export]
    J --> K{export ok?}
    K -- no --> L[drmtap_set_error DMA-BUF failed, return -errno]
    K -- yes --> M{virtio GPU?}
    M -- yes --> N[virtio_transfer + virtio_dumb_mmap]
    M -- no --> O{fast_no_cpu_map == 0?}
    O -- yes --> P[dmabuf_sync_start + mmap]
    P --> Q{mmap ok?}
    Q -- no --> R[log once, fast_no_cpu_map = 1]
    Q -- yes --> S[mapped = ptr]
    R --> T{mapped == MAP_FAILED?}
    O -- no, already known --> T
    N --> T
    S --> U[Store slot, copy pixels, return 0]
    T -- HAVE_EGL --> V{EGL available?}
    V -- yes --> W[gpu_auto_process via EGL fd, return 0]
    V -- no --> X[drmtap_set_error no EGL backend, return -ENOMEM]
    T -- no HAVE_EGL --> X
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: match the .so, not meson&#39;s build dir..."](https://github.com/fxd0h/libdrmtap/commit/2ef63bcc5a07b74ba7c376a88b71e246f35740e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47935060)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/howdidthecatgetsofat/github/fxd0h/libdrmtap/-/custom-context?memory=5e4f4850-184d-45de-af35-5f4f36157b7c))

<!-- /greptile_comment -->