### PR TITLE
tools: one-shot capture diagnostic for bug reports

### DIFF
--- a/tools/drmtap-report.sh
+++ b/tools/drmtap-report.sh
@@ -61,10 +61,15 @@ for card in /sys/class/drm/card[0-9]*; do
     drv=$(basename "$(readlink -f "$card/device/driver" 2>/dev/null)" 2>/dev/null)
     val "$name driver" "${drv:-unknown}"
 done
-say "connectors (status / modes)"
+say "connectors (status, current mode)"
 for conn in /sys/class/drm/card[0-9]*-*; do
     [ -r "$conn/status" ] || continue
-    val "$(basename "$conn")" "$(cat "$conn/status" 2>/dev/null)"
+    st=$(cat "$conn/status" 2>/dev/null)
+    # First entry of modes is the active/preferred one. A capture bug is often about
+    # a specific mode (a refresh rate, or a resolution that does not match the fb),
+    # so do not label this "modes" and then print only the status.
+    mode=$(head -1 "$conn/modes" 2>/dev/null)
+    val "$(basename "$conn")" "$st${mode:+ $mode}"
 done
 
 # ------------------------------------------------------------------ the build
@@ -152,17 +157,48 @@ val ppm_bytes "$(stat -c %s "$img" 2>/dev/null || echo 0)"
 # not 0x00. A correct desktop has millions; a black frame has none. This is the
 # single number that separates "the detile produced nothing" from "it produced
 # a wrong image" from "it worked".
+ppm_ok=0
 if [ -s "$img" ]; then
