### PR TITLE
Say why the fast path cannot serve an unprivileged caller (#36)

### DIFF
--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -1520,6 +1520,13 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
          * the reporter and me after a tiling bug that was not there (issue #36). */
         drmModeFreeFB2(fb2);
         ctx->fast_no_privilege = 1;
+        /* Nothing on this path can be served again, so release whatever the slots hold
+         * (prime fds, mappings, GEM handles) now instead of at drmtap_close. Normally
+         * there is nothing: an unprivileged process never populated a slot in the first
+         * place. It matters for the one case that can, a process that captured with
+         * CAP_SYS_ADMIN and then dropped it, where the slots are live and unusable.
+         * Runs AFTER the flag is set, since cleanup deliberately leaves it alone. */
+        drmtap_fast_cleanup(ctx);
         drmtap_debug_log(ctx,
             "fast2: this process has no CAP_SYS_ADMIN, and the fast path has no helper "
             "fallback (it caches a CPU mapping per framebuffer; a helper hands over a "

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -1300,6 +1300,10 @@ void drmtap_fast_cleanup(drmtap_ctx *ctx) {
     ctx->fast_last_fb_id = 0;
     ctx->fast_initialized = 0;
     ctx->fast_no_cpu_map = 0;
+    /* fast_no_privilege is deliberately NOT cleared: it records a property of the
+     * PROCESS (no CAP_SYS_ADMIN), not of the plane, the framebuffer or the device,
+     * so re-discovering it after every teardown would repeat the whole GetFB2 dance
+     * to reach the same verdict. */
 }
 
 // Find or allocate a slot for the given fb_id
@@ -1352,6 +1356,17 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         drmtap_set_error(ctx, "context is render-only (drmtap_open_render); "
                          "grab needs a KMS context from drmtap_open");
         return -ENOTSUP;
+    }
+
+    /* Established on an earlier call that this process cannot export the scanout and
+     * that this entry point has no helper fallback. Answer immediately and quietly:
+     * the caller has the reason in drmtap_error() from the first failure, and a
+     * capture loop calling this at frame rate must not produce a line per frame. */
+    if (ctx->fast_no_privilege) {
+        drmtap_set_error(ctx,
+            "drmtap_grab_mapped_fast needs CAP_SYS_ADMIN in this process and has no "
+            "helper fallback; use drmtap_grab_mapped()");
+        return -EACCES;
     }
 
     int ret;
@@ -1496,8 +1511,23 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     }
 
     if (fb2->handles[0] == 0) {
+        /* drmModeGetFB2 zeroes the GEM handles for a caller without CAP_SYS_ADMIN.
+         * drmtap_grab_mapped treats that as "go through the helper"; this entry point
+         * has no such branch, so it cannot serve an unprivileged caller on ANY gpu.
+         * Say that, name the call that does work, and latch it so the next frame is
+         * answered at the top of the function instead of repeating this whole dance.
+         * Reported as endless cache-miss lines with the cause buried, which sent both
+         * the reporter and me after a tiling bug that was not there (issue #36). */
         drmModeFreeFB2(fb2);
-        drmtap_set_error(ctx, "fast2: handles[0]==0, no CAP_SYS_ADMIN");
+        ctx->fast_no_privilege = 1;
+        drmtap_debug_log(ctx,
+            "fast2: this process has no CAP_SYS_ADMIN, and the fast path has no helper "
+            "fallback (it caches a CPU mapping per framebuffer; a helper hands over a "
+            "fresh fd per grab, so there is nothing to cache). Use drmtap_grab_mapped(), "
+            "which falls back to the helper. Not repeated per frame.");
+        drmtap_set_error(ctx,
+            "drmtap_grab_mapped_fast needs CAP_SYS_ADMIN in this process and has no "
+            "helper fallback; use drmtap_grab_mapped()");
         return -EACCES;
     }
 

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -134,7 +134,14 @@ int drmtap_displays_changed(drmtap_ctx *ctx);
 
 /** Captured frame metadata and pixel data. */
 typedef struct {
-    void *data;             /**< Pixel data (mapped path) or NULL (zero-copy) */
+    /** Pixel data. Always set on the mapped paths (drmtap_grab_mapped,
+     *  drmtap_grab_mapped_fast). On the zero-copy path (drmtap_grab,
+     *  drmtap_grab_desc) it is NOT guaranteed: it holds the raw, UNCONVERTED
+     *  scanout mapping where one was possible and NULL where the scanout cannot
+     *  be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia). Do not read it after
+     *  a zero-copy grab -- that it happens to work on one GPU and returns NULL on
+     *  another is exactly how issue #36 was mistaken for a driver bug. */
+    void *data;
     int dma_buf_fd;         /**< DMA-BUF fd (zero-copy) or -1 (mapped) */
     uint32_t width;         /**< Frame width in pixels */
     uint32_t height;        /**< Frame height in pixels */
@@ -151,10 +158,11 @@ typedef struct {
  * Returns a DMA-BUF file descriptor in frame->dma_buf_fd that can be
  * passed directly to VAAPI/V4L2 encoders without copying pixel data.
  *
- * THERE ARE NO CPU PIXELS HERE. This call does no conversion and no detiling, so
- * `frame->data` is whatever the raw scanout mapping happened to give: on a GPU whose
- * scanout cannot be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia) it is NULL, and
- * the call still returns 0. Reading `frame->data` after a successful `drmtap_grab` is
+ * THERE ARE NO USABLE CPU PIXELS HERE. This call does no conversion and no detiling.
+ * `frame->data` is whatever the raw scanout mapping happened to give: still tiled where
+ * the scanout is tiled, and NULL on a GPU whose scanout cannot be CPU-mapped at all
+ * (amdgpu GFX9+, discrete VRAM, nvidia) -- and the call still returns 0 in both cases.
+ * Reading `frame->data` after a successful `drmtap_grab` is
  * therefore not portable and renders black on those GPUs -- it was reported as a
  * capture bug (issue #36). For pixels in this process use `drmtap_grab_mapped()`;
  * to hand the buffer to another process use `drmtap_grab_desc()` plus

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -151,6 +151,15 @@ typedef struct {
  * Returns a DMA-BUF file descriptor in frame->dma_buf_fd that can be
  * passed directly to VAAPI/V4L2 encoders without copying pixel data.
  *
+ * THERE ARE NO CPU PIXELS HERE. This call does no conversion and no detiling, so
+ * `frame->data` is whatever the raw scanout mapping happened to give: on a GPU whose
+ * scanout cannot be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia) it is NULL, and
+ * the call still returns 0. Reading `frame->data` after a successful `drmtap_grab` is
+ * therefore not portable and renders black on those GPUs -- it was reported as a
+ * capture bug (issue #36). For pixels in this process use `drmtap_grab_mapped()`;
+ * to hand the buffer to another process use `drmtap_grab_desc()` plus
+ * `drmtap_convert_dmabuf()` on the receiving side.
+ *
  * @param ctx   Capture context
  * @param frame Output frame info (caller-allocated)
  * @return 0 on success, negative errno on error
@@ -198,9 +207,16 @@ int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame);
  * function OR until drmtap_close(). Do NOT call drmtap_frame_release()
  * on frames from this function — cleanup is automatic.
  *
+ * REQUIRES CAP_SYS_ADMIN IN THE CALLING PROCESS. Unlike `drmtap_grab_mapped()`, this
+ * entry point has NO helper fallback: caching a persistent CPU mapping per framebuffer
+ * is the whole point of it, and the helper hands over a fresh fd per grab, so there is
+ * nothing stable to cache. Without the capability it returns -EACCES on every call, on
+ * any GPU, and `drmtap_error()` names `drmtap_grab_mapped()` as the call to use instead.
+ *
  * @param ctx   Capture context
  * @param frame Output frame info (caller-allocated, reused between calls)
  * @return 0 = frame captured, negative errno on error
+ * @retval -EACCES The process lacks CAP_SYS_ADMIN (no helper fallback on this path)
  */
 int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame);
 

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -96,6 +96,17 @@ struct drmtap_ctx {
      * the per-frame "miss" honest in the log: nothing was ever cached to hit. */
     int      fast_no_cpu_map;
 
+    /* Set once drmtap_grab_mapped_fast has established that this process cannot
+     * export the scanout itself (drmModeGetFB2 returns handles[0]==0 without
+     * CAP_SYS_ADMIN). Unlike drmtap_grab_mapped, the fast path has no helper
+     * fallback -- caching a persistent CPU mapping per framebuffer is its whole
+     * purpose, and a helper hands over a fresh fd per grab, so there is nothing
+     * stable to cache. It therefore cannot work for an unprivileged caller on
+     * any GPU. Sticky so the diagnosis is stated once instead of once per frame:
+     * reported as pages of "CACHE MISS ... cold start" with the real reason only
+     * in drmtap_error(), it read as a broken cache (issue #36). */
+    int      fast_no_privilege;
+
     /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
      * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;
      * freed in drmtap_close(). */

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -134,7 +134,14 @@ int drmtap_displays_changed(drmtap_ctx *ctx);
 
 /** Captured frame metadata and pixel data. */
 typedef struct {
-    void *data;             /**< Pixel data (mapped path) or NULL (zero-copy) */
+    /** Pixel data. Always set on the mapped paths (drmtap_grab_mapped,
+     *  drmtap_grab_mapped_fast). On the zero-copy path (drmtap_grab,
+     *  drmtap_grab_desc) it is NOT guaranteed: it holds the raw, UNCONVERTED
+     *  scanout mapping where one was possible and NULL where the scanout cannot
+     *  be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia). Do not read it after
+     *  a zero-copy grab -- that it happens to work on one GPU and returns NULL on
+     *  another is exactly how issue #36 was mistaken for a driver bug. */
+    void *data;
     int dma_buf_fd;         /**< DMA-BUF fd (zero-copy) or -1 (mapped) */
     uint32_t width;         /**< Frame width in pixels */
     uint32_t height;        /**< Frame height in pixels */
@@ -151,10 +158,11 @@ typedef struct {
  * Returns a DMA-BUF file descriptor in frame->dma_buf_fd that can be
  * passed directly to VAAPI/V4L2 encoders without copying pixel data.
  *
- * THERE ARE NO CPU PIXELS HERE. This call does no conversion and no detiling, so
- * `frame->data` is whatever the raw scanout mapping happened to give: on a GPU whose
- * scanout cannot be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia) it is NULL, and
- * the call still returns 0. Reading `frame->data` after a successful `drmtap_grab` is
+ * THERE ARE NO USABLE CPU PIXELS HERE. This call does no conversion and no detiling.
+ * `frame->data` is whatever the raw scanout mapping happened to give: still tiled where
+ * the scanout is tiled, and NULL on a GPU whose scanout cannot be CPU-mapped at all
+ * (amdgpu GFX9+, discrete VRAM, nvidia) -- and the call still returns 0 in both cases.
+ * Reading `frame->data` after a successful `drmtap_grab` is
  * therefore not portable and renders black on those GPUs -- it was reported as a
  * capture bug (issue #36). For pixels in this process use `drmtap_grab_mapped()`;
  * to hand the buffer to another process use `drmtap_grab_desc()` plus

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -151,6 +151,15 @@ typedef struct {
  * Returns a DMA-BUF file descriptor in frame->dma_buf_fd that can be
  * passed directly to VAAPI/V4L2 encoders without copying pixel data.
  *
+ * THERE ARE NO CPU PIXELS HERE. This call does no conversion and no detiling, so
+ * `frame->data` is whatever the raw scanout mapping happened to give: on a GPU whose
+ * scanout cannot be CPU-mapped (amdgpu GFX9+, discrete VRAM, nvidia) it is NULL, and
+ * the call still returns 0. Reading `frame->data` after a successful `drmtap_grab` is
+ * therefore not portable and renders black on those GPUs -- it was reported as a
+ * capture bug (issue #36). For pixels in this process use `drmtap_grab_mapped()`;
+ * to hand the buffer to another process use `drmtap_grab_desc()` plus
+ * `drmtap_convert_dmabuf()` on the receiving side.
+ *
  * @param ctx   Capture context
  * @param frame Output frame info (caller-allocated)
  * @return 0 on success, negative errno on error
@@ -198,9 +207,16 @@ int drmtap_grab_mapped(drmtap_ctx *ctx, drmtap_frame_info *frame);
  * function OR until drmtap_close(). Do NOT call drmtap_frame_release()
  * on frames from this function — cleanup is automatic.
  *
+ * REQUIRES CAP_SYS_ADMIN IN THE CALLING PROCESS. Unlike `drmtap_grab_mapped()`, this
+ * entry point has NO helper fallback: caching a persistent CPU mapping per framebuffer
+ * is the whole point of it, and the helper hands over a fresh fd per grab, so there is
+ * nothing stable to cache. Without the capability it returns -EACCES on every call, on
+ * any GPU, and `drmtap_error()` names `drmtap_grab_mapped()` as the call to use instead.
+ *
  * @param ctx   Capture context
  * @param frame Output frame info (caller-allocated, reused between calls)
  * @return 0 = frame captured, negative errno on error
+ * @retval -EACCES The process lacks CAP_SYS_ADMIN (no helper fallback on this path)
  */
 int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame);
 

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -1520,6 +1520,13 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
          * the reporter and me after a tiling bug that was not there (issue #36). */
         drmModeFreeFB2(fb2);
         ctx->fast_no_privilege = 1;
+        /* Nothing on this path can be served again, so release whatever the slots hold
+         * (prime fds, mappings, GEM handles) now instead of at drmtap_close. Normally
+         * there is nothing: an unprivileged process never populated a slot in the first
+         * place. It matters for the one case that can, a process that captured with
+         * CAP_SYS_ADMIN and then dropped it, where the slots are live and unusable.
+         * Runs AFTER the flag is set, since cleanup deliberately leaves it alone. */
+        drmtap_fast_cleanup(ctx);
         drmtap_debug_log(ctx,
             "fast2: this process has no CAP_SYS_ADMIN, and the fast path has no helper "
             "fallback (it caches a CPU mapping per framebuffer; a helper hands over a "

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -1300,6 +1300,10 @@ void drmtap_fast_cleanup(drmtap_ctx *ctx) {
     ctx->fast_last_fb_id = 0;
     ctx->fast_initialized = 0;
     ctx->fast_no_cpu_map = 0;
+    /* fast_no_privilege is deliberately NOT cleared: it records a property of the
+     * PROCESS (no CAP_SYS_ADMIN), not of the plane, the framebuffer or the device,
+     * so re-discovering it after every teardown would repeat the whole GetFB2 dance
+     * to reach the same verdict. */
 }
 
 // Find or allocate a slot for the given fb_id
@@ -1352,6 +1356,17 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         drmtap_set_error(ctx, "context is render-only (drmtap_open_render); "
                          "grab needs a KMS context from drmtap_open");
         return -ENOTSUP;
+    }
+
+    /* Established on an earlier call that this process cannot export the scanout and
+     * that this entry point has no helper fallback. Answer immediately and quietly:
+     * the caller has the reason in drmtap_error() from the first failure, and a
+     * capture loop calling this at frame rate must not produce a line per frame. */
+    if (ctx->fast_no_privilege) {
+        drmtap_set_error(ctx,
+            "drmtap_grab_mapped_fast needs CAP_SYS_ADMIN in this process and has no "
+            "helper fallback; use drmtap_grab_mapped()");
+        return -EACCES;
     }
 
     int ret;
@@ -1496,8 +1511,23 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     }
 
     if (fb2->handles[0] == 0) {
+        /* drmModeGetFB2 zeroes the GEM handles for a caller without CAP_SYS_ADMIN.
+         * drmtap_grab_mapped treats that as "go through the helper"; this entry point
+         * has no such branch, so it cannot serve an unprivileged caller on ANY gpu.
+         * Say that, name the call that does work, and latch it so the next frame is
+         * answered at the top of the function instead of repeating this whole dance.
+         * Reported as endless cache-miss lines with the cause buried, which sent both
+         * the reporter and me after a tiling bug that was not there (issue #36). */
         drmModeFreeFB2(fb2);
-        drmtap_set_error(ctx, "fast2: handles[0]==0, no CAP_SYS_ADMIN");
+        ctx->fast_no_privilege = 1;
+        drmtap_debug_log(ctx,
+            "fast2: this process has no CAP_SYS_ADMIN, and the fast path has no helper "
+            "fallback (it caches a CPU mapping per framebuffer; a helper hands over a "
+            "fresh fd per grab, so there is nothing to cache). Use drmtap_grab_mapped(), "
+            "which falls back to the helper. Not repeated per frame.");
+        drmtap_set_error(ctx,
+            "drmtap_grab_mapped_fast needs CAP_SYS_ADMIN in this process and has no "
+            "helper fallback; use drmtap_grab_mapped()");
         return -EACCES;
     }
 

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -96,6 +96,17 @@ struct drmtap_ctx {
      * the per-frame "miss" honest in the log: nothing was ever cached to hit. */
     int      fast_no_cpu_map;
 
+    /* Set once drmtap_grab_mapped_fast has established that this process cannot
+     * export the scanout itself (drmModeGetFB2 returns handles[0]==0 without
+     * CAP_SYS_ADMIN). Unlike drmtap_grab_mapped, the fast path has no helper
+     * fallback -- caching a persistent CPU mapping per framebuffer is its whole
+     * purpose, and a helper hands over a fresh fd per grab, so there is nothing
+     * stable to cache. It therefore cannot work for an unprivileged caller on
+     * any GPU. Sticky so the diagnosis is stated once instead of once per frame:
+     * reported as pages of "CACHE MISS ... cold start" with the real reason only
+     * in drmtap_error(), it read as a broken cache (issue #36). */
+    int      fast_no_privilege;
+
     /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
      * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;
      * freed in drmtap_close(). */


### PR DESCRIPTION
Closes the diagnosability half of #36.

`drmtap_grab_mapped_fast` has no helper fallback, by design: caching a persistent CPU mapping per framebuffer is its whole purpose, and a helper hands over a fresh fd per grab, so there is nothing stable to cache. Without CAP_SYS_ADMIN, `drmModeGetFB2` zeroes the GEM handles and the entry point can only fail, on any GPU.

The problem was how it said so. Per frame it logged `fast2: CACHE MISS fb=N slot=0 (cold start)` and returned -EACCES, with the actual reason reachable only through `drmtap_error()`. That reads as a broken cache, which is exactly how it was reported. It cost the reporter three rounds, and it cost me two wrong answers: I diagnosed a tiling/mmap problem that his fast path never reached, because it stopped at the privilege check before it.

Now the first call states it once and names `drmtap_grab_mapped()` as the call that does fall back to the helper. A sticky `fast_no_privilege` answers every later call at the top of the function, so a capture loop at frame rate produces no repeats.

The flag is deliberately not cleared alongside the rest of the fast state: it records a property of the process, not of the plane, the framebuffer or the device, so re-discovering it after a teardown would repeat the whole GetFB2 dance to reach the same verdict. There is a comment at the reset site saying so, since the omission otherwise reads as an oversight.

Verified unprivileged on i915 (uid 1000), three consecutive calls:

```
fast2: CACHE MISS fb=565 slot=0 (cold start)
fast2: this process has no CAP_SYS_ADMIN, and the fast path has no helper fallback (...) Not repeated per frame.
call 0 -> ret=-13 err="drmtap_grab_mapped_fast needs CAP_SYS_ADMIN in this process and has no helper fallback; use drmtap_grab_mapped()"
call 1 -> ret=-13 err="..."      <- no log output
call 2 -> ret=-13 err="..."      <- no log output
```

csrc/ is regenerated with tools/sync-crate.sh (--check clean).

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR improves diagnosability for unprivileged callers of `drmtap_grab_mapped_fast` by introducing a sticky `fast_no_privilege` flag that fires a clear, one-time diagnostic log on the first failure and silences all subsequent per-frame noise, addressing the confusing "CACHE MISS cold start" spam that obscured the real cause in issue #36.

- Adds `fast_no_privilege` to `drmtap_ctx`; on first detection of `handles[0]==0` the flag is latched, a descriptive `drmtap_debug_log` message is emitted once, and a helpful error string (naming `drmtap_grab_mapped()` as the correct alternative) is set via `drmtap_set_error`.
- The early-return guard at the top of `drmtap_grab_mapped_fast` answers all subsequent calls immediately and silently, eliminating per-frame repetition without changing the `-EACCES` return code.
- The flag is deliberately excluded from `drmtap_fast_cleanup()`, with a comment explaining it records a process-level property rather than a device or framebuffer property; the Rust `csrc/` copies are regenerated in lockstep.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge; all changes are purely diagnostic — no data paths, cache logic, or resource management are altered.

The only observable behavioral change is that repeated calls from an unprivileged process now return -EACCES immediately and silently instead of re-running the GetFB2 dance and emitting a misleading log line each time. The sticky flag follows the exact same pattern as the existing fast_no_cpu_map field, the cleanup comment clearly documents the intentional omission, and the Rust bindings are kept in sync. No new error paths, no resource allocation changes.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/drmtap_internal.h | Adds fast_no_privilege field to drmtap_ctx with a thorough comment explaining its sticky-per-process semantics; the field is correctly placed adjacent to fast_no_cpu_map which has the same sticky pattern. |
| src/drm_grab.c | Adds early-return guard using fast_no_privilege, sets the flag on first handles[0]==0 detection, emits a one-time drmtap_debug_log, and adds a comment in drmtap_fast_cleanup explaining why the flag is intentionally not cleared. |
| bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h | Mirror copy of src/drmtap_internal.h regenerated by tools/sync-crate.sh; identical diff to the canonical source. |
| bindings/rust/libdrmtap-sys/csrc/drm_grab.c | Mirror copy of src/drm_grab.c regenerated by tools/sync-crate.sh; identical diff to the canonical source. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[drmtap_grab_mapped_fast called] --> B{fast_no_privilege set?}
    B -->|yes| C[drmtap_set_error: needs CAP_SYS_ADMIN]
    C --> D[return -EACCES, no log output]
    B -->|no| E[Step 1: Find plane on first call]
    E --> F[Step 2: Get fb_id from plane]
    F --> G[Cache lookup by fb_id]
    G -->|HIT| H[Serve frame from cached slot]
    G -->|MISS| I[drmModeGetFB2]
    I --> J{handles zero?}
    J -->|yes| K[drmModeFreeFB2, set fast_no_privilege = 1]
    K --> L[drmtap_debug_log: one-time diagnostic]
    L --> M[drmtap_set_error]
    M --> N[return -EACCES]
    J -->|no| O[Populate cache slot and map DMA-BUF]
    O --> H
    H --> P[return 0]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Say why the fast path cannot serve an un..."](https://github.com/fxd0h/libdrmtap/commit/53f8735d62360239e756b395ef6ef8ef5f69ab9f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48209561)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/howdidthecatgetsofat/github/fxd0h/libdrmtap/-/custom-context?memory=5e4f4850-184d-45de-af35-5f4f36157b7c))

<!-- /greptile_comment -->