-    # Skip exactly the PPM header ("P6\n<w> <h>\n255\n"), by finding the byte after
-    # its third newline. A fixed guess leaves header bytes in the count, and "255\n"
-    # alone is enough non-zero data to stop a fully black frame from reading as black,
-    # which is the one case this whole section exists to catch.
-    hdr_len=$(head -c 64 "$img" | LC_ALL=C awk 'BEGIN{RS="\n"} {n++; len+=length($0)+1; if(n==3){print len; exit}}')
-    : "${hdr_len:=15}"
+    # Parse the PPM header ("P6\n<w> <h>\n255\n") rather than assuming it: the byte
+    # after its third newline is where pixels start, and a fixed guess leaves header
+    # bytes in the count -- "255\n" alone is enough non-zero data to stop a fully
+    # black frame from reading as black, the one case this section exists to catch.
+    #
+    # And validate it before drawing any conclusion. A truncated write, or anything
+    # else that lands on stdout, would otherwise be reported as "every pixel is
+    # black", which accuses the EGL path of a failure that did not happen.
+    read -r magic ppm_w ppm_h ppm_max hdr_len < <(
+        head -c 64 "$img" | LC_ALL=C awk '
+            BEGIN { RS="\n" }
+            { n++; len += length($0) + 1
+              # $1, not $0: arbitrary stdout can have spaces on its first line, and a
+              # multi-word field here would shift every later one in the read below,
+              # leaving hdr_len holding words instead of a number.
+              if (n == 1) m = $1
+              else if (n == 2) { w = $1; h = $2 }
+              else if (n == 3) { print m, w+0, h+0, $0+0, len; exit } }')
     body() { tail -c "+$((hdr_len + 1))" "$img"; }
+    if [ "$magic" != "P6" ]; then
+        val ppm_valid "no (stdout is not a P6 ppm)"
+    elif [ "${ppm_w:-0}" -le 0 ] || [ "${ppm_h:-0}" -le 0 ] || [ "${ppm_max:-0}" -ne 255 ]; then
+        val ppm_valid "no (bad header ${ppm_w}x${ppm_h} max=${ppm_max})"
+    else
+        want=$(( ppm_w * ppm_h * 3 ))
+        got=$(( $(stat -c %s "$img") - hdr_len ))
+        if [ "$got" -ne "$want" ]; then
+            val ppm_valid "no (truncated: ${got} pixel bytes, expected ${want} for ${ppm_w}x${ppm_h})"
+        else
+            ppm_valid=yes
+            ppm_ok=1
+            val ppm_valid "yes (${ppm_w}x${ppm_h})"
+        fi
+    fi
+fi
+
+if [ "$ppm_ok" = 1 ]; then
     nonzero=$(body | tr -d '\000' | wc -c)
     val nonblack_bytes "$nonzero"
-    total=$(( $(stat -c %s "$img") - hdr_len ))
+    total=$(( ppm_w * ppm_h * 3 ))
     if [ "$total" -gt 0 ]; then
         val nonblack_pct "$(( nonzero * 100 / total ))%"
     fi
@@ -181,13 +217,24 @@ if grep -q 'unknown command' "$log"; then
     # "unknown command" plus a generic helper-failed errno. Name it here, because
     # nothing in that pair points at the actual cause.
     echo "the INSTALLED HELPER IS STALE: it does not speak this library's helper"
-    echo "protocol. reinstall it from the same build as the .so above:"
-    echo "    sudo install -m 0755 $BUILD_DIR/drmtap-helper /usr/local/bin/"
+    echo "protocol. reinstall it from the same build as the .so above. keep it"
+    echo "restricted while you do -- it carries CAP_SYS_ADMIN, so it must not be"
+    echo "world-executable (SECURITY.md), which is why this is not a plain install:"
+    # %q so a build dir with a space or a quote in it cannot produce a copy-paste
+    # line that means something other than what it looks like.
+    printf '    sudo install -m 0750 -o root -g <capture-group> %q /usr/local/bin/drmtap-helper\n' \
+        "$BUILD_DIR/drmtap-helper"
     echo "    sudo setcap cap_sys_admin+ep /usr/local/bin/drmtap-helper"
     echo "then re-run this script. everything below is downstream of that."
+elif [ "$ppm_ok" = 0 ] && [ "$rc" -eq 0 ]; then
+    echo "the capture reported success but its output is not a usable ppm (see"
+    echo "ppm_valid above). that is a problem with the run, not with the detile;"
+    echo "the debug log below says what happened."
 elif [ "$rc" -ne 0 ]; then
     echo "capture FAILED. the error line from the log:"
-    grep -iE 'Capture failed|No pixel data' "$log" | head -3
+    # screenshot.c has three failure messages, not two: drmtap_open failing prints
+    # "Failed to open". Without it this heading is printed with nothing under it.
+    grep -iE 'Capture failed|No pixel data|Failed to open' "$log" | head -3
 elif [ "${nonzero:-0}" -eq 0 ]; then
     echo "capture returned a frame but every pixel is black."
     echo "the EGL convert result below is the diagnosis."

--- a/tools/drmtap-report.sh
+++ b/tools/drmtap-report.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# Collect everything a libdrmtap capture bug report needs, in one run, so a
+# report does not turn into five rounds of "please also paste X".
+#
+# Most libdrmtap failures are decided by facts the reporter has no reason to
+# think are relevant: whether the process has CAP_SYS_ADMIN or is going through
+# the helper, whether the build actually has the EGL backend (meson treats it as
+# optional and silently ships a CPU-only stub without it), which grab entry point
+# was called, and the scanout modifier. This gathers those together with an
+# actual capture attempt and says what the result means.
+#
+#   tools/drmtap-report.sh                 build in ./build, capture, analyze
+#   tools/drmtap-report.sh --build DIR     use an existing meson build dir
+#   tools/drmtap-report.sh --so PATH       point at an installed .so instead
+#
+# Prints to stdout. It reports hardware, driver and build facts only: no
+# hostname, no user name, no window contents (the captured image is reduced to
+# "how many non-black bytes", never included).
+
+set -uo pipefail
+
+BUILD_DIR=build
+SO_PATH=
+KEEP_IMAGE=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --build) BUILD_DIR=${2:?--build needs a directory}; shift 2 ;;
+        --so)    SO_PATH=${2:?--so needs a path}; shift 2 ;;
+        --keep-image) KEEP_IMAGE=1; shift ;;
+        -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; exit 0 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+say() { printf '\n== %s ==\n' "$1"; }
+val() { printf '%-22s %s\n' "$1" "$2"; }
+
+# ---------------------------------------------------------------- environment
+say "system"
+val kernel "$(uname -r)"
+val arch "$(uname -m)"
+if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    val distro "$(. /etc/os-release; echo "${PRETTY_NAME:-$ID}")"
+fi
+val session_type "${XDG_SESSION_TYPE:-unset}"
+val wayland_display "${WAYLAND_DISPLAY:-unset}"
+val x_display "${DISPLAY:-unset}"
+
+say "drm devices"
+for dev in /dev/dri/*; do
+    [ -e "$dev" ] || continue
+    perms=$(stat -c '%A %U:%G' "$dev" 2>/dev/null)
+    val "$(basename "$dev")" "$perms"
+done
+for card in /sys/class/drm/card[0-9]*; do
+    [ -d "$card" ] || continue
+    name=$(basename "$card")
+    case "$name" in *-*) continue ;; esac   # skip connector entries
+    drv=$(basename "$(readlink -f "$card/device/driver" 2>/dev/null)" 2>/dev/null)
+    val "$name driver" "${drv:-unknown}"
+done
+say "connectors (status / modes)"
+for conn in /sys/class/drm/card[0-9]*-*; do
+    [ -r "$conn/status" ] || continue
+    val "$(basename "$conn")" "$(cat "$conn/status" 2>/dev/null)"
+done
+
+# ------------------------------------------------------------------ the build
+say "libdrmtap build"
+if [ -d .git ]; then
+    val git_commit "$(git rev-parse HEAD 2>/dev/null)"
+    val git_describe "$(git describe --tags --always --dirty 2>/dev/null)"
+    val git_dirty "$(test -n "$(git status --porcelain 2>/dev/null)" && echo yes || echo no)"
+else
+    val git_commit "(not run from a libdrmtap checkout)"
+fi
+
+if [ -z "$SO_PATH" ]; then
+    # Prefer the build dir, then a system install. The REAL object, not a symlink,
+    # so the version in the name is the one actually loaded.
+    for cand in "$BUILD_DIR"/libdrmtap.so.0.*.* \
+                /usr/local/lib/libdrmtap.so.0.*.* \
+                /usr/lib/libdrmtap.so.0.*.*; do
+        if [ -f "$cand" ] && [ ! -L "$cand" ]; then SO_PATH=$cand; break; fi
+    done
+fi
+val so_path "${SO_PATH:-NOT FOUND}"
+
+if [ -n "$SO_PATH" ] && [ -f "$SO_PATH" ]; then
+    # The EGL backend is dlopen'd by name, so it never shows in ldd; the string is
+    # present only if src/gpu_egl.c was compiled in. 0 here means the build is a
+    # CPU-only stub and cannot detile ANY tiled scanout, whatever the version says.
+    egl_count=$(strings "$SO_PATH" 2>/dev/null | grep -c 'libEGL\.so\.1')
+    val egl_backend "$([ "$egl_count" -gt 0 ] && echo "present" || echo "ABSENT (built without egl)")"
+    val gles_symbols "$(strings "$SO_PATH" 2>/dev/null | grep -c 'eglCreateImageKHR')"
+else
+    val egl_backend "unknown (no .so found)"
+fi
+
+if command -v meson >/dev/null 2>&1 && [ -d "$BUILD_DIR/meson-info" ]; then
+    opt=$(meson introspect "$BUILD_DIR" --buildoptions 2>/dev/null \
+        | tr '{' '\n' | grep '"name": "egl"' | grep -o '"value": "[^"]*"' | cut -d'"' -f4)
+    [ -n "$opt" ] && val meson_egl_opt "$opt"
+fi
+
+say "helper"
+helper=$(command -v drmtap-helper 2>/dev/null)
+[ -z "$helper" ] && [ -x /usr/local/bin/drmtap-helper ] && helper=/usr/local/bin/drmtap-helper
+[ -z "$helper" ] && [ -x "$BUILD_DIR/drmtap-helper" ] && helper=$BUILD_DIR/drmtap-helper
+val helper_path "${helper:-not installed}"
+if [ -n "$helper" ]; then
+    val helper_caps "$(getcap "$helper" 2>/dev/null || echo '(getcap unavailable)')"
+    val helper_perms "$(stat -c '%A %U:%G' "$helper" 2>/dev/null)"
+fi
+# Whether THIS process could capture without the helper at all. Read the EFFECTIVE
+# capability set straight from /proc: `capsh --print | grep cap_sys_admin` also
+# matches the bounding set, so it answers "yes" for a process that does not have it
+# and flatly contradicts the "No CAP_SYS_ADMIN (needs helper)" line in the log below.
+caps_eff=$(awk '/^CapEff:/ {print $2}' /proc/self/status 2>/dev/null)
+if [ -n "$caps_eff" ]; then
+    # CAP_SYS_ADMIN is bit 21.
+    if (( (0x$caps_eff >> 21) & 1 )); then
+        val caller_sysadmin "yes (capture runs in-process)"
+    else
+        val caller_sysadmin "no, uid $(id -u) (capture must go through the helper)"
+    fi
+else
+    val caller_sysadmin "$([ "$(id -u)" = 0 ] && echo root || echo "no (uid $(id -u))")"
+fi
+
+# ------------------------------------------------------------- capture attempt
+say "capture attempt (examples/screenshot, drmtap_grab_mapped)"
+shot=$BUILD_DIR/screenshot
+if [ ! -x "$shot" ]; then
+    echo "no $shot; build first:  meson setup $BUILD_DIR -Degl=enabled && ninja -C $BUILD_DIR"
+    exit 1
+fi
+
+img=$(mktemp -t drmtap-report-XXXXXX.ppm)
+log=$(mktemp -t drmtap-report-XXXXXX.log)
+cleanup() { [ "$KEEP_IMAGE" = 1 ] || rm -f "$img"; rm -f "$log"; }
+trap cleanup EXIT
+
+DRMTAP_DEBUG=1 "$shot" > "$img" 2> "$log"
+rc=$?
+val exit_code "$rc"
+val ppm_bytes "$(stat -c %s "$img" 2>/dev/null || echo 0)"
+
+# Is the image actually black? Strip the PPM header, then count bytes that are
+# not 0x00. A correct desktop has millions; a black frame has none. This is the
+# single number that separates "the detile produced nothing" from "it produced
+# a wrong image" from "it worked".
+if [ -s "$img" ]; then
+    # Skip exactly the PPM header ("P6\n<w> <h>\n255\n"), by finding the byte after
+    # its third newline. A fixed guess leaves header bytes in the count, and "255\n"
+    # alone is enough non-zero data to stop a fully black frame from reading as black,
+    # which is the one case this whole section exists to catch.
+    hdr_len=$(head -c 64 "$img" | LC_ALL=C awk 'BEGIN{RS="\n"} {n++; len+=length($0)+1; if(n==3){print len; exit}}')
+    : "${hdr_len:=15}"
+    body() { tail -c "+$((hdr_len + 1))" "$img"; }
+    nonzero=$(body | tr -d '\000' | wc -c)
+    val nonblack_bytes "$nonzero"
+    total=$(( $(stat -c %s "$img") - hdr_len ))
+    if [ "$total" -gt 0 ]; then
+        val nonblack_pct "$(( nonzero * 100 / total ))%"
+    fi
+    # A tiled buffer read as if it were linear is not black, it is structured
+    # noise; distinct byte values separate that from a solid fill. Sampled from the
+    # first 2 MB: od plus sort over a whole 4K frame is tens of seconds for a number
+    # that does not get more informative with more input.
+    val distinct_bytes "$(body | head -c 2000000 | od -An -tu1 -v 2>/dev/null \
+        | tr -s ' ' '\n' | sort -u | grep -c .)"
+fi
+
+say "verdict"
+if grep -q 'unknown command' "$log"; then
+    # The helper speaks a versioned command frame and closes the connection on a
+    # mismatch, so an installed helper older than the library fails as an opaque
+    # "unknown command" plus a generic helper-failed errno. Name it here, because
+    # nothing in that pair points at the actual cause.
+    echo "the INSTALLED HELPER IS STALE: it does not speak this library's helper"
+    echo "protocol. reinstall it from the same build as the .so above:"
+    echo "    sudo install -m 0755 $BUILD_DIR/drmtap-helper /usr/local/bin/"
+    echo "    sudo setcap cap_sys_admin+ep /usr/local/bin/drmtap-helper"
+    echo "then re-run this script. everything below is downstream of that."
+elif [ "$rc" -ne 0 ]; then
+    echo "capture FAILED. the error line from the log:"
+    grep -iE 'Capture failed|No pixel data' "$log" | head -3
+elif [ "${nonzero:-0}" -eq 0 ]; then
+    echo "capture returned a frame but every pixel is black."
+    echo "the EGL convert result below is the diagnosis."
+else
+    echo "capture produced a non-black image (${nonzero} non-zero bytes)."
+    echo "if it still looks wrong, it is decoded with the wrong tiling, not missing."
+fi
+
+say "decisive log lines"
+grep -E 'CAP_SYS_ADMIN|needs helper|helper V3|helper:|FB2:|EGL check|EGL convert|auto-process|fast2:|not CPU-mappable' \
+    "$log" | head -40
+
+say "full debug log"
+cat "$log"
+
+if [ "$KEEP_IMAGE" = 1 ]; then
+    say "image kept"
+    echo "$img"
+fi


### PR DESCRIPTION
Issue #36 took three rounds to establish basic facts about the reporter setup, and two of my answers were wrong for lack of them: the failure turned out to be that `drmtap_grab_mapped_fast` has no helper fallback, which neither of us could see from a log full of per-frame cache-miss lines.

This collects, in one run, the things that actually decide a capture failure and that a reporter has no reason to think matter:

- whether the calling process has CAP_SYS_ADMIN or is going through the helper
- whether the .so really carries the EGL backend (meson treats egl as optional and silently ships a CPU-only stub without it, so the version string tells you nothing)
- gpu, driver, connectors, and the scanout modifier
- a real capture through `examples/screenshot` (which calls `drmtap_grab_mapped` and nothing else, so the reporter own program is out of the picture)

Then it says what the result means: an image decoded, a frame that came back entirely black (counted, not judged), or a stale installed helper.

Tested both paths on i915. Three defects found while testing it, all in the script:

- `capsh --print | grep cap_sys_admin` also matches the bounding set, so it answered "yes" for a process that did not have it and contradicted the log two lines below. Reads bit 21 of CapEff from /proc now.
- the PPM header skip was a fixed guess of 15 bytes against a real header of 17, leaving `5\n` in the body, so the all-black branch could never fire. That is the one case the section exists to detect. It finds the third newline now.
- the stale-helper case is detected explicitly because I hit it myself: an installed helper older than the library fails as an opaque `unknown command` plus a generic errno, and the string does not even exist in the current sources.

It reports hardware, driver and build facts only, and reduces the captured image to a count of non-black bytes rather than including it.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR adds `tools/drmtap-report.sh`, a one-shot diagnostic script that collects the facts that decide a capture failure — CAP_SYS_ADMIN status (read directly from `CapEff` in `/proc/self/status` to avoid the bounding-set false-positive), EGL backend presence in the `.so`, GPU/driver/connector info, scanout modifier, and an actual capture attempt through `examples/screenshot` — then reduces the image to a non-black byte count and writes a plain-English verdict. The PR also corrects three bugs found during testing: the `capsh` bounding-set false-positive, the fixed 15-byte PPM header skip, and missing detection of the stale-helper `"unknown command"` error.

- **`CapEff` bit-21 check** replaces the `capsh --print | grep` approach, correctly distinguishing the effective set from the bounding set.
- **PPM header parsing** now finds the third newline dynamically via `awk`, fixing the off-by-two that left `"5\n"` in the pixel body and prevented the all-black branch from ever firing.
- **Verdict grep** was extended to cover `"Failed to open"` (addressed from prior review feedback), but `"No displays found"` — printed by `screenshot.c` when `drmtap_list_displays()` returns ≤ 0 — is still absent, leaving the failure heading empty for that case.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with a one-line fix; the script's core logic is sound but the verdict section has a remaining gap.

The PPM parsing, CAP_SYS_ADMIN detection, stale-helper branch, and image analysis are all correct. The one remaining defect is that "No displays found" — a real failure path in screenshot.c — is not matched by the verdict grep, so the script prints an empty error block when that case occurs. It is the same class of bug the PR explicitly fixed for "Failed to open", just for a different code path.

**Files Needing Attention:** tools/drmtap-report.sh — specifically the verdict grep at line 237
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| tools/drmtap-report.sh | New one-shot diagnostic script; PPM header parsing, CAP_SYS_ADMIN detection, and stale-helper verdict are all correct, but the `rc != 0` verdict grep still misses `screenshot.c`'s "No displays found" error message |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Atools%2Fdrmtap-report.sh%3A237%0A%60%22No%20displays%20found%22%60%20is%20still%20missing%20from%20the%20verdict%20grep.%20When%20%60drmtap_list_displays%28%29%60%20returns%20%E2%89%A4%200%20%28headless%20system%2C%20no%20active%20connector%29%2C%20%60screenshot.c%60%20prints%20%60%22No%20displays%20found%0A%22%60%20to%20stderr%20and%20exits%20with%20rc%3D1.%20Because%20that%20string%20matches%20none%20of%20the%20three%20patterns%20in%20the%20grep%20below%2C%20the%20verdict%20prints%20the%20heading%20%60%22capture%20FAILED.%20the%20error%20line%20from%20the%20log%3A%22%60%20followed%20by%20nothing%20%E2%80%94%20the%20exact%20silent-heading%20bug%20the%20PR%20description%20says%20was%20fixed%20for%20%60%22Failed%20to%20open%22%60.%20The%20%60%22malloc%20failed%22%60%20case%20%28row-buffer%20allocation%29%20has%20the%20same%20hole%2C%20though%20it%20is%20far%20less%20likely%20in%20practice.%0A%0A%60%60%60suggestion%0A%20%20%20%20grep%20-iE%20'Capture%20failed%7CNo%20pixel%20data%7CFailed%20to%20open%7CNo%20displays%20found%7Cmalloc%20failed'%20%22%24log%22%20%7C%20head%20-3%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=fxd0h%2Flibdrmtap&pr=40&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
tools/drmtap-report.sh:237
`"No displays found"` is still missing from the verdict grep. When `drmtap_list_displays()` returns ≤ 0 (headless system, no active connector), `screenshot.c` prints `"No displays found
"` to stderr and exits with rc=1. Because that string matches none of the three patterns in the grep below, the verdict prints the heading `"capture FAILED. the error line from the log:"` followed by nothing — the exact silent-heading bug the PR description says was fixed for `"Failed to open"`. The `"malloc failed"` case (row-buffer allocation) has the same hole, though it is far less likely in practice.

```suggestion
    grep -iE 'Capture failed|No pixel data|Failed to open|No displays found|malloc failed' "$log" | head -3
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["tools: address the review of the capture..."](https://github.com/fxd0h/libdrmtap/commit/a625ed23ee8645699d92d72b1e4f2819e8c3586d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48155687)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->