### PR TITLE
Report the scanned-out width, and let the caller supply the output buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
   output buffer, so owning a large mapping cannot unlock a frame larger than this
   library handles. Verified under ASan and UBSan against a real tiled scanout,
   with guard bytes either side of the destination.
+- The privileged-helper wire is now bounded on stride-covers-width, which the two
+  existing checks did not imply. validate_fb_size bounds stride * height and
+  validate_fb_dims bounds the dimensions, but a wire frame claiming
+  width * bpp > stride still reached the per-pixel CPU converters, which read
+  y * stride + width * bpp per row with no size argument, so the last rows ran off
+  the end of the receive buffer (a heap over-read). drmtap_convert_dmabuf already
+  applied this check to its IPC descriptor; the two trust boundaries are bounded
+  alike now.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,8 +37,8 @@ entry point is additive and would not on its own have justified more than a patc
 ### Security
 
 - Framebuffer DIMENSIONS are now bounded at every entry point, not just
-  stride * height. validate_fb_size() never constrained width, yet every converted
-  output is sized width * height * 4 -- a product that can wrap size_t and hand a
+  `stride * height`. validate_fb_size() never constrained width, yet every converted
+  output is sized `width * height * 4` -- a product that can wrap size_t and hand a
   large write a small destination. Reachable with a width from the helper wire or
   an IPC-supplied descriptor. Each dimension is now bounded before anything
   multiplies it (so the product cannot wrap even where size_t is 32-bit) and the
@@ -47,10 +47,10 @@ entry point is additive and would not on its own have justified more than a patc
   library handles. Verified under ASan and UBSan against a real tiled scanout,
   with guard bytes either side of the destination.
 - The privileged-helper wire is now bounded on stride-covers-width, which the two
-  existing checks did not imply. validate_fb_size bounds stride * height and
+  existing checks did not imply. validate_fb_size bounds `stride * height` and
   validate_fb_dims bounds the dimensions, but a wire frame claiming
-  width * bpp > stride still reached the per-pixel CPU converters, which read
-  y * stride + width * bpp per row with no size argument, so the last rows ran off
+  `width * bpp > stride` still reached the per-pixel CPU converters, which read
+  `y * stride + width * bpp` per row with no size argument, so the last rows ran off
   the end of the receive buffer (a heap over-read). drmtap_convert_dmabuf already
   applied this check to its IPC descriptor; the two trust boundaries are bounded
   alike now.
@@ -73,7 +73,7 @@ entry point is additive and would not on its own have justified more than a patc
   getting that wrong returns part of the image as if it were the whole screen. On
   the measured machine the plane reports SRC 60x2170 onto a 60x2170 CRTC rect, so
   the four columns are provably not scanned out. A pitch test cannot substitute:
-  fb_width * bpp == pitches[0] holds for a 3840-wide downscaled framebuffer exactly
+  `fb_width * bpp == pitches[0]` holds for a 3840-wide downscaled framebuffer exactly
   as it does for the padded 64-wide one.
   It only ever SHRINKS, and only the width, and every refusal is a case where the
   framebuffer width is the right answer: a scaling plane (the whole fb is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 
 ## [Unreleased]
 
+### Added
+
+- drmtap_set_output_buffer(ctx, dst, len): have conversions write into a
+  caller-owned buffer instead of a library-owned one, so a consumer that must end
+  up with the pixels in specific memory (a memfd it already shares downstream, a
+  pre-registered upload buffer) stops paying a full-frame memcpy per frame -- at
+  2560x1440 that was 14.7 MB a frame for nothing (issue #36). Nothing required the
+  copy: the EGL detile ends in a glReadPixels and the CPU converters take a
+  destination pointer, and both write wherever they are pointed.
+  Applies to every path that materializes pixels -- EGL detile, CPU deswizzle,
+  10/16-bit and HDR reductions, padded-linear repack -- so a caller does not have
+  to know which one ran, and on an unprivileged drmtap_open_render() context too,
+  so the converting half of the split can write straight into the consumer's
+  buffer. It does NOT apply where there is nothing to materialize: a linear 8-bit
+  scanout is handed back as a direct pointer into the mapped scanout, with no
+  intermediate buffer to redirect. A frame that would not fit is REFUSED with
+  -ENOSPC, leaving the buffer untouched and naming the required size through
+  drmtap_error(), rather than writing short.
+
+### Security
+
+- Framebuffer DIMENSIONS are now bounded at every entry point, not just
+  stride * height. validate_fb_size() never constrained width, yet every converted
+  output is sized width * height * 4 -- a product that can wrap size_t and hand a
+  large write a small destination. Reachable with a width from the helper wire or
+  an IPC-supplied descriptor. Each dimension is now bounded before anything
+  multiplies it (so the product cannot wrap even where size_t is 32-bit) and the
+  pixel count is bounded after. The frame cap also applies to a caller-supplied
+  output buffer, so owning a large mapping cannot unlock a frame larger than this
+  library handles. Verified under ASan and UBSan against a real tiled scanout,
+  with guard bytes either side of the destination.
+
 ### Fixed
 
 - A grab reported the width of the framebuffer OBJECT instead of the width the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 
 ### Fixed
 
+- A grab reported the width of the framebuffer OBJECT instead of the width the
+  CRTC actually scans out, so a display whose scanout fb is padded wider than its
+  mode could not be captured at all by a consumer that had enumerated the mode.
+  Measured on an Apple T2 MacBook: the Touch Bar card (appletbdrm) drives a
+  60x2170 mode from a 64x2170 framebuffer with a 256-byte pitch, and those four
+  columns are alignment padding that is never scanned out. Every frame came back
+  64 wide against a display advertised as 60, which rustdesk read as "this
+  display never matched its advertised geometry"; it rejected the frames,
+  demoted the display to PipeWire, and the client sat on "waiting for image".
+  Reported geometry is now narrowed to the mode. It only ever shrinks and only
+  the width: a framebuffer NARROWER than the mode is a CRTC scaling a smaller
+  buffer up, which is a different image and is left alone. A CRTC whose viewport
+  does not start at the framebuffer origin (several heads scanning out of one big
+  fb) would need an offset crop, which drmtap_dmabuf_desc has no field for, so
+  such a frame is reported whole and the reason is logged once. Buffer-size
+  arithmetic is unchanged -- the mapping is still of the whole padded fb, only
+  the reported width narrows and the caller reads rows at the unchanged stride.
+  No ABI change: the decision is an internal function, the exported symbol set is
+  untouched.
+
 - drmtap_grab_mapped_fast() said nothing useful when it could not read the
   scanout (issue #36, a Radeon Vega 64 on amdgpu where the tiled VRAM scanout
   refuses a CPU mmap). Three separate silences: the no-mapping-and-no-EGL exit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,21 +50,34 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
   64 wide against a display advertised as 60, which rustdesk read as "this
   display never matched its advertised geometry"; it rejected the frames,
   demoted the display to PipeWire, and the client sat on "waiting for image".
-  Reported geometry is now narrowed to the mode. It only ever shrinks, only the
-  width, and only for a LINEAR layout: a framebuffer NARROWER than the mode is a
-  CRTC scaling a smaller buffer up, which is a different image and is left alone,
-  and a padded TILED scanout is left alone too, because the CPU deswizzle derives
-  its tile grid from the width and uses it to address the SOURCE, so a narrowed
-  width there would mis-address every tile row after the first and silently mangle
-  the image. No padded tiled scanout has been seen on any hardware here, so that
-  branch keeps the previous behaviour rather than being narrowed on a guess.
-  A CRTC whose viewport does not start at the framebuffer origin (several heads scanning out of one big
-  fb) would need an offset crop, which drmtap_dmabuf_desc has no field for, so
-  such a frame is reported whole and the reason is logged once. Buffer-size
-  arithmetic is unchanged -- the mapping is still of the whole padded fb, only
-  the reported width narrows and the caller reads rows at the unchanged stride.
-  No ABI change: the decision is an internal function, the exported symbol set is
-  untouched.
+  Reported geometry is now narrowed to what the primary plane actually reads, and
+  the mode is only the cheap gate that says "worth looking closer". The plane rect
+  is what decides, because a framebuffer wider than the mode looks IDENTICAL to
+  pitch padding whether it is padding or a plane that genuinely downscales, and
+  getting that wrong returns part of the image as if it were the whole screen. On
+  the measured machine the plane reports SRC 60x2170 onto a 60x2170 CRTC rect, so
+  the four columns are provably not scanned out. A pitch test cannot substitute:
+  fb_width * bpp == pitches[0] holds for a 3840-wide downscaled framebuffer exactly
+  as it does for the padded 64-wide one.
+  It only ever SHRINKS, and only the width, and every refusal is a case where the
+  framebuffer width is the right answer: a scaling plane (the whole fb is
+  displayed, just smaller), a plane reading from a non-zero origin (several heads
+  out of one framebuffer, which would need an offset crop that the frozen
+  drmtap_dmabuf_desc has nowhere to carry), a TILED layout (the CPU deswizzle
+  derives its tile grid from the width and uses it to address the SOURCE, so a
+  narrowed width there mis-addresses every tile row after the first and silently
+  mangles the image), and an unreadable plane rect -- which is NOT the same as "no
+  scaling" and is not treated as one.
+  Reading the plane rect needs DRM_CLIENT_CAP_ATOMIC, since the SRC and CRTC
+  properties are hidden from a non-atomic client (measured: the same plane reports
+  SRC_W with the cap and nothing without it). The cap is requested LAZILY, only
+  once a framebuffer has turned out to be wider than its mode, so the common path
+  never touches it; it is per-fd, needs no privilege and no DRM master, no atomic
+  commit is ever issued, and no other client is affected.
+  Buffer-size arithmetic is unchanged -- the mapping is still of the whole padded
+  fb, only the reported width narrows and the caller reads rows at the unchanged
+  stride. No ABI change: the decision is an internal function, the exported symbol
+  set is untouched.
 
 - drmtap_grab_mapped_fast() said nothing useful when it could not read the
   scanout (issue #36, a Radeon Vega 64 on amdgpu where the tiled VRAM scanout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
   to know which one ran, and on an unprivileged drmtap_open_render() context too,
   so the converting half of the split can write straight into the consumer's
   buffer. It does NOT apply where there is nothing to materialize: a linear 8-bit
-  scanout is handed back as a direct pointer into the mapped scanout, with no
-  intermediate buffer to redirect. A frame that would not fit is REFUSED with
+  scanout is reported where the pixels already are -- the mapped scanout on the
+  direct path, the library receive buffer on the privileged-helper pixel path -- so
+  no conversion destination is chosen. A frame that would not fit is REFUSED with
   -ENOSPC, leaving the buffer untouched and naming the required size through
   drmtap_error(), rather than writing short.
 
@@ -49,10 +50,15 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
   64 wide against a display advertised as 60, which rustdesk read as "this
   display never matched its advertised geometry"; it rejected the frames,
   demoted the display to PipeWire, and the client sat on "waiting for image".
-  Reported geometry is now narrowed to the mode. It only ever shrinks and only
-  the width: a framebuffer NARROWER than the mode is a CRTC scaling a smaller
-  buffer up, which is a different image and is left alone. A CRTC whose viewport
-  does not start at the framebuffer origin (several heads scanning out of one big
+  Reported geometry is now narrowed to the mode. It only ever shrinks, only the
+  width, and only for a LINEAR layout: a framebuffer NARROWER than the mode is a
+  CRTC scaling a smaller buffer up, which is a different image and is left alone,
+  and a padded TILED scanout is left alone too, because the CPU deswizzle derives
+  its tile grid from the width and uses it to address the SOURCE, so a narrowed
+  width there would mis-address every tile row after the first and silently mangle
+  the image. No padded tiled scanout has been seen on any hardware here, so that
+  branch keeps the previous behaviour rather than being narrowed on a guess.
+  A CRTC whose viewport does not start at the framebuffer origin (several heads scanning out of one big
   fb) would need an offset crop, which drmtap_dmabuf_desc has no field for, so
   such a frame is reported whole and the reason is logged once. Buffer-size
   arithmetic is unchanged -- the mapping is still of the whole padded fb, only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ Notable changes to libdrmtap. Loosely follows Keep a Changelog; the project uses
 semantic versioning. The C library, the `libdrmtap-sys` crate and the meson
 project share one version; the `libdrmtap` wrapper crate is versioned separately.
 
-## [Unreleased]
+## [0.5.0] - 2026-07-30
+
+A MINOR bump, not a patch, for one reason: the scanout-width fix below changes the
+SEMANTICS of an existing call. Any consumer reading drmtap_frame_info.width can now
+get a different number for the same hardware. Nothing was removed and the soname is
+unchanged (still libdrmtap.so.0), so a dlopen-by-soname consumer keeps loading it --
+which is exactly why the version has to say so: a consumer built against 0.4.x
+semantics would otherwise pick up different widths with no signal at all. The new
+entry point is additive and would not on its own have justified more than a patch.
 
 ### Added
 
@@ -426,6 +434,7 @@ project share one version; the `libdrmtap` wrapper crate is versioned separately
 - amdgpu EGL detile fix, privileged-helper hardening, and a batch of full-audit
   fixes.
 
+[0.5.0]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.0
 [0.4.15]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.15
 [0.4.14]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.14
 [0.4.13]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.13

--- a/README.md
+++ b/README.md
@@ -94,13 +94,31 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 > ⚠️ **Testing status**: Capture pipeline verified with the V3 zero-copy path on
 > `virtio_gpu` (QEMU/Parallels VMs), Intel Meteor Lake (`i915`, dual 3840x2160,
 > EGL CCS detiling), and NVIDIA Jetson Orin Nano (`nvidia-drm`, aarch64, Wayland).
-> The AMD (`amdgpu`) backend is verified on real hardware (RX Vega 64, gfx9, via the EGL detile path — see [#26](https://github.com/fxd0h/libdrmtap/issues/26)).
+> The AMD (`amdgpu`) backend is verified on real hardware on two generations, by
+> two different people: **RX Vega 64 (gfx9), confirmed by an outside tester** (via
+> the EGL detile path — see [#26](https://github.com/fxd0h/libdrmtap/issues/26)),
+> and **RX560 (Polaris/gfx8), verified here** (2880x1800 `eDP-1`, tiled `XR30`
+> scanout, EGL detile).
 > **Multi-GPU render-node selection is verified on the Jetson Orin's two DRM
 > devices** (`tegra`/renderD128 with no connectors + `nvidia-drm`/renderD129
 > driving the display): the converter now binds renderD129, the node that
-> exported the scanout. The multi-card display *merge* (one monitor per GPU on two
-> display-driving GPUs) is implemented but not yet verified end-to-end for lack of
-> such hardware.
+> exported the scanout.
+> **Multi-card, multi-VENDOR hosts with more than one display-driving GPU are now
+> verified** on an Apple T2 MacBook Pro: three DRM cards — `appletbdrm` (the Touch
+> Bar strip), `i915` (no connected output) and `amdgpu` (the panel) — where two
+> different vendors are each scanning out a display at once, and each was captured
+> from its own card. That machine also covers two cases nothing else here does:
+>
+> - **A display-only card with NO render node.** `appletbdrm` exposes an active
+>   CRTC and no `renderD*`, so a consumer cannot be told which GPU exported the
+>   scanout and must not guess: importing it on the wrong device can corrupt the
+>   image silently. Such a frame takes the CPU path instead.
+> - **A scanout framebuffer PADDED wider than the mode.** That card drives a
+>   60x2170 mode out of a 64x2170 framebuffer (256-byte pitch), and those four
+>   columns are alignment padding that is never scanned out. A grab reports the
+>   width the CRTC scans out, not the framebuffer's, so a consumer that enumerated
+>   the mode is not handed an image wider than the display it asked for. Worth
+>   knowing if you compare a frame's geometry against a display list.
 > If you test on real hardware, please [report results](https://github.com/fxd0h/libdrmtap/issues).
 >
 > ℹ️ **virgl note**: Plain `virtio-gpu` is captured with a direct linear map. A

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.4.15"
+version = "0.5.0"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -353,6 +353,10 @@ int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
     return 0;
 }
 
+/* Defined further down with the convert path that first needed it. Declared here
+ * because the helper wire has to apply the same stride-covers-width bound. */
+static uint32_t format_min_bpp(uint32_t fourcc);
+
 int validate_fb_dims(uint32_t width, uint32_t height) {
     if (width == 0 || height == 0) {
         return -EINVAL;
@@ -894,6 +898,20 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         ret = validate_fb_dims(frame->width, frame->height);
         if (ret == 0) {
             ret = validate_fb_size(frame->stride, frame->height);
+        }
+        if (ret == 0 &&
+            (uint64_t)frame->width * format_min_bpp(frame->format) > frame->stride) {
+            /* THIRD bound, and the one the other two do not imply: the stride must
+             * actually cover width pixels. Without it a wire frame claiming
+             * width*bpp > stride reaches the per-pixel CPU converters, which read
+             * y*stride + width*bpp per row with no size argument, and the last rows
+             * run off the end of the receive buffer. drmtap_convert_dmabuf applies
+             * the same check to its IPC descriptor; the two trust boundaries must be
+             * bounded alike, and this one was not. */
+            drmtap_set_error(ctx, "helper sent stride %u too small for width %u "
+                             "(fourcc %.4s)", frame->stride, frame->width,
+                             (const char *)&frame->format);
+            ret = -EINVAL;
         }
         if (ret != 0) {
             drmtap_set_error(ctx, "helper sent invalid geometry %ux%u stride=%u",
@@ -1956,8 +1974,10 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             if (pr == 0 && !frame->data) {
                 pr = -EIO;
             }
-            /* gpu_auto_process EGL-read the fd back into ctx->deswizzle_buf, so the
-             * fd and handle are no longer needed and nothing is cached for fb_id. */
+            /* gpu_auto_process EGL-read the fd back into the conversion destination
+             * (the caller's output buffer if one was set, otherwise the ctx-owned
+             * one), so the fd and handle are no longer needed and nothing is cached
+             * for fb_id. */
             close(prime_fd);
             frame->dma_buf_fd = -1;  /* prime_fd is closed; don't hand back a stale fd */
             drmtap_gem_close(ctx, fb2->handles[0]);
@@ -2167,7 +2187,8 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
                                      desc->modifier, desc->fb_id,
                                      &egl_data, &egl_size);
         if (ret == 0 && egl_data) {
-            frame->data = egl_data;   /* ctx-owned grow-once buffer */
+            frame->data = egl_data;   /* the resolved destination: caller's output
+                                       * buffer if set, else the ctx-owned one */
             frame->format = DRM_FORMAT_XRGB8888;
             frame->stride = desc->width * 4;
             frame->modifier = DRM_FORMAT_MOD_LINEAR;

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -518,41 +518,132 @@ static uint64_t fb2_effective_modifier(const drmModeFB2 *fb2) {
  * allocation is still the full padded framebuffer. Only the REPORTED geometry
  * narrows, and the caller reads rows out of it at the unchanged stride.
  */
-/* The decision alone, with no DRM fd, so it is unit-testable on any machine:
- * the padded-scanout case needs hardware that pads (Apple's Touch Bar) to
- * observe, and a rule this easy to get subtly wrong should not be reachable
- * only through that one laptop. Reports through *why which branch was taken. */
-uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
-                                 uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 int layout_is_linear, drmtap_scanout_why *why) {
+/* The decision alone, with no DRM fd, so it is unit-testable on any machine: the
+ * padded-scanout case needs hardware that pads (Apple's Touch Bar) to observe, and a
+ * rule this easy to get subtly wrong should not be reachable only through that one
+ * laptop. Reports through *why which branch was taken.
+ *
+ * Only ever SHRINKS, and only the width. Every branch that declines to narrow is a
+ * case where the framebuffer width IS the right answer:
+ *
+ *  - TILED. The CPU deswizzle derives its tile grid from the width and uses it to
+ *    address the SOURCE (deswizzle_nvidia_x_tiled: tiles_x = ceil(width/tile_w), then
+ *    src_off = (tile_row * tiles_x + tx) * tile_size; it ignores src_stride). A width
+ *    short by a tile or more mis-addresses every tile row after the first and silently
+ *    mangles the image. The visible width and the width the tiling was laid out for
+ *    are different quantities. No padded tiled scanout has been observed here, so it
+ *    is left alone rather than narrowed on a guess.
+ *  - SCALING. A plane whose SRC rect is larger than its CRTC rect is genuinely
+ *    downscaling: the whole framebuffer IS being displayed, just smaller. Narrowing
+ *    would hand the caller the left part of the image and call it the whole screen.
+ *    A framebuffer wider than the mode looks IDENTICAL to pitch padding until the
+ *    plane rect is read, which is the entire reason this needs the plane and cannot
+ *    be decided from the mode alone. Note a pitch test cannot substitute:
+ *    fb_width * bpp == pitches[0] holds for a 3840-wide downscaled framebuffer just
+ *    as it does for the padded 64-wide one.
+ *  - OFFSET. The plane reads from a non-zero SRC_X/SRC_Y, i.e. several heads out of
+ *    one big framebuffer. That needs an offset crop, and drmtap_dmabuf_desc has a
+ *    frozen layout with nowhere to carry a crop origin. No hardware here has it.
+ *  - UNREADABLE. Without the plane rect the padding and the downscale are
+ *    indistinguishable, so the safe answer is the pre-existing behaviour.
+ */
+uint32_t drmtap_scanout_width_of(uint32_t fb_width,
+                                 const drmtap_plane_rect *rect,
+                                 int layout_is_linear,
+                                 drmtap_scanout_why *why) {
     drmtap_scanout_why w = DRMTAP_SCANOUT_AS_IS;
     uint32_t out = fb_width;
-    if (mode_valid && hdisplay > 0 && hdisplay < fb_width) {
-        if (!layout_is_linear) {
-            /* A TILED scanout must be reported at its framebuffer width, because
-             * the CPU deswizzle derives the tile grid from the width and uses it to
-             * address the SOURCE (deswizzle_*_tiled: tiles_x = ceil(width/tile_w),
-             * src_off = (tile_row * tiles_x + tx) * tile_size). Narrowing the width
-             * by a tile or more would shrink tiles_x and mis-address every tile row
-             * after the first -- a silently mangled image. The visible width and the
-             * width the tiling was laid out for are two different things, one level
-             * down from the mode-vs-framebuffer distinction this function exists for.
-             * No padded TILED scanout has been observed here, so this stays at the
-             * pre-existing behaviour rather than being narrowed on a guess. */
+
+    if (!layout_is_linear) {
+        if (rect && rect->valid && rect->src_w > 0 && rect->src_w < fb_width) {
             w = DRMTAP_SCANOUT_TILED_NOT_NARROWED;
-        } else if (crtc_x == 0 && crtc_y == 0) {
-            out = hdisplay;
-            w = DRMTAP_SCANOUT_NARROWED;
-        } else {
-            w = DRMTAP_SCANOUT_OFFSET_UNSUPPORTED;
         }
+    } else if (!rect || !rect->valid) {
+        /* Only worth reporting when there was something to decide. */
+        w = (fb_width > 0) ? DRMTAP_SCANOUT_NO_PLANE_RECT : DRMTAP_SCANOUT_AS_IS;
+    } else if (rect->src_x != 0 || rect->src_y != 0) {
+        w = DRMTAP_SCANOUT_OFFSET_UNSUPPORTED;
+    } else if (rect->src_w != rect->crtc_w || rect->src_h != rect->crtc_h) {
+        w = DRMTAP_SCANOUT_SCALING_NOT_NARROWED;
+    } else if (rect->src_w > 0 && rect->src_w < fb_width) {
+        out = rect->src_w;
+        w = DRMTAP_SCANOUT_NARROWED;
     }
+
     if (why) {
         *why = w;
     }
     return out;
 }
 
+/* Read the primary plane rectangle of the context's CRTC. The SRC and CRTC properties
+ * are atomic-only: a client that has not asked for DRM_CLIENT_CAP_ATOMIC is shown
+ * none of them (measured on appletbdrm -- SRC_W present with the cap, absent without).
+ * The cap is therefore requested here, LAZILY: this function is only called once a
+ * framebuffer has turned out to be wider than its mode, so the common case never
+ * touches it. It is a per-fd flag, needs no privilege and no DRM master, no atomic
+ * commit is ever issued, and no other client is affected. rect->valid stays 0 when
+ * anything is missing, which the decision above treats as "cannot tell". */
+static void read_primary_plane_rect(drmtap_ctx *ctx, drmtap_plane_rect *rect) {
+    memset(rect, 0, sizeof(*rect));
+
+    if (!ctx->atomic_cap_tried) {
+        ctx->atomic_cap_tried = 1;
+        if (drmSetClientCap(ctx->drm_fd, DRM_CLIENT_CAP_ATOMIC, 1) != 0) {
+            drmtap_debug_log(ctx,
+                "DRM_CLIENT_CAP_ATOMIC refused (%s); plane SRC_W is unreadable, so a "
+                "padded scanout will be reported at its framebuffer width",
+                strerror(errno));
+        }
+    }
+
+    uint32_t plane_id = find_primary_plane(ctx);
+    if (plane_id == 0) {
+        return;
+    }
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(ctx->drm_fd, plane_id, DRM_MODE_OBJECT_PLANE);
+    if (!props) {
+        return;
+    }
+
+    /* 16.16 fixed point for the SRC rect, plain pixels for the CRTC rect. Fractions are dropped:
+     * a fractional source rect is a scaling plane, and the equality test below
+     * already declines to narrow that. */
+    int got = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(ctx->drm_fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        uint64_t v = props->prop_values[i];
+        if      (!strcmp(p->name, "SRC_X"))  { rect->src_x  = (uint32_t)(v >> 16); got |= 1; }
+        else if (!strcmp(p->name, "SRC_Y"))  { rect->src_y  = (uint32_t)(v >> 16); got |= 2; }
+        else if (!strcmp(p->name, "SRC_W"))  { rect->src_w  = (uint32_t)(v >> 16); got |= 4; }
+        else if (!strcmp(p->name, "SRC_H"))  { rect->src_h  = (uint32_t)(v >> 16); got |= 8; }
+        else if (!strcmp(p->name, "CRTC_W")) { rect->crtc_w = (uint32_t)v;         got |= 16; }
+        else if (!strcmp(p->name, "CRTC_H")) { rect->crtc_h = (uint32_t)v;         got |= 32; }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    rect->valid = (got == 63);
+}
+
+/* Report the width the CRTC actually scans out, not the width of the framebuffer
+ * OBJECT. A driver may allocate the scanout fb wider than the mode to satisfy a pitch
+ * alignment: Apple's appletbdrm (the Touch Bar strip) drives a 60x2170 mode from a
+ * 64x2170 fb with a 256-byte pitch, and its primary plane reads SRC_W=60 -- those four
+ * columns are padding that is never scanned out. Reporting the fb width hands the
+ * caller an image wider than the display it asked to capture. In rustdesk that read as
+ * "this display never matched its advertised geometry" -- the display list carries the
+ * mode -- so every frame was rejected, the display was demoted to PipeWire, and the
+ * client sat on "waiting for image".
+ *
+ * The mode is only the CHEAP GATE here: it says "worth looking closer", and the plane
+ * rect decides. Buffer-size arithmetic must keep using fb2->width and fb2->pitches:
+ * the allocation is still the full padded framebuffer. Only the REPORTED geometry
+ * narrows, and the caller reads rows out of it at the unchanged stride.
+ */
 static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
                                      uint64_t modifier) {
     if (ctx->crtc_id == 0) {
@@ -562,40 +653,69 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
     if (!crtc) {
         return fb_width;
     }
+    int worth_looking = crtc->mode_valid && crtc->mode.hdisplay > 0 &&
+                        crtc->mode.hdisplay < fb_width;
+    uint32_t hdisplay = crtc->mode.hdisplay;
+    uint32_t vdisplay = crtc->mode.vdisplay;
+    drmModeFreeCrtc(crtc);
+    if (!worth_looking) {
+        return fb_width;
+    }
+
     /* LINEAR and INVALID (unknown layout, handled downstream as linear) are the
      * layouts whose only width-dependent consumer is the OUTPUT: rows are addressed
-     * through the stride, so narrowing the reported width is safe. Anything else is
-     * a real tiling. */
+     * through the stride, so narrowing the reported width is safe. Anything else is a
+     * real tiling -- see drmtap_scanout_width_of. */
     int linear = (modifier == DRM_FORMAT_MOD_LINEAR ||
                   modifier == DRM_FORMAT_MOD_INVALID);
+
+    drmtap_plane_rect rect;
+    read_primary_plane_rect(ctx, &rect);
+
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
-    uint32_t out = drmtap_scanout_width_of(fb_width, crtc->mode_valid,
-                                           crtc->mode.hdisplay, crtc->x,
-                                           crtc->y, linear, &why);
+    uint32_t out = drmtap_scanout_width_of(fb_width, &rect, linear, &why);
+
     if (why != DRMTAP_SCANOUT_AS_IS && !ctx->logged_scanout_crop) {
         ctx->logged_scanout_crop = 1;
-        if (why == DRMTAP_SCANOUT_NARROWED) {
+        switch (why) {
+        case DRMTAP_SCANOUT_NARROWED:
             drmtap_debug_log(ctx,
-                "crtc %u scans out %u of the %u-pixel-wide scanout fb "
-                "(pitch padding); reporting %u",
-                ctx->crtc_id, crtc->mode.hdisplay, fb_width, out);
-        } else if (why == DRMTAP_SCANOUT_TILED_NOT_NARROWED) {
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb (pitch padding; "
+                "plane reads SRC %ux%u 1:1); reporting %u",
+                ctx->crtc_id, rect.src_w, fb_width, rect.src_w, rect.src_h, out);
+            break;
+        case DRMTAP_SCANOUT_TILED_NOT_NARROWED:
             drmtap_debug_log(ctx,
-                "crtc %u scans out %u of the %u-pixel-wide scanout fb, but the "
-                "layout is tiled (modifier 0x%llx); reporting the whole fb "
-                "(narrowing a tiled width would mis-address the deswizzle)",
-                ctx->crtc_id, crtc->mode.hdisplay, fb_width,
-                (unsigned long long)modifier);
-        } else {
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb, but the layout "
+                "is tiled (modifier 0x%llx); reporting the whole fb (narrowing a tiled "
+                "width would mis-address the deswizzle)",
+                ctx->crtc_id, hdisplay, fb_width, (unsigned long long)modifier);
+            break;
+        case DRMTAP_SCANOUT_SCALING_NOT_NARROWED:
             drmtap_debug_log(ctx,
-                "crtc %u viewport is %ux%u at +%d+%d inside a %u-pixel-wide "
-                "scanout fb; reporting the whole fb (the frame descriptor has "
-                "no crop origin)",
-                ctx->crtc_id, crtc->mode.hdisplay, crtc->mode.vdisplay,
-                crtc->x, crtc->y, fb_width);
+                "crtc %u plane scales %ux%u -> %ux%u, so the whole %u-pixel-wide fb is "
+                "displayed; reporting it unchanged (this is not pitch padding)",
+                ctx->crtc_id, rect.src_w, rect.src_h, rect.crtc_w, rect.crtc_h,
+                fb_width);
+            break;
+        case DRMTAP_SCANOUT_OFFSET_UNSUPPORTED:
+            drmtap_debug_log(ctx,
+                "crtc %u plane reads from +%u+%u inside a %u-pixel-wide scanout fb "
+                "(mode %ux%u); reporting the whole fb (the frame descriptor has no "
+                "crop origin)",
+                ctx->crtc_id, rect.src_x, rect.src_y, fb_width, hdisplay, vdisplay);
+            break;
+        case DRMTAP_SCANOUT_NO_PLANE_RECT:
+            drmtap_debug_log(ctx,
+                "crtc %u has a %u-pixel-wide scanout fb for a %u-pixel mode, but the "
+                "plane SRC rect is unreadable, so pitch padding cannot be told from a "
+                "scaling plane; reporting the whole fb",
+                ctx->crtc_id, fb_width, hdisplay);
+            break;
+        case DRMTAP_SCANOUT_AS_IS:
+            break;
         }
     }
-    drmModeFreeCrtc(crtc);
     return out;
 }
 

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -1345,6 +1345,18 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             drmtap_debug_log(ctx, "auto-process: EGL detiled to linear XRGB8888");
             return 0;
         }
+        /* An output buffer too small for the frame is a CALLER CONFIGURATION error,
+         * not an EGL failure, and must not fall through. The CPU deswizzle below
+         * needs stride*height, which is never LESS than the width*height*4 the detile
+         * just refused, so it can only fail again -- and it would replace the
+         * actionable -ENOSPC (whose message names the exact size required) with
+         * whatever the CPU path reports. On a scanout with no CPU mapping, which is
+         * precisely the hardware that depends on this detile, that is -ENOTSUP and a
+         * message about a missing mapping: the caller is told its GPU is unsupported
+         * when in truth its buffer was a few bytes short. */
+        if (ret == -ENOSPC) {
+            return ret;
+        }
         drmtap_debug_log(ctx, "auto-process: EGL failed (%d), trying CPU", ret);
     }
 #endif

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -299,13 +299,19 @@ static uint32_t find_primary_plane(drmtap_ctx *ctx) {
     }
 
     drmModeFreePlaneResources(planes);
-
-    /* Direct (no-helper) path: read the connector HDR metadata for this CRTC so
-     * the conversion path can tone-map. In helper mode this comes over the wire
-     * instead (drmtap_helper_grab sets ctx->cur_hdr_eotf). */
-    read_hdr_metadata_direct(ctx, ctx->crtc_id);
-
     return result;
+}
+
+/* The connector HDR metadata for this CRTC, so the conversion path can tone-map.
+ * Used to live at the end of find_primary_plane, which made a plane LOOKUP rewrite
+ * ctx->cur_hdr_eotf as a side effect. That was invisible until the scanout-width
+ * decision started looking up the plane too: a pure geometry query then clobbered
+ * the HDR state, and on the helper path (where these values arrive over the wire,
+ * see drmtap_helper_grab) only the order of two assignments kept the wire values
+ * from being replaced by a direct read that an unprivileged process cannot even
+ * make. Called explicitly by the paths that want it now. */
+static void read_hdr_for_current_crtc(drmtap_ctx *ctx) {
+    read_hdr_metadata_direct(ctx, ctx->crtc_id);
 }
 
 /* ========================================================================= */
@@ -357,7 +363,7 @@ int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
  * because the helper wire has to apply the same stride-covers-width bound. */
 static uint32_t format_min_bpp(uint32_t fourcc);
 
-int validate_fb_dims(uint32_t width, uint32_t height) {
+int drmtap_validate_fb_dims(uint32_t width, uint32_t height) {
     if (width == 0 || height == 0) {
         return -EINVAL;
     }
@@ -666,6 +672,15 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
         return fb_width;
     }
 
+    /* Serve a memoized answer rather than re-reading the plane rect on every frame of
+     * a padded scanout: the decision only changes when this key changes, and the read
+     * costs a plane sweep plus a drmModeGetProperty per property. */
+    if (ctx->sw_cached && ctx->sw_key_crtc == ctx->crtc_id &&
+        ctx->sw_key_hdisplay == hdisplay && ctx->sw_key_fb_width == fb_width &&
+        ctx->sw_key_modifier == modifier) {
+        return ctx->sw_cached_width;
+    }
+
     /* LINEAR and INVALID (unknown layout, handled downstream as linear) are the
      * layouts whose only width-dependent consumer is the OUTPUT: rows are addressed
      * through the stride, so narrowing the reported width is safe. Anything else is a
@@ -720,6 +735,13 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
             break;
         }
     }
+
+    ctx->sw_key_crtc = ctx->crtc_id;
+    ctx->sw_key_hdisplay = hdisplay;
+    ctx->sw_key_fb_width = fb_width;
+    ctx->sw_key_modifier = modifier;
+    ctx->sw_cached_width = out;
+    ctx->sw_cached = 1;
     return out;
 }
 
@@ -739,6 +761,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Step 1: Find the primary plane */
     uint32_t plane_id = find_primary_plane(ctx);
+    read_hdr_for_current_crtc(ctx);
     if (plane_id == 0) {
         drmtap_set_error(ctx, "No active plane found for capture");
         return -ENODEV;
@@ -772,7 +795,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
-    ret = validate_fb_dims(fb2->width, fb2->height);
+    ret = drmtap_validate_fb_dims(fb2->width, fb2->height);
     if (ret == 0) {
         ret = validate_fb_size(fb2->pitches[0], fb2->height);
     }
@@ -892,10 +915,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* The helper validates its own geometry, but it sends it over the wire —
          * re-check before we mmap/size anything from those values. BOTH checks are
          * needed: validate_fb_size bounds stride*height (what we mmap/receive) and
-         * validate_fb_dims bounds width, which the first one does not constrain at
+         * drmtap_validate_fb_dims bounds width, which the first one does not constrain at
          * all. An unbounded width reaches the conversion paths, where every output
          * is sized width*height*4 and that product can wrap. */
-        ret = validate_fb_dims(frame->width, frame->height);
+        ret = drmtap_validate_fb_dims(frame->width, frame->height);
         if (ret == 0) {
             ret = validate_fb_size(frame->stride, frame->height);
         }
@@ -1219,7 +1242,17 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     size_t out_size = (size_t)frame->width * frame->height * 4u;
     void *out = NULL;
     int b = drmtap_ensure_out(ctx, out_size, &out);
-    if (b != 0) return b;
+    if (b != 0) {
+        /* Name it here too. ensure_out only sets a message for the caller-buffer
+         * refusal; an allocation failure for the library-owned buffer would otherwise
+         * return a bare errno and leave drmtap_error() reporting something older. */
+        if (b != -ENOSPC) {
+            drmtap_set_error(ctx, "cannot allocate %zu bytes to reduce a %ux%u frame "
+                             "to XRGB8888: %s", out_size, frame->width, frame->height,
+                             strerror(-b));
+        }
+        return b;
+    }
     uint32_t dst_stride = frame->width * 4u;
     int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
     int ret;
@@ -1712,6 +1745,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     /* Step 1: Find plane on first call only */
     if (!ctx->fast_initialized) {
         ctx->fast_plane_id = find_primary_plane(ctx);
+        read_hdr_for_current_crtc(ctx);
         if (ctx->fast_plane_id == 0) {
             drmtap_set_error(ctx, "No active plane found for capture");
             return -ENODEV;
@@ -1750,7 +1784,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                 if (is_virtio_gpu(ctx)) {
                     ret = virtio_transfer_from_host(ctx,
                             ctx->fast_slots[i].gem_handle,
-                            ctx->fast_slots[i].width,
+                            ctx->fast_slots[i].fb_width,
                             ctx->fast_slots[i].height);
                     if (ret < 0) return ret;
                 } else {
@@ -1795,7 +1829,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
 
         if (is_virtio_gpu(ctx)) {
             ret = virtio_transfer_from_host(ctx, ctx->fast_slots[slot].gem_handle,
-                                             ctx->fast_slots[slot].width,
+                                             ctx->fast_slots[slot].fb_width,
                                              ctx->fast_slots[slot].height);
             if (ret < 0) {
                 drmtap_debug_log(ctx, "fast2: cached transfer failed: %d", ret);
@@ -1878,7 +1912,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
 
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
-    ret = validate_fb_dims(fb2->width, fb2->height);
+    ret = drmtap_validate_fb_dims(fb2->width, fb2->height);
     if (ret == 0) {
         ret = validate_fb_size(fb2->pitches[0], fb2->height);
     }
@@ -2023,9 +2057,12 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].mmap_ptr = mapped;
     ctx->fast_slots[slot].mmap_size = size;
     /* Cache the SCANNED-OUT width, so every later cache hit replays the narrowed
-     * geometry without paying another drmModeGetCrtc on the hot path. The mmap
-     * size below deliberately stays on fb2->pitches[0] * fb2->height: the mapping
-     * is of the whole padded framebuffer. */
+     * geometry without paying another plane query on the hot path, and keep the
+     * framebuffer width beside it for anything that describes the BUFFER rather than
+     * the visible image (a virtio transfer box covers the buffer being made coherent,
+     * not the visible sub-region of it). The mmap size below deliberately stays on
+     * fb2->pitches[0] * fb2->height: the mapping is of the whole padded framebuffer. */
+    ctx->fast_slots[slot].fb_width = fb2->width;
     ctx->fast_slots[slot].width =
         drmtap_scanout_width(ctx, fb2->width, fb2_effective_modifier(fb2));
     ctx->fast_slots[slot].height = fb2->height;
@@ -2111,7 +2148,7 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
         return -EINVAL;
     }
     /* Bound the DIMENSIONS too (see the GetFB2 entry points): desc comes over IPC. */
-    int ret = validate_fb_dims(desc->width, desc->height);
+    int ret = drmtap_validate_fb_dims(desc->width, desc->height);
     if (ret == 0) {
         ret = validate_fb_size(desc->pitches[0], desc->height);
     }

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -484,6 +484,17 @@ static int validate_fb_size(uint32_t stride, uint32_t height) {
     return 0;
 }
 
+/* fb2->modifier is only meaningful when the framebuffer was created with the
+ * DRM_MODE_FB_MODIFIERS flag; with the flag clear the field is undefined (commonly
+ * 0, garbage on some drivers). Trusting a bogus LINEAR on a driver that is actually
+ * tiling corrupts the import, so report INVALID and let the layout be inferred.
+ * Open-coded identically at every frame-filling site; named here because the
+ * scanout-width decision needs the same answer. */
+static uint64_t fb2_effective_modifier(const drmModeFB2 *fb2) {
+    return (fb2->flags & DRM_MODE_FB_MODIFIERS) ? fb2->modifier
+                                                : DRM_FORMAT_MOD_INVALID;
+}
+
 /* Report the width the CRTC actually scans out, not the width of the framebuffer
  * OBJECT. A driver may allocate the scanout fb wider than the mode to satisfy a
  * pitch alignment: Apple's appletbdrm (the Touch Bar strip) drives a 60x2170 mode
@@ -513,11 +524,23 @@ static int validate_fb_size(uint32_t stride, uint32_t height) {
  * only through that one laptop. Reports through *why which branch was taken. */
 uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
                                  uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 drmtap_scanout_why *why) {
+                                 int layout_is_linear, drmtap_scanout_why *why) {
     drmtap_scanout_why w = DRMTAP_SCANOUT_AS_IS;
     uint32_t out = fb_width;
     if (mode_valid && hdisplay > 0 && hdisplay < fb_width) {
-        if (crtc_x == 0 && crtc_y == 0) {
+        if (!layout_is_linear) {
+            /* A TILED scanout must be reported at its framebuffer width, because
+             * the CPU deswizzle derives the tile grid from the width and uses it to
+             * address the SOURCE (deswizzle_*_tiled: tiles_x = ceil(width/tile_w),
+             * src_off = (tile_row * tiles_x + tx) * tile_size). Narrowing the width
+             * by a tile or more would shrink tiles_x and mis-address every tile row
+             * after the first -- a silently mangled image. The visible width and the
+             * width the tiling was laid out for are two different things, one level
+             * down from the mode-vs-framebuffer distinction this function exists for.
+             * No padded TILED scanout has been observed here, so this stays at the
+             * pre-existing behaviour rather than being narrowed on a guess. */
+            w = DRMTAP_SCANOUT_TILED_NOT_NARROWED;
+        } else if (crtc_x == 0 && crtc_y == 0) {
             out = hdisplay;
             w = DRMTAP_SCANOUT_NARROWED;
         } else {
@@ -530,7 +553,8 @@ uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
     return out;
 }
 
-static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
+static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
+                                     uint64_t modifier) {
     if (ctx->crtc_id == 0) {
         return fb_width;
     }
@@ -538,10 +562,16 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
     if (!crtc) {
         return fb_width;
     }
+    /* LINEAR and INVALID (unknown layout, handled downstream as linear) are the
+     * layouts whose only width-dependent consumer is the OUTPUT: rows are addressed
+     * through the stride, so narrowing the reported width is safe. Anything else is
+     * a real tiling. */
+    int linear = (modifier == DRM_FORMAT_MOD_LINEAR ||
+                  modifier == DRM_FORMAT_MOD_INVALID);
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
     uint32_t out = drmtap_scanout_width_of(fb_width, crtc->mode_valid,
                                            crtc->mode.hdisplay, crtc->x,
-                                           crtc->y, &why);
+                                           crtc->y, linear, &why);
     if (why != DRMTAP_SCANOUT_AS_IS && !ctx->logged_scanout_crop) {
         ctx->logged_scanout_crop = 1;
         if (why == DRMTAP_SCANOUT_NARROWED) {
@@ -549,6 +579,13 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
                 "crtc %u scans out %u of the %u-pixel-wide scanout fb "
                 "(pitch padding); reporting %u",
                 ctx->crtc_id, crtc->mode.hdisplay, fb_width, out);
+        } else if (why == DRMTAP_SCANOUT_TILED_NOT_NARROWED) {
+            drmtap_debug_log(ctx,
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb, but the "
+                "layout is tiled (modifier 0x%llx); reporting the whole fb "
+                "(narrowing a tiled width would mis-address the deswizzle)",
+                ctx->crtc_id, crtc->mode.hdisplay, fb_width,
+                (unsigned long long)modifier);
         } else {
             drmtap_debug_log(ctx,
                 "crtc %u viewport is %ux%u at +%d+%d inside a %u-pixel-wide "
@@ -717,7 +754,8 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* Narrow to what the CRTC scans out, exactly as the direct path does.
          * The helper reports the framebuffer, and the padding is the driver's,
          * so it is present on this path too. */
-        frame->width = drmtap_scanout_width(ctx, hresult.wire.width);
+        frame->width = drmtap_scanout_width(ctx, hresult.wire.width,
+                                            hresult.wire.modifier);
         frame->height = hresult.wire.height;
         frame->stride = hresult.wire.stride;
         frame->format = hresult.wire.format;
@@ -876,7 +914,8 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Fill frame info */
     memset(frame, 0, sizeof(*frame));
-    frame->width = drmtap_scanout_width(ctx, fb2->width);
+    frame->width = drmtap_scanout_width(ctx, fb2->width,
+                                        fb2_effective_modifier(fb2));
     frame->height = fb2->height;
     frame->stride = fb2->pitches[0];
     frame->format = fb2->pixel_format;
@@ -1778,7 +1817,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         if (drmtap_gpu_egl_available(ctx)) {
             frame->data = NULL;
             frame->dma_buf_fd = prime_fd;
-            frame->width = drmtap_scanout_width(ctx, fb2->width);
+            frame->width = drmtap_scanout_width(ctx, fb2->width,
+                                                fb2_effective_modifier(fb2));
             frame->height = fb2->height;
             frame->stride = fb2->pitches[0];
             frame->format = fb2->pixel_format;
@@ -1834,7 +1874,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
      * geometry without paying another drmModeGetCrtc on the hot path. The mmap
      * size below deliberately stays on fb2->pitches[0] * fb2->height: the mapping
      * is of the whole padded framebuffer. */
-    ctx->fast_slots[slot].width = drmtap_scanout_width(ctx, fb2->width);
+    ctx->fast_slots[slot].width =
+        drmtap_scanout_width(ctx, fb2->width, fb2_effective_modifier(fb2));
     ctx->fast_slots[slot].height = fb2->height;
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -353,6 +353,60 @@ int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
     return 0;
 }
 
+int validate_fb_dims(uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    /* Bound each dimension BEFORE any multiply, so the product below cannot wrap
+     * (even where size_t is 32-bit): 32768*32768 == 2^30, and *4 == 2^32. -EFBIG,
+     * not -EINVAL: an over-range dimension is the too-large case, and callers
+     * (and tests) already distinguish "oversized geometry" from "malformed". */
+    if (width > DRMTAP_MAX_DIM || height > DRMTAP_MAX_DIM) {
+        return -EFBIG;
+    }
+    if ((size_t)width * height > DRMTAP_MAX_FB_BYTES / 4) {
+        return -EFBIG;
+    }
+    return 0;
+}
+
+int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out) {
+    if (size == 0) {
+        return -EINVAL;
+    }
+    /* Cap the frame itself even when the destination is the caller's: a caller
+     * that happens to own a huge mapping must not be able to unlock a frame
+     * larger than this library is willing to handle, and keeping the cap on both
+     * paths means the caller-supplied case is not the loose one. */
+    if (size > DRMTAP_MAX_FB_BYTES) {
+        return -EFBIG;
+    }
+    if (ctx->user_out) {
+        if (size > ctx->user_out_len) {
+            /* Refuse rather than write short. The caller sized its buffer for a
+             * geometry; if the display changed under it, a partial frame would be
+             * indistinguishable from a good one, and the caller cannot re-mmap what
+             * it does not know went stale. Named through drmtap_error so this is
+             * actionable and not just an errno. */
+            drmtap_set_error(ctx,
+                "output buffer is %zu bytes but this frame needs %zu "
+                "(geometry changed?); call drmtap_set_output_buffer again with a "
+                "buffer of at least that size, or pass NULL to go back to the "
+                "library-owned buffer",
+                ctx->user_out_len, size);
+            return -ENOSPC;
+        }
+        *out = ctx->user_out;
+        return 0;
+    }
+    int ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    if (ret != 0) {
+        return ret;
+    }
+    *out = ctx->deswizzle_buf;
+    return 0;
+}
+
 /* ========================================================================= */
 /* virtio_gpu transfer helpers                                               */
 /* ========================================================================= */
@@ -430,6 +484,84 @@ static int validate_fb_size(uint32_t stride, uint32_t height) {
     return 0;
 }
 
+/* Report the width the CRTC actually scans out, not the width of the framebuffer
+ * OBJECT. A driver may allocate the scanout fb wider than the mode to satisfy a
+ * pitch alignment: Apple's appletbdrm (the Touch Bar strip) drives a 60x2170 mode
+ * from a 64x2170 fb with a 256-byte pitch, and those four columns are padding that
+ * is never scanned out. Reporting the fb width hands the caller an image wider
+ * than the display it asked to capture. In rustdesk that read as "this display
+ * never matched its advertised geometry" -- the display list carries the mode --
+ * so every frame was rejected, the display was demoted to PipeWire, and the
+ * client sat on "waiting for image".
+ *
+ * This only ever SHRINKS, and only the width:
+ *  - An fb NARROWER than the mode means the CRTC is scaling a smaller buffer up
+ *    to its mode. That is a genuinely different image, not padding, so it stays
+ *    reported as it is and the caller can decide.
+ *  - A CRTC whose viewport does not start at the fb origin (crtc->x/y != 0, i.e.
+ *    several heads scanning out of one big framebuffer) needs an OFFSET crop too.
+ *    drmtap_dmabuf_desc has a frozen layout with no crop origin, so such a frame
+ *    is left whole; untested here, hence the one-time log rather than a guess.
+ *
+ * Buffer-size arithmetic must keep using fb2->width and fb2->pitches: the
+ * allocation is still the full padded framebuffer. Only the REPORTED geometry
+ * narrows, and the caller reads rows out of it at the unchanged stride.
+ */
+/* The decision alone, with no DRM fd, so it is unit-testable on any machine:
+ * the padded-scanout case needs hardware that pads (Apple's Touch Bar) to
+ * observe, and a rule this easy to get subtly wrong should not be reachable
+ * only through that one laptop. Reports through *why which branch was taken. */
+uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
+                                 uint32_t hdisplay, int crtc_x, int crtc_y,
+                                 drmtap_scanout_why *why) {
+    drmtap_scanout_why w = DRMTAP_SCANOUT_AS_IS;
+    uint32_t out = fb_width;
+    if (mode_valid && hdisplay > 0 && hdisplay < fb_width) {
+        if (crtc_x == 0 && crtc_y == 0) {
+            out = hdisplay;
+            w = DRMTAP_SCANOUT_NARROWED;
+        } else {
+            w = DRMTAP_SCANOUT_OFFSET_UNSUPPORTED;
+        }
+    }
+    if (why) {
+        *why = w;
+    }
+    return out;
+}
+
+static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
+    if (ctx->crtc_id == 0) {
+        return fb_width;
+    }
+    drmModeCrtc *crtc = drmModeGetCrtc(ctx->drm_fd, ctx->crtc_id);
+    if (!crtc) {
+        return fb_width;
+    }
+    drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
+    uint32_t out = drmtap_scanout_width_of(fb_width, crtc->mode_valid,
+                                           crtc->mode.hdisplay, crtc->x,
+                                           crtc->y, &why);
+    if (why != DRMTAP_SCANOUT_AS_IS && !ctx->logged_scanout_crop) {
+        ctx->logged_scanout_crop = 1;
+        if (why == DRMTAP_SCANOUT_NARROWED) {
+            drmtap_debug_log(ctx,
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb "
+                "(pitch padding); reporting %u",
+                ctx->crtc_id, crtc->mode.hdisplay, fb_width, out);
+        } else {
+            drmtap_debug_log(ctx,
+                "crtc %u viewport is %ux%u at +%d+%d inside a %u-pixel-wide "
+                "scanout fb; reporting the whole fb (the frame descriptor has "
+                "no crop origin)",
+                ctx->crtc_id, crtc->mode.hdisplay, crtc->mode.vdisplay,
+                crtc->x, crtc->y, fb_width);
+        }
+    }
+    drmModeFreeCrtc(crtc);
+    return out;
+}
+
 // Internal capture that populates frame_info
 // If do_mmap is true, also maps the pixel data to frame->data
 static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
@@ -477,7 +609,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                      (const char *)&fb2->pixel_format,
                      (unsigned long)fb2->modifier);
 
-    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
+     * validate_fb_size, and every converted output is sized width*height*4. */
+    ret = validate_fb_dims(fb2->width, fb2->height);
+    if (ret == 0) {
+        ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    }
     if (ret != 0) {
         drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
@@ -577,7 +714,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
         /* Fill frame info from helper metadata */
         memset(frame, 0, sizeof(*frame));
-        frame->width = hresult.wire.width;
+        /* Narrow to what the CRTC scans out, exactly as the direct path does.
+         * The helper reports the framebuffer, and the padding is the driver's,
+         * so it is present on this path too. */
+        frame->width = drmtap_scanout_width(ctx, hresult.wire.width);
         frame->height = hresult.wire.height;
         frame->stride = hresult.wire.stride;
         frame->format = hresult.wire.format;
@@ -587,9 +727,16 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         ctx->cur_hdr_eotf = hresult.wire.hdr_eotf;
         ctx->cur_hdr_max_nits = hresult.wire.hdr_max_nits;
 
-        /* The helper validates its own geometry, but it sends stride/height over
-         * the wire — re-check before we mmap/size anything from those values. */
-        ret = validate_fb_size(frame->stride, frame->height);
+        /* The helper validates its own geometry, but it sends it over the wire —
+         * re-check before we mmap/size anything from those values. BOTH checks are
+         * needed: validate_fb_size bounds stride*height (what we mmap/receive) and
+         * validate_fb_dims bounds width, which the first one does not constrain at
+         * all. An unbounded width reaches the conversion paths, where every output
+         * is sized width*height*4 and that product can wrap. */
+        ret = validate_fb_dims(frame->width, frame->height);
+        if (ret == 0) {
+            ret = validate_fb_size(frame->stride, frame->height);
+        }
         if (ret != 0) {
             drmtap_set_error(ctx, "helper sent invalid geometry %ux%u stride=%u",
                              frame->width, frame->height, frame->stride);
@@ -729,7 +876,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Fill frame info */
     memset(frame, 0, sizeof(*frame));
-    frame->width = fb2->width;
+    frame->width = drmtap_scanout_width(ctx, fb2->width);
     frame->height = fb2->height;
     frame->stride = fb2->pitches[0];
     frame->format = fb2->pixel_format;
@@ -893,8 +1040,8 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     }
 
     size_t out_size = (size_t)frame->width * frame->height * 4u;
-    int b = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                              out_size);
+    void *out = NULL;
+    int b = drmtap_ensure_out(ctx, out_size, &out);
     if (b != 0) return b;
     uint32_t dst_stride = frame->width * 4u;
     int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
@@ -902,23 +1049,23 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
 
     if (is_ar30) {
         if (hdr) {
-            ret = drmtap_tonemap_hdr10(data, ctx->deswizzle_buf,
+            ret = drmtap_tonemap_hdr10(data, out,
                     frame->width, frame->height, frame->stride, dst_stride,
                     fmt, ctx->cur_hdr_max_nits);
         } else {
-            ret = drmtap_convert_format(data, ctx->deswizzle_buf,
+            ret = drmtap_convert_format(data, out,
                     frame->width, frame->height, frame->stride, dst_stride,
                     fmt, DRMTAP_FMT_XR24);
         }
     } else if (is_rgb16) {
         int bgr = (fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
-        ret = drmtap_convert_rgb16(data, ctx->deswizzle_buf,
+        ret = drmtap_convert_rgb16(data, out,
                 frame->width, frame->height, frame->stride, dst_stride,
                 bgr, ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
     } else {
         /* Half-float FP16 (XR4H family): linear-light decode + sRGB re-encode. */
         int bgr = (fmt == DRMTAP_FMT_XB4H || fmt == DRMTAP_FMT_AB4H);
-        ret = drmtap_convert_rgb16f(data, ctx->deswizzle_buf,
+        ret = drmtap_convert_rgb16f(data, out,
                 frame->width, frame->height, frame->stride, dst_stride, bgr);
     }
     if (ret != 0) return ret;
@@ -926,7 +1073,7 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     drmtap_debug_log(ctx, "auto-process: linear %s -> XRGB8888 (%s)",
                      is_ar30 ? "10-bit" : (is_rgb16f ? "FP16" : "16-bit"),
                      hdr ? "HDR tone-mapped" : "SDR");
-    frame->data = ctx->deswizzle_buf;
+    frame->data = out;
     frame->format = DRMTAP_FMT_XR24;
     frame->stride = dst_stride;
     return 1;
@@ -986,24 +1133,6 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
      */
 
 
-    /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
-     * see drmtap_ensure_buf). frame->stride/height are validated at every entry point
-     * (validate_fb_size), so this multiply cannot overflow. NOTE: this does NOT
-     * bound the EGL output, which is always 4-byte RGBA — a sub-4-byte source
-     * (e.g. RG16) can expand past stride*height, so the EGL path caps egl_size
-     * separately below. */
-    size_t size = (size_t)frame->stride * frame->height;
-    int bres = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                                 size);
-    if (bres != 0) {
-        if (bres == -EFBIG) {
-            drmtap_set_error(ctx,
-                "framebuffer too large for deswizzle: %zu bytes (max %zu)",
-                size, (size_t)DRMTAP_MAX_FB_BYTES);
-        }
-        return bres;
-    }
-
     /* --- EGL path: import DMA-BUF, GPU renders to linear RGBA ---
      *
      * This path requires a valid dma_buf_fd, which is only available when
@@ -1028,9 +1157,10 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                                           &egl_data, &egl_size);
         drmtap_debug_log(ctx, "EGL convert: ret=%d data=%p", ret, egl_data);
         if (ret == 0 && egl_data) {
-            /* egl_data IS ctx->deswizzle_buf: the convert reads back into the
-             * ctx-owned grow-once buffer (size-capped inside), so adopting it
-             * is just repointing the frame — no allocation churn. */
+            /* egl_data is whatever drmtap_ensure_out resolved inside the convert:
+             * the caller's output buffer if it set one, otherwise the ctx-owned
+             * grow-once buffer (size-capped inside). Either way adopting it is just
+             * repointing the frame — no allocation churn, and no copy. */
             frame->data = egl_data;
             /* EGL outputs RGBA/BGRA 8-bit */
             frame->format = DRM_FORMAT_XRGB8888;
@@ -1080,14 +1210,33 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         return 0;
     }
 
-    /* --- CPU deswizzle for classic tiling (buffer already allocated above) --- */
+    /* --- CPU deswizzle for classic tiling --- */
+    /* Resolve the destination HERE and not before the EGL attempt above. The CPU
+     * deswizzle keeps the SOURCE stride, so it needs stride*height bytes, which on a
+     * padded scanout is MORE than the width*height*4 the EGL detile produces (a
+     * 60-wide mode on a 256-byte pitch: 555520 vs 520800). Sizing it up front would
+     * refuse a caller-supplied output buffer that the EGL path would have filled
+     * perfectly, and on the EGL path it also allocated a shadow buffer that was then
+     * never used. frame->stride/height are validated at every entry point
+     * (validate_fb_size), so this multiply cannot overflow. */
+    size_t size = (size_t)frame->stride * frame->height;
+    void *out = NULL;
+    int bres = drmtap_ensure_out(ctx, size, &out);
+    if (bres != 0) {
+        if (bres == -EFBIG) {
+            drmtap_set_error(ctx,
+                "framebuffer too large for deswizzle: %zu bytes (max %zu)",
+                size, (size_t)DRMTAP_MAX_FB_BYTES);
+        }
+        return bres;
+    }
     const char *driver = ctx->driver_name;
     if (drmtap_gpu_intel_match(driver) ||
         drmtap_gpu_nvidia_match(driver) ||
         drmtap_gpu_amd_match(driver)) {
         drmtap_debug_log(ctx, "auto-process: %s CPU deswizzle (mod=0x%lx)",
                          driver, (unsigned long)modifier);
-        int ret = drmtap_deswizzle(data, ctx->deswizzle_buf,
+        int ret = drmtap_deswizzle(data, out,
                                    frame->width, frame->height,
                                    frame->stride, frame->stride, modifier,
                                    (size_t)frame->stride * frame->height);
@@ -1109,7 +1258,7 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             return -ENOTSUP;
         }
         if (ret == 0) {
-            frame->data = ctx->deswizzle_buf;
+            frame->data = out;
             drmtap_debug_log(ctx, "auto-process: CPU deswizzled to linear");
 
             /* Reduce 10-bit X/AR30 and X/AB30 to 8-bit XRGB8888. An HDR10 (PQ)
@@ -1126,7 +1275,7 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                         "auto-process: HDR10 AR30 -> tone-map to SDR (peak=%u)",
                         ctx->cur_hdr_max_nits);
                     conv = drmtap_tonemap_hdr10(
-                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        out, out,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
                         frame->format, ctx->cur_hdr_max_nits);
@@ -1134,7 +1283,7 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                     drmtap_debug_log(ctx,
                         "auto-process: SDR 10-bit AR30 -> 8-bit XRGB8888");
                     conv = drmtap_convert_format(
-                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        out, out,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
                         frame->format, DRMTAP_FMT_XR24);
@@ -1538,7 +1687,12 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         return -EACCES;
     }
 
-    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
+     * validate_fb_size, and every converted output is sized width*height*4. */
+    ret = validate_fb_dims(fb2->width, fb2->height);
+    if (ret == 0) {
+        ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    }
     if (ret != 0) {
         drmtap_set_error(ctx, "fast2: rejecting geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
@@ -1624,7 +1778,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         if (drmtap_gpu_egl_available(ctx)) {
             frame->data = NULL;
             frame->dma_buf_fd = prime_fd;
-            frame->width = fb2->width;
+            frame->width = drmtap_scanout_width(ctx, fb2->width);
             frame->height = fb2->height;
             frame->stride = fb2->pitches[0];
             frame->format = fb2->pixel_format;
@@ -1676,7 +1830,11 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].prime_fd = prime_fd;
     ctx->fast_slots[slot].mmap_ptr = mapped;
     ctx->fast_slots[slot].mmap_size = size;
-    ctx->fast_slots[slot].width = fb2->width;
+    /* Cache the SCANNED-OUT width, so every later cache hit replays the narrowed
+     * geometry without paying another drmModeGetCrtc on the hot path. The mmap
+     * size below deliberately stays on fb2->pitches[0] * fb2->height: the mapping
+     * is of the whole padded framebuffer. */
+    ctx->fast_slots[slot].width = drmtap_scanout_width(ctx, fb2->width);
     ctx->fast_slots[slot].height = fb2->height;
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;
@@ -1759,7 +1917,11 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
                          desc->width, desc->num_planes);
         return -EINVAL;
     }
-    int ret = validate_fb_size(desc->pitches[0], desc->height);
+    /* Bound the DIMENSIONS too (see the GetFB2 entry points): desc comes over IPC. */
+    int ret = validate_fb_dims(desc->width, desc->height);
+    if (ret == 0) {
+        ret = validate_fb_size(desc->pitches[0], desc->height);
+    }
     if (ret != 0) {
         drmtap_set_error(ctx, "convert: rejecting geometry %ux%u stride=%u",
                          desc->width, desc->height, desc->pitches[0]);
@@ -1932,11 +2094,11 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
          * bound checked above keeps every per-row read inside the mapping. */
         uint32_t out_stride = desc->width * 4u;
         size_t out_size = (size_t)out_stride * desc->height;
-        ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                                out_size);
+        void *out = NULL;
+        ret = drmtap_ensure_out(ctx, out_size, &out);
         if (ret == 0) {
             const uint8_t *src = mapped;
-            uint8_t *dst = ctx->deswizzle_buf;
+            uint8_t *dst = out;
             if (desc->pitches[0] == out_stride) {
                 memcpy(dst, src, out_size);
             } else {
@@ -1945,7 +2107,7 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
                            src + (size_t)y * desc->pitches[0], out_stride);
                 }
             }
-            frame->data = ctx->deswizzle_buf;
+            frame->data = out;
             frame->stride = out_stride;
         }
     }

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -770,3 +770,27 @@ int drmtap_drm_fd(drmtap_ctx *ctx) {
     }
     return ctx->drm_fd;
 }
+
+int drmtap_set_output_buffer(drmtap_ctx *ctx, void *dst, size_t len) {
+    if (!ctx) {
+        return -EINVAL;
+    }
+    if (!dst) {
+        /* Explicit reset: go back to the library-owned buffer. len is ignored so a
+         * caller can clear with (ctx, NULL, 0) without having to remember a size. */
+        ctx->user_out = NULL;
+        ctx->user_out_len = 0;
+        drmtap_debug_log(ctx, "output buffer cleared; conversions go back to the "
+                              "library-owned buffer");
+        return 0;
+    }
+    if (len == 0) {
+        drmtap_set_error(ctx, "output buffer length is 0 "
+                              "(pass dst=NULL to clear it instead)");
+        return -EINVAL;
+    }
+    ctx->user_out = dst;
+    ctx->user_out_len = len;
+    drmtap_debug_log(ctx, "output buffer set: %p (%zu bytes)", dst, len);
+    return 0;
+}

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -566,6 +566,11 @@ int drmtap_drm_fd(drmtap_ctx *ctx);
  * stride, and a scanout whose pitch is padded wider than the visible width needs
  * that padded size. On a geometry change, re-mmap and call this again.
  *
+ * @p dst must not OVERLAP the frame source. The CPU converters read the scanout and
+ * write the destination with different strides, so pointing this at a mapping of the
+ * very dma-buf being captured would have them read bytes they have already written.
+ * Nothing detects it; before this call no such aliasing was possible.
+ *
  * LIFETIME. You own @p dst. libdrmtap never frees, reallocates or retains it past
  * a frame, and drmtap_close() does not touch it, so it must stay valid and
  * unmapped-from-under-us for as long as it is set and for as long as you hold a

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -30,8 +30,8 @@ extern "C" {
  * project version; the unit tests cross-check all three. The higher-level
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
-#define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 15
+#define DRMTAP_VERSION_MINOR 5
+#define DRMTAP_VERSION_PATCH 0
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -533,6 +533,49 @@ const char *drmtap_gpu_driver(drmtap_ctx *ctx);
  */
 int drmtap_drm_fd(drmtap_ctx *ctx);
 
+/**
+ * @brief Have conversions write into YOUR buffer instead of a library-owned one.
+ *
+ * By default a converted frame lands in a context-owned buffer and
+ * drmtap_frame_info.data points at it, so a caller that must end up with the
+ * pixels somewhere specific (a memfd it already shares with a consumer, a
+ * pre-registered upload buffer) pays a full-frame memcpy per frame. Nothing
+ * requires that: the EGL detile ends in a glReadPixels and the CPU converters
+ * take a destination pointer, and both write wherever they are pointed. Point
+ * them at your memory and the copy disappears.
+ *
+ * Applies to every path that MATERIALIZES pixels, so a caller does not have to
+ * know which one ran: the EGL detile, the CPU deswizzle, the 10/16-bit and HDR
+ * reductions, and the padded-linear repack. It applies on an unprivileged
+ * drmtap_open_render() context too, so the converting half of the split
+ * (drmtap_convert_dmabuf) can write straight into the consumer's buffer.
+ *
+ * It does NOT apply when there is nothing to materialize: a linear 8-bit scanout
+ * needs no conversion, so the frame points directly at the mapped scanout and no
+ * intermediate buffer exists to redirect. Compare drmtap_frame_info.data against
+ * @p dst if your code must know which happened.
+ *
+ * SIZE. A grab that would need more than @p len bytes FAILS with -ENOSPC and
+ * leaves your buffer untouched, rather than writing a short frame you could not
+ * tell from a good one; drmtap_error() then names the exact number of bytes the
+ * frame needed. Size it from the frame you actually get -- stride * height of a
+ * first grab -- not from width * height * 4: the CPU deswizzle keeps the source
+ * stride, and a scanout whose pitch is padded wider than the visible width needs
+ * that padded size. On a geometry change, re-mmap and call this again.
+ *
+ * LIFETIME. You own @p dst. libdrmtap never frees, reallocates or retains it past
+ * a frame, and drmtap_close() does not touch it, so it must stay valid and
+ * unmapped-from-under-us for as long as it is set and for as long as you hold a
+ * frame that points into it. Call with @p dst NULL to go back to the
+ * library-owned buffer (@p len is then ignored).
+ *
+ * @param ctx Capture or render context
+ * @param dst Destination for converted pixels, or NULL to clear
+ * @param len Bytes available at @p dst (must be > 0 when dst is non-NULL)
+ * @return 0 on success, -EINVAL on a NULL ctx or a zero len with a non-NULL dst
+ */
+int drmtap_set_output_buffer(drmtap_ctx *ctx, void *dst, size_t len);
+
 /* ========================================================================= */
 /* Pixel Conversion                                                          */
 /* ========================================================================= */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -550,10 +550,13 @@ int drmtap_drm_fd(drmtap_ctx *ctx);
  * drmtap_open_render() context too, so the converting half of the split
  * (drmtap_convert_dmabuf) can write straight into the consumer's buffer.
  *
- * It does NOT apply when there is nothing to materialize: a linear 8-bit scanout
- * needs no conversion, so the frame points directly at the mapped scanout and no
- * intermediate buffer exists to redirect. Compare drmtap_frame_info.data against
- * @p dst if your code must know which happened.
+ * It does NOT apply when there is nothing to materialize. A linear 8-bit scanout
+ * needs no conversion, so the frame is reported where the pixels already are and no
+ * conversion destination is chosen at all: that is the mapped scanout on the direct
+ * path (already zero-copy, nothing to redirect), and the library receive buffer on
+ * the privileged-helper pixel path (where a caller that must own the memory still
+ * has to copy). Compare drmtap_frame_info.data against @p dst if your code needs to
+ * know which happened.
  *
  * SIZE. A grab that would need more than @p len bytes FAILS with -ENOSPC and
  * leaves your buffer untouched, rather than writing a short frame you could not

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -33,6 +33,10 @@
  * ~126 MB). */
 #define DRMTAP_MAX_FB_BYTES ((size_t)7680 * 4320 * 4)
 
+/* Per-dimension ceiling, used to make width*height wrap-proof before the multiply.
+ * Far above any real scanout; the byte cap above is what actually binds. */
+#define DRMTAP_MAX_DIM 32768u
+
 struct drmtap_ctx {
     /* DRM device */
     int drm_fd;
@@ -106,6 +110,22 @@ struct drmtap_ctx {
      * reported as pages of "CACHE MISS ... cold start" with the real reason only
      * in drmtap_error(), it read as a broken cache (issue #36). */
     int      fast_no_privilege;
+
+    /* Set once the CRTC mode and the scanout framebuffer have been found to
+     * disagree on width, so the reason a frame is narrower than the fb (or is
+     * deliberately NOT narrowed) is stated once per context instead of per
+     * frame. See drmtap_scanout_width() in drm_grab.c. */
+    int      logged_scanout_crop;
+
+    /* Caller-supplied destination for converted pixels (drmtap_set_output_buffer).
+     * NULL means "use the ctx-owned deswizzle_buf". Set once by the caller, who
+     * owns the memory and must keep it alive; libdrmtap never frees or reallocates
+     * it, and refuses a frame that would not fit rather than writing short. Every
+     * path that produces converted pixels resolves its destination through
+     * drmtap_ensure_out(), so the EGL detile and the CPU conversions behave
+     * identically -- a caller must not have to know which one ran. */
+    void   *user_out;
+    size_t  user_out_len;
 
     /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
      * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;
@@ -233,6 +253,25 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
  * 0, -EINVAL (zero size), -EFBIG (over the cap) or -ENOMEM. (drm_grab.c) */
 int drmtap_ensure_buf(void **buf, size_t *cap, size_t size);
 
+/* Resolve where this frame's converted pixels must be written: the caller's
+ * buffer when drmtap_set_output_buffer() set one (checked against `size`, so a
+ * geometry change that no longer fits fails the grab instead of writing short or
+ * overflowing), otherwise the ctx-owned grow-once deswizzle buffer. Returns 0 and
+ * sets *out, or -ENOSPC / whatever drmtap_ensure_buf returns. Every producer of
+ * converted pixels must go through this and must NOT reference
+ * ctx->deswizzle_buf directly, or the caller's buffer would be honoured on some
+ * paths and silently ignored on others. (drm_grab.c) */
+int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out);
+
+/* Reject framebuffer DIMENSIONS that cannot be a real scanout, before anything
+ * multiplies them. validate_fb_size() bounds stride*height, which does NOT bound
+ * width: a wire or IPC peer that sends a huge width with a small stride passes it,
+ * and every converted output is sized width*height*4 -- a product that can wrap
+ * size_t and hand a large write a small destination. Returns 0, -EINVAL (a zero
+ * dimension) or -EFBIG (a dimension over DRMTAP_MAX_DIM, or more than
+ * DRMTAP_MAX_FB_BYTES worth of pixels). (drm_grab.c) */
+int validate_fb_dims(uint32_t width, uint32_t height);
+
 /* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
  * On success *out_data points at ctx->deswizzle_buf (ctx-owned, grow-once,
  * valid until the next convert or drmtap_close) — the caller must NOT free
@@ -269,5 +308,20 @@ int drmtap_convert_rgb16(const void *src, void *dst,
 int drmtap_convert_rgb16f(const void *src, void *dst,
                           uint32_t width, uint32_t height,
                           uint32_t src_stride, uint32_t dst_stride, int bgr);
+
+/* Which branch drmtap_scanout_width_of() took, so the caller can log the reason
+ * once and a test can assert the branch and not just the number. */
+typedef enum {
+    DRMTAP_SCANOUT_AS_IS = 0,          /* fb reported unchanged */
+    DRMTAP_SCANOUT_NARROWED,           /* padded fb narrowed to the mode width */
+    DRMTAP_SCANOUT_OFFSET_UNSUPPORTED, /* CRTC viewport is offset in a bigger fb */
+} drmtap_scanout_why;
+
+/* Decide the width a CRTC actually scans out of a framebuffer that may be wider
+ * than its mode. Pure (no DRM fd) so it is testable without the padding hardware.
+ * See the comment on the definition in drm_grab.c for the rules. */
+uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
+                                 uint32_t hdisplay, int crtc_x, int crtc_y,
+                                 drmtap_scanout_why *why);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -80,6 +80,11 @@ struct drmtap_ctx {
         void    *mmap_ptr;      /* persistent mmap */
         size_t   mmap_size;     /* mapped region size */
         uint32_t width, height, stride;
+        /* The framebuffer OBJECT width, kept alongside `width` (which is the
+         * SCANNED-OUT width and may be narrower on a padded scanout). Transfer and
+         * allocation geometry must use this one: a virtio transfer box describes the
+         * buffer being made coherent, not the visible sub-region of it. */
+        uint32_t fb_width;
         uint32_t format;
         uint64_t modifier;
         /* Full plane layout captured at cache-miss (GetFB2) time. Restaged
@@ -125,6 +130,20 @@ struct drmtap_ctx {
      * atomic commit is ever made, and no other client is affected. Sticky so the
      * cap is requested once rather than per frame. */
     int      atomic_cap_tried;
+
+    /* Memoized scanout-width decision for a PADDED scanout. Reading the plane rect
+     * costs a plane-resource sweep plus one drmModeGetProperty per property, and the
+     * answer only changes when the CRTC, the mode, the framebuffer width or the
+     * layout changes -- not per page flip. Keyed on all four so a modeset invalidates
+     * it (a mode change with an identical fb width and modifier would otherwise be
+     * served the stale answer). The cheap drmModeGetCrtc gate still runs per grab: it
+     * is the ioctl the code always did, and it supplies hdisplay for this key. */
+    uint32_t sw_key_crtc;
+    uint32_t sw_key_hdisplay;
+    uint32_t sw_key_fb_width;
+    uint64_t sw_key_modifier;
+    uint32_t sw_cached_width;
+    int      sw_cached;
 
     /* Caller-supplied destination for converted pixels (drmtap_set_output_buffer).
      * NULL means "use the ctx-owned deswizzle_buf". Set once by the caller, who
@@ -279,13 +298,13 @@ int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out);
  * size_t and hand a large write a small destination. Returns 0, -EINVAL (a zero
  * dimension) or -EFBIG (a dimension over DRMTAP_MAX_DIM, or more than
  * DRMTAP_MAX_FB_BYTES worth of pixels). (drm_grab.c) */
-int validate_fb_dims(uint32_t width, uint32_t height);
+int drmtap_validate_fb_dims(uint32_t width, uint32_t height);
 
 /* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
  * On success *out_data points at the resolved conversion destination: the caller's
- * output buffer when drmtap_set_output_buffer() set one, otherwise
- * ctx->deswizzle_buf (ctx-owned, grow-once,
- * valid until the next convert or drmtap_close) — which the caller must NOT free. fb_id keys the import-once EGLImage cache (0 = no caching); for an
+ * output buffer when drmtap_set_output_buffer() set one, otherwise ctx->deswizzle_buf
+ * (ctx-owned, grow-once, valid until the next convert or drmtap_close).
+ * The caller must NOT free it. fb_id keys the import-once EGLImage cache (0 = no caching); for an
  * fb_id already cached with matching geometry dma_buf_fd may be -1. */
 int drmtap_gpu_egl_available(drmtap_ctx *ctx);
 int drmtap_gpu_egl_convert(drmtap_ctx *ctx,

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -315,6 +315,7 @@ typedef enum {
     DRMTAP_SCANOUT_AS_IS = 0,          /* fb reported unchanged */
     DRMTAP_SCANOUT_NARROWED,           /* padded fb narrowed to the mode width */
     DRMTAP_SCANOUT_OFFSET_UNSUPPORTED, /* CRTC viewport is offset in a bigger fb */
+    DRMTAP_SCANOUT_TILED_NOT_NARROWED, /* padded, but tiled: width feeds tile math */
 } drmtap_scanout_why;
 
 /* Decide the width a CRTC actually scans out of a framebuffer that may be wider
@@ -322,6 +323,6 @@ typedef enum {
  * See the comment on the definition in drm_grab.c for the rules. */
 uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
                                  uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 drmtap_scanout_why *why);
+                                 int layout_is_linear, drmtap_scanout_why *why);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -117,6 +117,15 @@ struct drmtap_ctx {
      * frame. See drmtap_scanout_width() in drm_grab.c. */
     int      logged_scanout_crop;
 
+    /* 1 = DRM_CLIENT_CAP_ATOMIC has been requested on drm_fd. Set LAZILY, only when
+     * a scanout framebuffer turns out to be wider than its mode, because the plane
+     * SRC_W/CRTC_W properties that settle whether that is pitch padding or a scaling
+     * plane are hidden from a non-atomic client (measured: the same plane reports
+     * SRC_W with the cap and nothing without it). Per-fd, needs no privilege, no
+     * atomic commit is ever made, and no other client is affected. Sticky so the
+     * cap is requested once rather than per frame. */
+    int      atomic_cap_tried;
+
     /* Caller-supplied destination for converted pixels (drmtap_set_output_buffer).
      * NULL means "use the ctx-owned deswizzle_buf". Set once by the caller, who
      * owns the memory and must keep it alive; libdrmtap never frees or reallocates
@@ -312,17 +321,31 @@ int drmtap_convert_rgb16f(const void *src, void *dst,
 /* Which branch drmtap_scanout_width_of() took, so the caller can log the reason
  * once and a test can assert the branch and not just the number. */
 typedef enum {
-    DRMTAP_SCANOUT_AS_IS = 0,          /* fb reported unchanged */
-    DRMTAP_SCANOUT_NARROWED,           /* padded fb narrowed to the mode width */
-    DRMTAP_SCANOUT_OFFSET_UNSUPPORTED, /* CRTC viewport is offset in a bigger fb */
-    DRMTAP_SCANOUT_TILED_NOT_NARROWED, /* padded, but tiled: width feeds tile math */
+    DRMTAP_SCANOUT_AS_IS = 0,           /* fb reported unchanged */
+    DRMTAP_SCANOUT_NARROWED,            /* padded fb narrowed to what is scanned out */
+    DRMTAP_SCANOUT_OFFSET_UNSUPPORTED,  /* plane reads from an offset in a bigger fb */
+    DRMTAP_SCANOUT_TILED_NOT_NARROWED,  /* padded, but tiled: width feeds tile math */
+    DRMTAP_SCANOUT_SCALING_NOT_NARROWED,/* plane genuinely scales; fb is all visible */
+    DRMTAP_SCANOUT_NO_PLANE_RECT,       /* plane rect unreadable: cannot tell, so do not */
 } drmtap_scanout_why;
+
+/* The primary plane rectangle: which region of the framebuffer the plane reads and
+ * where it lands on the CRTC. Whole pixels (the kernel SRC_* properties are 16.16
+ * fixed point; the fractional part is dropped by the reader). `valid` is 0 when the
+ * properties could not be read, which is a distinct case from "no scaling" and must
+ * not be treated as one. */
+typedef struct {
+    int      valid;
+    uint32_t src_x, src_y, src_w, src_h;
+    uint32_t crtc_w, crtc_h;
+} drmtap_plane_rect;
 
 /* Decide the width a CRTC actually scans out of a framebuffer that may be wider
  * than its mode. Pure (no DRM fd) so it is testable without the padding hardware.
  * See the comment on the definition in drm_grab.c for the rules. */
-uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
-                                 uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 int layout_is_linear, drmtap_scanout_why *why);
+uint32_t drmtap_scanout_width_of(uint32_t fb_width,
+                                 const drmtap_plane_rect *rect,
+                                 int layout_is_linear,
+                                 drmtap_scanout_why *why);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap_internal.h
@@ -282,9 +282,10 @@ int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out);
 int validate_fb_dims(uint32_t width, uint32_t height);
 
 /* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
- * On success *out_data points at ctx->deswizzle_buf (ctx-owned, grow-once,
- * valid until the next convert or drmtap_close) — the caller must NOT free
- * it. fb_id keys the import-once EGLImage cache (0 = no caching); for an
+ * On success *out_data points at the resolved conversion destination: the caller's
+ * output buffer when drmtap_set_output_buffer() set one, otherwise
+ * ctx->deswizzle_buf (ctx-owned, grow-once,
+ * valid until the next convert or drmtap_close) — which the caller must NOT free. fb_id keys the import-once EGLImage cache (0 = no caching); for an
  * fb_id already cached with matching geometry dma_buf_fd may be -1. */
 int drmtap_gpu_egl_available(drmtap_ctx *ctx);
 int drmtap_gpu_egl_convert(drmtap_ctx *ctx,

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -1067,7 +1067,7 @@ static int egl_convert_impl(drmtap_ctx *ctx,
      * could wrap that product and give a large glReadPixels a small destination --
      * now more than a library-internal concern, since the destination can be the
      * caller's buffer (drmtap_set_output_buffer). */
-    int dim = validate_fb_dims(width, height);
+    int dim = drmtap_validate_fb_dims(width, height);
     if (dim != 0) {
         drmtap_set_error(ctx, "refusing %ux%u scanout: implausible geometry", width,
                          height);
@@ -1295,6 +1295,13 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     void *dst = NULL;
     ret = drmtap_ensure_out(ctx, rgba_size, &dst);
     if (ret != 0) {
+        /* ensure_out names the caller-buffer refusal itself; say something for the
+         * library-owned allocation failure too, or the caller gets a bare errno out
+         * of a detile with drmtap_error() still holding an older message. */
+        if (ret != -ENOSPC) {
+            drmtap_set_error(ctx, "cannot allocate %zu bytes for the %ux%u detile "
+                             "output: %s", rgba_size, width, height, strerror(-ret));
+        }
         goto cleanup;
     }
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, dst);

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -1061,6 +1061,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     if (!ctx || !out_data || !out_size) {
         return -EINVAL;
     }
+    /* Bound the dimensions before anything multiplies them. The readback below is
+     * sized width*height*4, and width does not go through validate_fb_size (which
+     * bounds stride*height only), so an out-of-range width from a wire/IPC peer
+     * could wrap that product and give a large glReadPixels a small destination --
+     * now more than a library-internal concern, since the destination can be the
+     * caller's buffer (drmtap_set_output_buffer). */
+    int dim = validate_fb_dims(width, height);
+    if (dim != 0) {
+        drmtap_set_error(ctx, "refusing %ux%u scanout: implausible geometry", width,
+                         height);
+        return dim;
+    }
 
     /* Lazy-init this thread's EGL context. `state` is the file-scope
      * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
@@ -1272,20 +1284,22 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     /* Ensure GPU rendering is complete before reading back */
     glFinish();
 
-    /* Read linear pixels straight into the ctx-owned grow-once buffer
-     * (drmtap_ensure_buf caps it at DRMTAP_MAX_FB_BYTES), so steady-state
-     * conversion performs zero per-frame allocations. The buffer belongs to
-     * the context and is freed in drmtap_close(); callers must not free it. */
+    /* Read the linear pixels straight into the destination, which is the CALLER's
+     * buffer when it set one (drmtap_set_output_buffer) and otherwise the ctx-owned
+     * grow-once buffer (capped at DRMTAP_MAX_FB_BYTES), so steady-state conversion
+     * performs zero per-frame allocations. glReadPixels writes wherever it is
+     * pointed, so a caller-supplied destination costs nothing here and removes the
+     * caller's whole-frame memcpy. The internal buffer belongs to the context and
+     * is freed in drmtap_close(); callers must not free it. */
     size_t rgba_size = (size_t)width * height * 4;
-    ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                            rgba_size);
+    void *dst = NULL;
+    ret = drmtap_ensure_out(ctx, rgba_size, &dst);
     if (ret != 0) {
         goto cleanup;
     }
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
-                 ctx->deswizzle_buf);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, dst);
     /* A GL error across the render + readback (notably GL_CONTEXT_LOST after a GPU
-     * reset/TDR) means deswizzle_buf holds stale or undefined pixels. Fail closed
+     * reset/TDR) means the destination holds stale or undefined pixels. Fail closed
      * instead of returning them as a valid frame. This glGetError also drains the
      * error state so the next convert starts clean. */
     GLenum gl_err = glGetError();
@@ -1300,7 +1314,7 @@ static int egl_convert_impl(drmtap_ctx *ctx,
      * orientation. The previous CPU flip was compensating for a shader-
      * based X flip (1.0 - v_texcoord.x) that has since been removed. */
 
-    *out_data = ctx->deswizzle_buf;
+    *out_data = dst;
     *out_size = rgba_size;
     ret = 0;
 

--- a/bindings/rust/libdrmtap-sys/src/lib.rs
+++ b/bindings/rust/libdrmtap-sys/src/lib.rs
@@ -158,6 +158,24 @@ extern "C" {
     pub fn drmtap_grab_mapped(ctx: *mut drmtap_ctx, frame: *mut drmtap_frame_info) -> c_int;
     pub fn drmtap_frame_release(ctx: *mut drmtap_ctx, frame: *mut drmtap_frame_info);
 
+    /// Point the conversion paths at a caller-owned buffer instead of a
+    /// library-owned one, so a consumer that must end up with the pixels in its own
+    /// memory does not copy the frame.
+    ///
+    /// `dst` must stay valid for as long as it is set AND for as long as any frame
+    /// pointing into it is held; libdrmtap never frees or reallocates it. Pass a
+    /// null `dst` (with any `len`) to go back to the library buffer. A frame needing
+    /// more than `len` bytes is refused with `-ENOSPC` and `dst` is left untouched,
+    /// so a short frame can never be mistaken for a complete one. Size `dst` from a
+    /// real frame's `stride * height`, not `width * height * 4`: the CPU deswizzle
+    /// keeps the source stride, which on a padded scanout is wider than the visible
+    /// width.
+    pub fn drmtap_set_output_buffer(
+        ctx: *mut drmtap_ctx,
+        dst: *mut c_void,
+        len: usize,
+    ) -> c_int;
+
     // Cursor
     pub fn drmtap_get_cursor(ctx: *mut drmtap_ctx, cursor: *mut drmtap_cursor_info) -> c_int;
     pub fn drmtap_cursor_release(ctx: *mut drmtap_ctx, cursor: *mut drmtap_cursor_info);

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.4.15", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.5.0", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -566,6 +566,11 @@ int drmtap_drm_fd(drmtap_ctx *ctx);
  * stride, and a scanout whose pitch is padded wider than the visible width needs
  * that padded size. On a geometry change, re-mmap and call this again.
  *
+ * @p dst must not OVERLAP the frame source. The CPU converters read the scanout and
+ * write the destination with different strides, so pointing this at a mapping of the
+ * very dma-buf being captured would have them read bytes they have already written.
+ * Nothing detects it; before this call no such aliasing was possible.
+ *
  * LIFETIME. You own @p dst. libdrmtap never frees, reallocates or retains it past
  * a frame, and drmtap_close() does not touch it, so it must stay valid and
  * unmapped-from-under-us for as long as it is set and for as long as you hold a

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -30,8 +30,8 @@ extern "C" {
  * project version; the unit tests cross-check all three. The higher-level
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
-#define DRMTAP_VERSION_MINOR 4
-#define DRMTAP_VERSION_PATCH 15
+#define DRMTAP_VERSION_MINOR 5
+#define DRMTAP_VERSION_PATCH 0
 
 /**
  * @brief Get the library version as a packed integer.

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -533,6 +533,49 @@ const char *drmtap_gpu_driver(drmtap_ctx *ctx);
  */
 int drmtap_drm_fd(drmtap_ctx *ctx);
 
+/**
+ * @brief Have conversions write into YOUR buffer instead of a library-owned one.
+ *
+ * By default a converted frame lands in a context-owned buffer and
+ * drmtap_frame_info.data points at it, so a caller that must end up with the
+ * pixels somewhere specific (a memfd it already shares with a consumer, a
+ * pre-registered upload buffer) pays a full-frame memcpy per frame. Nothing
+ * requires that: the EGL detile ends in a glReadPixels and the CPU converters
+ * take a destination pointer, and both write wherever they are pointed. Point
+ * them at your memory and the copy disappears.
+ *
+ * Applies to every path that MATERIALIZES pixels, so a caller does not have to
+ * know which one ran: the EGL detile, the CPU deswizzle, the 10/16-bit and HDR
+ * reductions, and the padded-linear repack. It applies on an unprivileged
+ * drmtap_open_render() context too, so the converting half of the split
+ * (drmtap_convert_dmabuf) can write straight into the consumer's buffer.
+ *
+ * It does NOT apply when there is nothing to materialize: a linear 8-bit scanout
+ * needs no conversion, so the frame points directly at the mapped scanout and no
+ * intermediate buffer exists to redirect. Compare drmtap_frame_info.data against
+ * @p dst if your code must know which happened.
+ *
+ * SIZE. A grab that would need more than @p len bytes FAILS with -ENOSPC and
+ * leaves your buffer untouched, rather than writing a short frame you could not
+ * tell from a good one; drmtap_error() then names the exact number of bytes the
+ * frame needed. Size it from the frame you actually get -- stride * height of a
+ * first grab -- not from width * height * 4: the CPU deswizzle keeps the source
+ * stride, and a scanout whose pitch is padded wider than the visible width needs
+ * that padded size. On a geometry change, re-mmap and call this again.
+ *
+ * LIFETIME. You own @p dst. libdrmtap never frees, reallocates or retains it past
+ * a frame, and drmtap_close() does not touch it, so it must stay valid and
+ * unmapped-from-under-us for as long as it is set and for as long as you hold a
+ * frame that points into it. Call with @p dst NULL to go back to the
+ * library-owned buffer (@p len is then ignored).
+ *
+ * @param ctx Capture or render context
+ * @param dst Destination for converted pixels, or NULL to clear
+ * @param len Bytes available at @p dst (must be > 0 when dst is non-NULL)
+ * @return 0 on success, -EINVAL on a NULL ctx or a zero len with a non-NULL dst
+ */
+int drmtap_set_output_buffer(drmtap_ctx *ctx, void *dst, size_t len);
+
 /* ========================================================================= */
 /* Pixel Conversion                                                          */
 /* ========================================================================= */

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -550,10 +550,13 @@ int drmtap_drm_fd(drmtap_ctx *ctx);
  * drmtap_open_render() context too, so the converting half of the split
  * (drmtap_convert_dmabuf) can write straight into the consumer's buffer.
  *
- * It does NOT apply when there is nothing to materialize: a linear 8-bit scanout
- * needs no conversion, so the frame points directly at the mapped scanout and no
- * intermediate buffer exists to redirect. Compare drmtap_frame_info.data against
- * @p dst if your code must know which happened.
+ * It does NOT apply when there is nothing to materialize. A linear 8-bit scanout
+ * needs no conversion, so the frame is reported where the pixels already are and no
+ * conversion destination is chosen at all: that is the mapped scanout on the direct
+ * path (already zero-copy, nothing to redirect), and the library receive buffer on
+ * the privileged-helper pixel path (where a caller that must own the memory still
+ * has to copy). Compare drmtap_frame_info.data against @p dst if your code needs to
+ * know which happened.
  *
  * SIZE. A grab that would need more than @p len bytes FAILS with -ENOSPC and
  * leaves your buffer untouched, rather than writing a short frame you could not

--- a/libdrmtap.map
+++ b/libdrmtap.map
@@ -32,6 +32,7 @@
         drmtap_error;
         drmtap_gpu_driver;
         drmtap_drm_fd;
+        drmtap_set_output_buffer;
         drmtap_deswizzle;
         drmtap_convert_format;
         drmtap_tonemap_hdr10;

--- a/meson.build
+++ b/meson.build
@@ -323,6 +323,11 @@ test_hdr = executable('test_hdr',
     dependencies: [libdrmtap_test_dep, m_dep],
     include_directories: lib_include,
 )
+test_outbuf = executable('test_outbuf',
+    'tests/test_outbuf.c',
+    dependencies: [libdrmtap_test_dep, libdrm_dep],
+    include_directories: lib_include,
+)
 test_scanout = executable('test_scanout',
     'tests/test_scanout.c',
     dependencies: [libdrmtap_test_dep, libdrm_dep],
@@ -344,6 +349,7 @@ test_wire = executable('test_wire',
 test('formats', test_formats, suite: 'unit')
 test('deswizzle', test_deswizzle, suite: 'unit')
 test('scanout', test_scanout, suite: 'unit')
+test('outbuf', test_outbuf, suite: 'unit')
 test('helper', test_helper, suite: 'unit')
 test('hdr', test_hdr, suite: 'unit')
 test('wire', test_wire, suite: 'unit')

--- a/meson.build
+++ b/meson.build
@@ -323,6 +323,11 @@ test_hdr = executable('test_hdr',
     dependencies: [libdrmtap_test_dep, m_dep],
     include_directories: lib_include,
 )
+test_scanout = executable('test_scanout',
+    'tests/test_scanout.c',
+    dependencies: [libdrmtap_test_dep, libdrm_dep],
+    include_directories: lib_include,
+)
 test_convert = executable('test_convert',
     'tests/test_convert.c',
     dependencies: [libdrmtap_test_dep],
@@ -338,6 +343,7 @@ test_wire = executable('test_wire',
 # Unit tests (no hardware needed)
 test('formats', test_formats, suite: 'unit')
 test('deswizzle', test_deswizzle, suite: 'unit')
+test('scanout', test_scanout, suite: 'unit')
 test('helper', test_helper, suite: 'unit')
 test('hdr', test_hdr, suite: 'unit')
 test('wire', test_wire, suite: 'unit')

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.4.15',
+    version: '0.5.0',
     license: 'MIT',
     default_options: [
         'c_std=c11',

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -353,6 +353,10 @@ int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
     return 0;
 }
 
+/* Defined further down with the convert path that first needed it. Declared here
+ * because the helper wire has to apply the same stride-covers-width bound. */
+static uint32_t format_min_bpp(uint32_t fourcc);
+
 int validate_fb_dims(uint32_t width, uint32_t height) {
     if (width == 0 || height == 0) {
         return -EINVAL;
@@ -894,6 +898,20 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         ret = validate_fb_dims(frame->width, frame->height);
         if (ret == 0) {
             ret = validate_fb_size(frame->stride, frame->height);
+        }
+        if (ret == 0 &&
+            (uint64_t)frame->width * format_min_bpp(frame->format) > frame->stride) {
+            /* THIRD bound, and the one the other two do not imply: the stride must
+             * actually cover width pixels. Without it a wire frame claiming
+             * width*bpp > stride reaches the per-pixel CPU converters, which read
+             * y*stride + width*bpp per row with no size argument, and the last rows
+             * run off the end of the receive buffer. drmtap_convert_dmabuf applies
+             * the same check to its IPC descriptor; the two trust boundaries must be
+             * bounded alike, and this one was not. */
+            drmtap_set_error(ctx, "helper sent stride %u too small for width %u "
+                             "(fourcc %.4s)", frame->stride, frame->width,
+                             (const char *)&frame->format);
+            ret = -EINVAL;
         }
         if (ret != 0) {
             drmtap_set_error(ctx, "helper sent invalid geometry %ux%u stride=%u",
@@ -1956,8 +1974,10 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
             if (pr == 0 && !frame->data) {
                 pr = -EIO;
             }
-            /* gpu_auto_process EGL-read the fd back into ctx->deswizzle_buf, so the
-             * fd and handle are no longer needed and nothing is cached for fb_id. */
+            /* gpu_auto_process EGL-read the fd back into the conversion destination
+             * (the caller's output buffer if one was set, otherwise the ctx-owned
+             * one), so the fd and handle are no longer needed and nothing is cached
+             * for fb_id. */
             close(prime_fd);
             frame->dma_buf_fd = -1;  /* prime_fd is closed; don't hand back a stale fd */
             drmtap_gem_close(ctx, fb2->handles[0]);
@@ -2167,7 +2187,8 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
                                      desc->modifier, desc->fb_id,
                                      &egl_data, &egl_size);
         if (ret == 0 && egl_data) {
-            frame->data = egl_data;   /* ctx-owned grow-once buffer */
+            frame->data = egl_data;   /* the resolved destination: caller's output
+                                       * buffer if set, else the ctx-owned one */
             frame->format = DRM_FORMAT_XRGB8888;
             frame->stride = desc->width * 4;
             frame->modifier = DRM_FORMAT_MOD_LINEAR;

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -518,41 +518,132 @@ static uint64_t fb2_effective_modifier(const drmModeFB2 *fb2) {
  * allocation is still the full padded framebuffer. Only the REPORTED geometry
  * narrows, and the caller reads rows out of it at the unchanged stride.
  */
-/* The decision alone, with no DRM fd, so it is unit-testable on any machine:
- * the padded-scanout case needs hardware that pads (Apple's Touch Bar) to
- * observe, and a rule this easy to get subtly wrong should not be reachable
- * only through that one laptop. Reports through *why which branch was taken. */
-uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
-                                 uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 int layout_is_linear, drmtap_scanout_why *why) {
+/* The decision alone, with no DRM fd, so it is unit-testable on any machine: the
+ * padded-scanout case needs hardware that pads (Apple's Touch Bar) to observe, and a
+ * rule this easy to get subtly wrong should not be reachable only through that one
+ * laptop. Reports through *why which branch was taken.
+ *
+ * Only ever SHRINKS, and only the width. Every branch that declines to narrow is a
+ * case where the framebuffer width IS the right answer:
+ *
+ *  - TILED. The CPU deswizzle derives its tile grid from the width and uses it to
+ *    address the SOURCE (deswizzle_nvidia_x_tiled: tiles_x = ceil(width/tile_w), then
+ *    src_off = (tile_row * tiles_x + tx) * tile_size; it ignores src_stride). A width
+ *    short by a tile or more mis-addresses every tile row after the first and silently
+ *    mangles the image. The visible width and the width the tiling was laid out for
+ *    are different quantities. No padded tiled scanout has been observed here, so it
+ *    is left alone rather than narrowed on a guess.
+ *  - SCALING. A plane whose SRC rect is larger than its CRTC rect is genuinely
+ *    downscaling: the whole framebuffer IS being displayed, just smaller. Narrowing
+ *    would hand the caller the left part of the image and call it the whole screen.
+ *    A framebuffer wider than the mode looks IDENTICAL to pitch padding until the
+ *    plane rect is read, which is the entire reason this needs the plane and cannot
+ *    be decided from the mode alone. Note a pitch test cannot substitute:
+ *    fb_width * bpp == pitches[0] holds for a 3840-wide downscaled framebuffer just
+ *    as it does for the padded 64-wide one.
+ *  - OFFSET. The plane reads from a non-zero SRC_X/SRC_Y, i.e. several heads out of
+ *    one big framebuffer. That needs an offset crop, and drmtap_dmabuf_desc has a
+ *    frozen layout with nowhere to carry a crop origin. No hardware here has it.
+ *  - UNREADABLE. Without the plane rect the padding and the downscale are
+ *    indistinguishable, so the safe answer is the pre-existing behaviour.
+ */
+uint32_t drmtap_scanout_width_of(uint32_t fb_width,
+                                 const drmtap_plane_rect *rect,
+                                 int layout_is_linear,
+                                 drmtap_scanout_why *why) {
     drmtap_scanout_why w = DRMTAP_SCANOUT_AS_IS;
     uint32_t out = fb_width;
-    if (mode_valid && hdisplay > 0 && hdisplay < fb_width) {
-        if (!layout_is_linear) {
-            /* A TILED scanout must be reported at its framebuffer width, because
-             * the CPU deswizzle derives the tile grid from the width and uses it to
-             * address the SOURCE (deswizzle_*_tiled: tiles_x = ceil(width/tile_w),
-             * src_off = (tile_row * tiles_x + tx) * tile_size). Narrowing the width
-             * by a tile or more would shrink tiles_x and mis-address every tile row
-             * after the first -- a silently mangled image. The visible width and the
-             * width the tiling was laid out for are two different things, one level
-             * down from the mode-vs-framebuffer distinction this function exists for.
-             * No padded TILED scanout has been observed here, so this stays at the
-             * pre-existing behaviour rather than being narrowed on a guess. */
+
+    if (!layout_is_linear) {
+        if (rect && rect->valid && rect->src_w > 0 && rect->src_w < fb_width) {
             w = DRMTAP_SCANOUT_TILED_NOT_NARROWED;
-        } else if (crtc_x == 0 && crtc_y == 0) {
-            out = hdisplay;
-            w = DRMTAP_SCANOUT_NARROWED;
-        } else {
-            w = DRMTAP_SCANOUT_OFFSET_UNSUPPORTED;
         }
+    } else if (!rect || !rect->valid) {
+        /* Only worth reporting when there was something to decide. */
+        w = (fb_width > 0) ? DRMTAP_SCANOUT_NO_PLANE_RECT : DRMTAP_SCANOUT_AS_IS;
+    } else if (rect->src_x != 0 || rect->src_y != 0) {
+        w = DRMTAP_SCANOUT_OFFSET_UNSUPPORTED;
+    } else if (rect->src_w != rect->crtc_w || rect->src_h != rect->crtc_h) {
+        w = DRMTAP_SCANOUT_SCALING_NOT_NARROWED;
+    } else if (rect->src_w > 0 && rect->src_w < fb_width) {
+        out = rect->src_w;
+        w = DRMTAP_SCANOUT_NARROWED;
     }
+
     if (why) {
         *why = w;
     }
     return out;
 }
 
+/* Read the primary plane rectangle of the context's CRTC. The SRC and CRTC properties
+ * are atomic-only: a client that has not asked for DRM_CLIENT_CAP_ATOMIC is shown
+ * none of them (measured on appletbdrm -- SRC_W present with the cap, absent without).
+ * The cap is therefore requested here, LAZILY: this function is only called once a
+ * framebuffer has turned out to be wider than its mode, so the common case never
+ * touches it. It is a per-fd flag, needs no privilege and no DRM master, no atomic
+ * commit is ever issued, and no other client is affected. rect->valid stays 0 when
+ * anything is missing, which the decision above treats as "cannot tell". */
+static void read_primary_plane_rect(drmtap_ctx *ctx, drmtap_plane_rect *rect) {
+    memset(rect, 0, sizeof(*rect));
+
+    if (!ctx->atomic_cap_tried) {
+        ctx->atomic_cap_tried = 1;
+        if (drmSetClientCap(ctx->drm_fd, DRM_CLIENT_CAP_ATOMIC, 1) != 0) {
+            drmtap_debug_log(ctx,
+                "DRM_CLIENT_CAP_ATOMIC refused (%s); plane SRC_W is unreadable, so a "
+                "padded scanout will be reported at its framebuffer width",
+                strerror(errno));
+        }
+    }
+
+    uint32_t plane_id = find_primary_plane(ctx);
+    if (plane_id == 0) {
+        return;
+    }
+    drmModeObjectProperties *props =
+        drmModeObjectGetProperties(ctx->drm_fd, plane_id, DRM_MODE_OBJECT_PLANE);
+    if (!props) {
+        return;
+    }
+
+    /* 16.16 fixed point for the SRC rect, plain pixels for the CRTC rect. Fractions are dropped:
+     * a fractional source rect is a scaling plane, and the equality test below
+     * already declines to narrow that. */
+    int got = 0;
+    for (uint32_t i = 0; i < props->count_props; i++) {
+        drmModePropertyRes *p = drmModeGetProperty(ctx->drm_fd, props->props[i]);
+        if (!p) {
+            continue;
+        }
+        uint64_t v = props->prop_values[i];
+        if      (!strcmp(p->name, "SRC_X"))  { rect->src_x  = (uint32_t)(v >> 16); got |= 1; }
+        else if (!strcmp(p->name, "SRC_Y"))  { rect->src_y  = (uint32_t)(v >> 16); got |= 2; }
+        else if (!strcmp(p->name, "SRC_W"))  { rect->src_w  = (uint32_t)(v >> 16); got |= 4; }
+        else if (!strcmp(p->name, "SRC_H"))  { rect->src_h  = (uint32_t)(v >> 16); got |= 8; }
+        else if (!strcmp(p->name, "CRTC_W")) { rect->crtc_w = (uint32_t)v;         got |= 16; }
+        else if (!strcmp(p->name, "CRTC_H")) { rect->crtc_h = (uint32_t)v;         got |= 32; }
+        drmModeFreeProperty(p);
+    }
+    drmModeFreeObjectProperties(props);
+    rect->valid = (got == 63);
+}
+
+/* Report the width the CRTC actually scans out, not the width of the framebuffer
+ * OBJECT. A driver may allocate the scanout fb wider than the mode to satisfy a pitch
+ * alignment: Apple's appletbdrm (the Touch Bar strip) drives a 60x2170 mode from a
+ * 64x2170 fb with a 256-byte pitch, and its primary plane reads SRC_W=60 -- those four
+ * columns are padding that is never scanned out. Reporting the fb width hands the
+ * caller an image wider than the display it asked to capture. In rustdesk that read as
+ * "this display never matched its advertised geometry" -- the display list carries the
+ * mode -- so every frame was rejected, the display was demoted to PipeWire, and the
+ * client sat on "waiting for image".
+ *
+ * The mode is only the CHEAP GATE here: it says "worth looking closer", and the plane
+ * rect decides. Buffer-size arithmetic must keep using fb2->width and fb2->pitches:
+ * the allocation is still the full padded framebuffer. Only the REPORTED geometry
+ * narrows, and the caller reads rows out of it at the unchanged stride.
+ */
 static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
                                      uint64_t modifier) {
     if (ctx->crtc_id == 0) {
@@ -562,40 +653,69 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
     if (!crtc) {
         return fb_width;
     }
+    int worth_looking = crtc->mode_valid && crtc->mode.hdisplay > 0 &&
+                        crtc->mode.hdisplay < fb_width;
+    uint32_t hdisplay = crtc->mode.hdisplay;
+    uint32_t vdisplay = crtc->mode.vdisplay;
+    drmModeFreeCrtc(crtc);
+    if (!worth_looking) {
+        return fb_width;
+    }
+
     /* LINEAR and INVALID (unknown layout, handled downstream as linear) are the
      * layouts whose only width-dependent consumer is the OUTPUT: rows are addressed
-     * through the stride, so narrowing the reported width is safe. Anything else is
-     * a real tiling. */
+     * through the stride, so narrowing the reported width is safe. Anything else is a
+     * real tiling -- see drmtap_scanout_width_of. */
     int linear = (modifier == DRM_FORMAT_MOD_LINEAR ||
                   modifier == DRM_FORMAT_MOD_INVALID);
+
+    drmtap_plane_rect rect;
+    read_primary_plane_rect(ctx, &rect);
+
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
-    uint32_t out = drmtap_scanout_width_of(fb_width, crtc->mode_valid,
-                                           crtc->mode.hdisplay, crtc->x,
-                                           crtc->y, linear, &why);
+    uint32_t out = drmtap_scanout_width_of(fb_width, &rect, linear, &why);
+
     if (why != DRMTAP_SCANOUT_AS_IS && !ctx->logged_scanout_crop) {
         ctx->logged_scanout_crop = 1;
-        if (why == DRMTAP_SCANOUT_NARROWED) {
+        switch (why) {
+        case DRMTAP_SCANOUT_NARROWED:
             drmtap_debug_log(ctx,
-                "crtc %u scans out %u of the %u-pixel-wide scanout fb "
-                "(pitch padding); reporting %u",
-                ctx->crtc_id, crtc->mode.hdisplay, fb_width, out);
-        } else if (why == DRMTAP_SCANOUT_TILED_NOT_NARROWED) {
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb (pitch padding; "
+                "plane reads SRC %ux%u 1:1); reporting %u",
+                ctx->crtc_id, rect.src_w, fb_width, rect.src_w, rect.src_h, out);
+            break;
+        case DRMTAP_SCANOUT_TILED_NOT_NARROWED:
             drmtap_debug_log(ctx,
-                "crtc %u scans out %u of the %u-pixel-wide scanout fb, but the "
-                "layout is tiled (modifier 0x%llx); reporting the whole fb "
-                "(narrowing a tiled width would mis-address the deswizzle)",
-                ctx->crtc_id, crtc->mode.hdisplay, fb_width,
-                (unsigned long long)modifier);
-        } else {
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb, but the layout "
+                "is tiled (modifier 0x%llx); reporting the whole fb (narrowing a tiled "
+                "width would mis-address the deswizzle)",
+                ctx->crtc_id, hdisplay, fb_width, (unsigned long long)modifier);
+            break;
+        case DRMTAP_SCANOUT_SCALING_NOT_NARROWED:
             drmtap_debug_log(ctx,
-                "crtc %u viewport is %ux%u at +%d+%d inside a %u-pixel-wide "
-                "scanout fb; reporting the whole fb (the frame descriptor has "
-                "no crop origin)",
-                ctx->crtc_id, crtc->mode.hdisplay, crtc->mode.vdisplay,
-                crtc->x, crtc->y, fb_width);
+                "crtc %u plane scales %ux%u -> %ux%u, so the whole %u-pixel-wide fb is "
+                "displayed; reporting it unchanged (this is not pitch padding)",
+                ctx->crtc_id, rect.src_w, rect.src_h, rect.crtc_w, rect.crtc_h,
+                fb_width);
+            break;
+        case DRMTAP_SCANOUT_OFFSET_UNSUPPORTED:
+            drmtap_debug_log(ctx,
+                "crtc %u plane reads from +%u+%u inside a %u-pixel-wide scanout fb "
+                "(mode %ux%u); reporting the whole fb (the frame descriptor has no "
+                "crop origin)",
+                ctx->crtc_id, rect.src_x, rect.src_y, fb_width, hdisplay, vdisplay);
+            break;
+        case DRMTAP_SCANOUT_NO_PLANE_RECT:
+            drmtap_debug_log(ctx,
+                "crtc %u has a %u-pixel-wide scanout fb for a %u-pixel mode, but the "
+                "plane SRC rect is unreadable, so pitch padding cannot be told from a "
+                "scaling plane; reporting the whole fb",
+                ctx->crtc_id, fb_width, hdisplay);
+            break;
+        case DRMTAP_SCANOUT_AS_IS:
+            break;
         }
     }
-    drmModeFreeCrtc(crtc);
     return out;
 }
 

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -1345,6 +1345,18 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             drmtap_debug_log(ctx, "auto-process: EGL detiled to linear XRGB8888");
             return 0;
         }
+        /* An output buffer too small for the frame is a CALLER CONFIGURATION error,
+         * not an EGL failure, and must not fall through. The CPU deswizzle below
+         * needs stride*height, which is never LESS than the width*height*4 the detile
+         * just refused, so it can only fail again -- and it would replace the
+         * actionable -ENOSPC (whose message names the exact size required) with
+         * whatever the CPU path reports. On a scanout with no CPU mapping, which is
+         * precisely the hardware that depends on this detile, that is -ENOTSUP and a
+         * message about a missing mapping: the caller is told its GPU is unsupported
+         * when in truth its buffer was a few bytes short. */
+        if (ret == -ENOSPC) {
+            return ret;
+        }
         drmtap_debug_log(ctx, "auto-process: EGL failed (%d), trying CPU", ret);
     }
 #endif

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -353,6 +353,60 @@ int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
     return 0;
 }
 
+int validate_fb_dims(uint32_t width, uint32_t height) {
+    if (width == 0 || height == 0) {
+        return -EINVAL;
+    }
+    /* Bound each dimension BEFORE any multiply, so the product below cannot wrap
+     * (even where size_t is 32-bit): 32768*32768 == 2^30, and *4 == 2^32. -EFBIG,
+     * not -EINVAL: an over-range dimension is the too-large case, and callers
+     * (and tests) already distinguish "oversized geometry" from "malformed". */
+    if (width > DRMTAP_MAX_DIM || height > DRMTAP_MAX_DIM) {
+        return -EFBIG;
+    }
+    if ((size_t)width * height > DRMTAP_MAX_FB_BYTES / 4) {
+        return -EFBIG;
+    }
+    return 0;
+}
+
+int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out) {
+    if (size == 0) {
+        return -EINVAL;
+    }
+    /* Cap the frame itself even when the destination is the caller's: a caller
+     * that happens to own a huge mapping must not be able to unlock a frame
+     * larger than this library is willing to handle, and keeping the cap on both
+     * paths means the caller-supplied case is not the loose one. */
+    if (size > DRMTAP_MAX_FB_BYTES) {
+        return -EFBIG;
+    }
+    if (ctx->user_out) {
+        if (size > ctx->user_out_len) {
+            /* Refuse rather than write short. The caller sized its buffer for a
+             * geometry; if the display changed under it, a partial frame would be
+             * indistinguishable from a good one, and the caller cannot re-mmap what
+             * it does not know went stale. Named through drmtap_error so this is
+             * actionable and not just an errno. */
+            drmtap_set_error(ctx,
+                "output buffer is %zu bytes but this frame needs %zu "
+                "(geometry changed?); call drmtap_set_output_buffer again with a "
+                "buffer of at least that size, or pass NULL to go back to the "
+                "library-owned buffer",
+                ctx->user_out_len, size);
+            return -ENOSPC;
+        }
+        *out = ctx->user_out;
+        return 0;
+    }
+    int ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size, size);
+    if (ret != 0) {
+        return ret;
+    }
+    *out = ctx->deswizzle_buf;
+    return 0;
+}
+
 /* ========================================================================= */
 /* virtio_gpu transfer helpers                                               */
 /* ========================================================================= */
@@ -555,7 +609,12 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                      (const char *)&fb2->pixel_format,
                      (unsigned long)fb2->modifier);
 
-    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
+     * validate_fb_size, and every converted output is sized width*height*4. */
+    ret = validate_fb_dims(fb2->width, fb2->height);
+    if (ret == 0) {
+        ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    }
     if (ret != 0) {
         drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
@@ -668,9 +727,16 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         ctx->cur_hdr_eotf = hresult.wire.hdr_eotf;
         ctx->cur_hdr_max_nits = hresult.wire.hdr_max_nits;
 
-        /* The helper validates its own geometry, but it sends stride/height over
-         * the wire — re-check before we mmap/size anything from those values. */
-        ret = validate_fb_size(frame->stride, frame->height);
+        /* The helper validates its own geometry, but it sends it over the wire —
+         * re-check before we mmap/size anything from those values. BOTH checks are
+         * needed: validate_fb_size bounds stride*height (what we mmap/receive) and
+         * validate_fb_dims bounds width, which the first one does not constrain at
+         * all. An unbounded width reaches the conversion paths, where every output
+         * is sized width*height*4 and that product can wrap. */
+        ret = validate_fb_dims(frame->width, frame->height);
+        if (ret == 0) {
+            ret = validate_fb_size(frame->stride, frame->height);
+        }
         if (ret != 0) {
             drmtap_set_error(ctx, "helper sent invalid geometry %ux%u stride=%u",
                              frame->width, frame->height, frame->stride);
@@ -974,8 +1040,8 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     }
 
     size_t out_size = (size_t)frame->width * frame->height * 4u;
-    int b = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                              out_size);
+    void *out = NULL;
+    int b = drmtap_ensure_out(ctx, out_size, &out);
     if (b != 0) return b;
     uint32_t dst_stride = frame->width * 4u;
     int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
@@ -983,23 +1049,23 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
 
     if (is_ar30) {
         if (hdr) {
-            ret = drmtap_tonemap_hdr10(data, ctx->deswizzle_buf,
+            ret = drmtap_tonemap_hdr10(data, out,
                     frame->width, frame->height, frame->stride, dst_stride,
                     fmt, ctx->cur_hdr_max_nits);
         } else {
-            ret = drmtap_convert_format(data, ctx->deswizzle_buf,
+            ret = drmtap_convert_format(data, out,
                     frame->width, frame->height, frame->stride, dst_stride,
                     fmt, DRMTAP_FMT_XR24);
         }
     } else if (is_rgb16) {
         int bgr = (fmt == DRMTAP_FMT_XB48 || fmt == DRMTAP_FMT_AB48);
-        ret = drmtap_convert_rgb16(data, ctx->deswizzle_buf,
+        ret = drmtap_convert_rgb16(data, out,
                 frame->width, frame->height, frame->stride, dst_stride,
                 bgr, ctx->cur_hdr_eotf, ctx->cur_hdr_max_nits);
     } else {
         /* Half-float FP16 (XR4H family): linear-light decode + sRGB re-encode. */
         int bgr = (fmt == DRMTAP_FMT_XB4H || fmt == DRMTAP_FMT_AB4H);
-        ret = drmtap_convert_rgb16f(data, ctx->deswizzle_buf,
+        ret = drmtap_convert_rgb16f(data, out,
                 frame->width, frame->height, frame->stride, dst_stride, bgr);
     }
     if (ret != 0) return ret;
@@ -1007,7 +1073,7 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     drmtap_debug_log(ctx, "auto-process: linear %s -> XRGB8888 (%s)",
                      is_ar30 ? "10-bit" : (is_rgb16f ? "FP16" : "16-bit"),
                      hdr ? "HDR tone-mapped" : "SDR");
-    frame->data = ctx->deswizzle_buf;
+    frame->data = out;
     frame->format = DRMTAP_FMT_XR24;
     frame->stride = dst_stride;
     return 1;
@@ -1067,24 +1133,6 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
      */
 
 
-    /* Ensure the CPU-deswizzle shadow buffer is allocated (grow-once, capped —
-     * see drmtap_ensure_buf). frame->stride/height are validated at every entry point
-     * (validate_fb_size), so this multiply cannot overflow. NOTE: this does NOT
-     * bound the EGL output, which is always 4-byte RGBA — a sub-4-byte source
-     * (e.g. RG16) can expand past stride*height, so the EGL path caps egl_size
-     * separately below. */
-    size_t size = (size_t)frame->stride * frame->height;
-    int bres = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                                 size);
-    if (bres != 0) {
-        if (bres == -EFBIG) {
-            drmtap_set_error(ctx,
-                "framebuffer too large for deswizzle: %zu bytes (max %zu)",
-                size, (size_t)DRMTAP_MAX_FB_BYTES);
-        }
-        return bres;
-    }
-
     /* --- EGL path: import DMA-BUF, GPU renders to linear RGBA ---
      *
      * This path requires a valid dma_buf_fd, which is only available when
@@ -1109,9 +1157,10 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                                           &egl_data, &egl_size);
         drmtap_debug_log(ctx, "EGL convert: ret=%d data=%p", ret, egl_data);
         if (ret == 0 && egl_data) {
-            /* egl_data IS ctx->deswizzle_buf: the convert reads back into the
-             * ctx-owned grow-once buffer (size-capped inside), so adopting it
-             * is just repointing the frame — no allocation churn. */
+            /* egl_data is whatever drmtap_ensure_out resolved inside the convert:
+             * the caller's output buffer if it set one, otherwise the ctx-owned
+             * grow-once buffer (size-capped inside). Either way adopting it is just
+             * repointing the frame — no allocation churn, and no copy. */
             frame->data = egl_data;
             /* EGL outputs RGBA/BGRA 8-bit */
             frame->format = DRM_FORMAT_XRGB8888;
@@ -1161,14 +1210,33 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
         return 0;
     }
 
-    /* --- CPU deswizzle for classic tiling (buffer already allocated above) --- */
+    /* --- CPU deswizzle for classic tiling --- */
+    /* Resolve the destination HERE and not before the EGL attempt above. The CPU
+     * deswizzle keeps the SOURCE stride, so it needs stride*height bytes, which on a
+     * padded scanout is MORE than the width*height*4 the EGL detile produces (a
+     * 60-wide mode on a 256-byte pitch: 555520 vs 520800). Sizing it up front would
+     * refuse a caller-supplied output buffer that the EGL path would have filled
+     * perfectly, and on the EGL path it also allocated a shadow buffer that was then
+     * never used. frame->stride/height are validated at every entry point
+     * (validate_fb_size), so this multiply cannot overflow. */
+    size_t size = (size_t)frame->stride * frame->height;
+    void *out = NULL;
+    int bres = drmtap_ensure_out(ctx, size, &out);
+    if (bres != 0) {
+        if (bres == -EFBIG) {
+            drmtap_set_error(ctx,
+                "framebuffer too large for deswizzle: %zu bytes (max %zu)",
+                size, (size_t)DRMTAP_MAX_FB_BYTES);
+        }
+        return bres;
+    }
     const char *driver = ctx->driver_name;
     if (drmtap_gpu_intel_match(driver) ||
         drmtap_gpu_nvidia_match(driver) ||
         drmtap_gpu_amd_match(driver)) {
         drmtap_debug_log(ctx, "auto-process: %s CPU deswizzle (mod=0x%lx)",
                          driver, (unsigned long)modifier);
-        int ret = drmtap_deswizzle(data, ctx->deswizzle_buf,
+        int ret = drmtap_deswizzle(data, out,
                                    frame->width, frame->height,
                                    frame->stride, frame->stride, modifier,
                                    (size_t)frame->stride * frame->height);
@@ -1190,7 +1258,7 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
             return -ENOTSUP;
         }
         if (ret == 0) {
-            frame->data = ctx->deswizzle_buf;
+            frame->data = out;
             drmtap_debug_log(ctx, "auto-process: CPU deswizzled to linear");
 
             /* Reduce 10-bit X/AR30 and X/AB30 to 8-bit XRGB8888. An HDR10 (PQ)
@@ -1207,7 +1275,7 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                         "auto-process: HDR10 AR30 -> tone-map to SDR (peak=%u)",
                         ctx->cur_hdr_max_nits);
                     conv = drmtap_tonemap_hdr10(
-                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        out, out,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
                         frame->format, ctx->cur_hdr_max_nits);
@@ -1215,7 +1283,7 @@ static int gpu_auto_process(drmtap_ctx *ctx, void *data,
                     drmtap_debug_log(ctx,
                         "auto-process: SDR 10-bit AR30 -> 8-bit XRGB8888");
                     conv = drmtap_convert_format(
-                        ctx->deswizzle_buf, ctx->deswizzle_buf,
+                        out, out,
                         frame->width, frame->height,
                         frame->stride, frame->stride,
                         frame->format, DRMTAP_FMT_XR24);
@@ -1619,7 +1687,12 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         return -EACCES;
     }
 
-    ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
+     * validate_fb_size, and every converted output is sized width*height*4. */
+    ret = validate_fb_dims(fb2->width, fb2->height);
+    if (ret == 0) {
+        ret = validate_fb_size(fb2->pitches[0], fb2->height);
+    }
     if (ret != 0) {
         drmtap_set_error(ctx, "fast2: rejecting geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
@@ -1844,7 +1917,11 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
                          desc->width, desc->num_planes);
         return -EINVAL;
     }
-    int ret = validate_fb_size(desc->pitches[0], desc->height);
+    /* Bound the DIMENSIONS too (see the GetFB2 entry points): desc comes over IPC. */
+    int ret = validate_fb_dims(desc->width, desc->height);
+    if (ret == 0) {
+        ret = validate_fb_size(desc->pitches[0], desc->height);
+    }
     if (ret != 0) {
         drmtap_set_error(ctx, "convert: rejecting geometry %ux%u stride=%u",
                          desc->width, desc->height, desc->pitches[0]);
@@ -2017,11 +2094,11 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
          * bound checked above keeps every per-row read inside the mapping. */
         uint32_t out_stride = desc->width * 4u;
         size_t out_size = (size_t)out_stride * desc->height;
-        ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                                out_size);
+        void *out = NULL;
+        ret = drmtap_ensure_out(ctx, out_size, &out);
         if (ret == 0) {
             const uint8_t *src = mapped;
-            uint8_t *dst = ctx->deswizzle_buf;
+            uint8_t *dst = out;
             if (desc->pitches[0] == out_stride) {
                 memcpy(dst, src, out_size);
             } else {
@@ -2030,7 +2107,7 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
                            src + (size_t)y * desc->pitches[0], out_stride);
                 }
             }
-            frame->data = ctx->deswizzle_buf;
+            frame->data = out;
             frame->stride = out_stride;
         }
     }

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -430,6 +430,84 @@ static int validate_fb_size(uint32_t stride, uint32_t height) {
     return 0;
 }
 
+/* Report the width the CRTC actually scans out, not the width of the framebuffer
+ * OBJECT. A driver may allocate the scanout fb wider than the mode to satisfy a
+ * pitch alignment: Apple's appletbdrm (the Touch Bar strip) drives a 60x2170 mode
+ * from a 64x2170 fb with a 256-byte pitch, and those four columns are padding that
+ * is never scanned out. Reporting the fb width hands the caller an image wider
+ * than the display it asked to capture. In rustdesk that read as "this display
+ * never matched its advertised geometry" -- the display list carries the mode --
+ * so every frame was rejected, the display was demoted to PipeWire, and the
+ * client sat on "waiting for image".
+ *
+ * This only ever SHRINKS, and only the width:
+ *  - An fb NARROWER than the mode means the CRTC is scaling a smaller buffer up
+ *    to its mode. That is a genuinely different image, not padding, so it stays
+ *    reported as it is and the caller can decide.
+ *  - A CRTC whose viewport does not start at the fb origin (crtc->x/y != 0, i.e.
+ *    several heads scanning out of one big framebuffer) needs an OFFSET crop too.
+ *    drmtap_dmabuf_desc has a frozen layout with no crop origin, so such a frame
+ *    is left whole; untested here, hence the one-time log rather than a guess.
+ *
+ * Buffer-size arithmetic must keep using fb2->width and fb2->pitches: the
+ * allocation is still the full padded framebuffer. Only the REPORTED geometry
+ * narrows, and the caller reads rows out of it at the unchanged stride.
+ */
+/* The decision alone, with no DRM fd, so it is unit-testable on any machine:
+ * the padded-scanout case needs hardware that pads (Apple's Touch Bar) to
+ * observe, and a rule this easy to get subtly wrong should not be reachable
+ * only through that one laptop. Reports through *why which branch was taken. */
+uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
+                                 uint32_t hdisplay, int crtc_x, int crtc_y,
+                                 drmtap_scanout_why *why) {
+    drmtap_scanout_why w = DRMTAP_SCANOUT_AS_IS;
+    uint32_t out = fb_width;
+    if (mode_valid && hdisplay > 0 && hdisplay < fb_width) {
+        if (crtc_x == 0 && crtc_y == 0) {
+            out = hdisplay;
+            w = DRMTAP_SCANOUT_NARROWED;
+        } else {
+            w = DRMTAP_SCANOUT_OFFSET_UNSUPPORTED;
+        }
+    }
+    if (why) {
+        *why = w;
+    }
+    return out;
+}
+
+static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
+    if (ctx->crtc_id == 0) {
+        return fb_width;
+    }
+    drmModeCrtc *crtc = drmModeGetCrtc(ctx->drm_fd, ctx->crtc_id);
+    if (!crtc) {
+        return fb_width;
+    }
+    drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
+    uint32_t out = drmtap_scanout_width_of(fb_width, crtc->mode_valid,
+                                           crtc->mode.hdisplay, crtc->x,
+                                           crtc->y, &why);
+    if (why != DRMTAP_SCANOUT_AS_IS && !ctx->logged_scanout_crop) {
+        ctx->logged_scanout_crop = 1;
+        if (why == DRMTAP_SCANOUT_NARROWED) {
+            drmtap_debug_log(ctx,
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb "
+                "(pitch padding); reporting %u",
+                ctx->crtc_id, crtc->mode.hdisplay, fb_width, out);
+        } else {
+            drmtap_debug_log(ctx,
+                "crtc %u viewport is %ux%u at +%d+%d inside a %u-pixel-wide "
+                "scanout fb; reporting the whole fb (the frame descriptor has "
+                "no crop origin)",
+                ctx->crtc_id, crtc->mode.hdisplay, crtc->mode.vdisplay,
+                crtc->x, crtc->y, fb_width);
+        }
+    }
+    drmModeFreeCrtc(crtc);
+    return out;
+}
+
 // Internal capture that populates frame_info
 // If do_mmap is true, also maps the pixel data to frame->data
 static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
@@ -577,7 +655,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
         /* Fill frame info from helper metadata */
         memset(frame, 0, sizeof(*frame));
-        frame->width = hresult.wire.width;
+        /* Narrow to what the CRTC scans out, exactly as the direct path does.
+         * The helper reports the framebuffer, and the padding is the driver's,
+         * so it is present on this path too. */
+        frame->width = drmtap_scanout_width(ctx, hresult.wire.width);
         frame->height = hresult.wire.height;
         frame->stride = hresult.wire.stride;
         frame->format = hresult.wire.format;
@@ -729,7 +810,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Fill frame info */
     memset(frame, 0, sizeof(*frame));
-    frame->width = fb2->width;
+    frame->width = drmtap_scanout_width(ctx, fb2->width);
     frame->height = fb2->height;
     frame->stride = fb2->pitches[0];
     frame->format = fb2->pixel_format;
@@ -1624,7 +1705,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         if (drmtap_gpu_egl_available(ctx)) {
             frame->data = NULL;
             frame->dma_buf_fd = prime_fd;
-            frame->width = fb2->width;
+            frame->width = drmtap_scanout_width(ctx, fb2->width);
             frame->height = fb2->height;
             frame->stride = fb2->pitches[0];
             frame->format = fb2->pixel_format;
@@ -1676,7 +1757,11 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].prime_fd = prime_fd;
     ctx->fast_slots[slot].mmap_ptr = mapped;
     ctx->fast_slots[slot].mmap_size = size;
-    ctx->fast_slots[slot].width = fb2->width;
+    /* Cache the SCANNED-OUT width, so every later cache hit replays the narrowed
+     * geometry without paying another drmModeGetCrtc on the hot path. The mmap
+     * size below deliberately stays on fb2->pitches[0] * fb2->height: the mapping
+     * is of the whole padded framebuffer. */
+    ctx->fast_slots[slot].width = drmtap_scanout_width(ctx, fb2->width);
     ctx->fast_slots[slot].height = fb2->height;
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -299,13 +299,19 @@ static uint32_t find_primary_plane(drmtap_ctx *ctx) {
     }
 
     drmModeFreePlaneResources(planes);
-
-    /* Direct (no-helper) path: read the connector HDR metadata for this CRTC so
-     * the conversion path can tone-map. In helper mode this comes over the wire
-     * instead (drmtap_helper_grab sets ctx->cur_hdr_eotf). */
-    read_hdr_metadata_direct(ctx, ctx->crtc_id);
-
     return result;
+}
+
+/* The connector HDR metadata for this CRTC, so the conversion path can tone-map.
+ * Used to live at the end of find_primary_plane, which made a plane LOOKUP rewrite
+ * ctx->cur_hdr_eotf as a side effect. That was invisible until the scanout-width
+ * decision started looking up the plane too: a pure geometry query then clobbered
+ * the HDR state, and on the helper path (where these values arrive over the wire,
+ * see drmtap_helper_grab) only the order of two assignments kept the wire values
+ * from being replaced by a direct read that an unprivileged process cannot even
+ * make. Called explicitly by the paths that want it now. */
+static void read_hdr_for_current_crtc(drmtap_ctx *ctx) {
+    read_hdr_metadata_direct(ctx, ctx->crtc_id);
 }
 
 /* ========================================================================= */
@@ -357,7 +363,7 @@ int drmtap_ensure_buf(void **buf, size_t *cap, size_t size) {
  * because the helper wire has to apply the same stride-covers-width bound. */
 static uint32_t format_min_bpp(uint32_t fourcc);
 
-int validate_fb_dims(uint32_t width, uint32_t height) {
+int drmtap_validate_fb_dims(uint32_t width, uint32_t height) {
     if (width == 0 || height == 0) {
         return -EINVAL;
     }
@@ -666,6 +672,15 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
         return fb_width;
     }
 
+    /* Serve a memoized answer rather than re-reading the plane rect on every frame of
+     * a padded scanout: the decision only changes when this key changes, and the read
+     * costs a plane sweep plus a drmModeGetProperty per property. */
+    if (ctx->sw_cached && ctx->sw_key_crtc == ctx->crtc_id &&
+        ctx->sw_key_hdisplay == hdisplay && ctx->sw_key_fb_width == fb_width &&
+        ctx->sw_key_modifier == modifier) {
+        return ctx->sw_cached_width;
+    }
+
     /* LINEAR and INVALID (unknown layout, handled downstream as linear) are the
      * layouts whose only width-dependent consumer is the OUTPUT: rows are addressed
      * through the stride, so narrowing the reported width is safe. Anything else is a
@@ -720,6 +735,13 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
             break;
         }
     }
+
+    ctx->sw_key_crtc = ctx->crtc_id;
+    ctx->sw_key_hdisplay = hdisplay;
+    ctx->sw_key_fb_width = fb_width;
+    ctx->sw_key_modifier = modifier;
+    ctx->sw_cached_width = out;
+    ctx->sw_cached = 1;
     return out;
 }
 
@@ -739,6 +761,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Step 1: Find the primary plane */
     uint32_t plane_id = find_primary_plane(ctx);
+    read_hdr_for_current_crtc(ctx);
     if (plane_id == 0) {
         drmtap_set_error(ctx, "No active plane found for capture");
         return -ENODEV;
@@ -772,7 +795,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
-    ret = validate_fb_dims(fb2->width, fb2->height);
+    ret = drmtap_validate_fb_dims(fb2->width, fb2->height);
     if (ret == 0) {
         ret = validate_fb_size(fb2->pitches[0], fb2->height);
     }
@@ -892,10 +915,10 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* The helper validates its own geometry, but it sends it over the wire —
          * re-check before we mmap/size anything from those values. BOTH checks are
          * needed: validate_fb_size bounds stride*height (what we mmap/receive) and
-         * validate_fb_dims bounds width, which the first one does not constrain at
+         * drmtap_validate_fb_dims bounds width, which the first one does not constrain at
          * all. An unbounded width reaches the conversion paths, where every output
          * is sized width*height*4 and that product can wrap. */
-        ret = validate_fb_dims(frame->width, frame->height);
+        ret = drmtap_validate_fb_dims(frame->width, frame->height);
         if (ret == 0) {
             ret = validate_fb_size(frame->stride, frame->height);
         }
@@ -1219,7 +1242,17 @@ static int reduce_linear_to_xrgb8888(drmtap_ctx *ctx, void *data,
     size_t out_size = (size_t)frame->width * frame->height * 4u;
     void *out = NULL;
     int b = drmtap_ensure_out(ctx, out_size, &out);
-    if (b != 0) return b;
+    if (b != 0) {
+        /* Name it here too. ensure_out only sets a message for the caller-buffer
+         * refusal; an allocation failure for the library-owned buffer would otherwise
+         * return a bare errno and leave drmtap_error() reporting something older. */
+        if (b != -ENOSPC) {
+            drmtap_set_error(ctx, "cannot allocate %zu bytes to reduce a %ux%u frame "
+                             "to XRGB8888: %s", out_size, frame->width, frame->height,
+                             strerror(-b));
+        }
+        return b;
+    }
     uint32_t dst_stride = frame->width * 4u;
     int hdr = (ctx->cur_hdr_eotf == DRMTAP_EOTF_PQ);
     int ret;
@@ -1712,6 +1745,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     /* Step 1: Find plane on first call only */
     if (!ctx->fast_initialized) {
         ctx->fast_plane_id = find_primary_plane(ctx);
+        read_hdr_for_current_crtc(ctx);
         if (ctx->fast_plane_id == 0) {
             drmtap_set_error(ctx, "No active plane found for capture");
             return -ENODEV;
@@ -1750,7 +1784,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                 if (is_virtio_gpu(ctx)) {
                     ret = virtio_transfer_from_host(ctx,
                             ctx->fast_slots[i].gem_handle,
-                            ctx->fast_slots[i].width,
+                            ctx->fast_slots[i].fb_width,
                             ctx->fast_slots[i].height);
                     if (ret < 0) return ret;
                 } else {
@@ -1795,7 +1829,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
 
         if (is_virtio_gpu(ctx)) {
             ret = virtio_transfer_from_host(ctx, ctx->fast_slots[slot].gem_handle,
-                                             ctx->fast_slots[slot].width,
+                                             ctx->fast_slots[slot].fb_width,
                                              ctx->fast_slots[slot].height);
             if (ret < 0) {
                 drmtap_debug_log(ctx, "fast2: cached transfer failed: %d", ret);
@@ -1878,7 +1912,7 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
 
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
-    ret = validate_fb_dims(fb2->width, fb2->height);
+    ret = drmtap_validate_fb_dims(fb2->width, fb2->height);
     if (ret == 0) {
         ret = validate_fb_size(fb2->pitches[0], fb2->height);
     }
@@ -2023,9 +2057,12 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
     ctx->fast_slots[slot].mmap_ptr = mapped;
     ctx->fast_slots[slot].mmap_size = size;
     /* Cache the SCANNED-OUT width, so every later cache hit replays the narrowed
-     * geometry without paying another drmModeGetCrtc on the hot path. The mmap
-     * size below deliberately stays on fb2->pitches[0] * fb2->height: the mapping
-     * is of the whole padded framebuffer. */
+     * geometry without paying another plane query on the hot path, and keep the
+     * framebuffer width beside it for anything that describes the BUFFER rather than
+     * the visible image (a virtio transfer box covers the buffer being made coherent,
+     * not the visible sub-region of it). The mmap size below deliberately stays on
+     * fb2->pitches[0] * fb2->height: the mapping is of the whole padded framebuffer. */
+    ctx->fast_slots[slot].fb_width = fb2->width;
     ctx->fast_slots[slot].width =
         drmtap_scanout_width(ctx, fb2->width, fb2_effective_modifier(fb2));
     ctx->fast_slots[slot].height = fb2->height;
@@ -2111,7 +2148,7 @@ int drmtap_convert_dmabuf(drmtap_ctx *ctx, const drmtap_dmabuf_desc *desc,
         return -EINVAL;
     }
     /* Bound the DIMENSIONS too (see the GetFB2 entry points): desc comes over IPC. */
-    int ret = validate_fb_dims(desc->width, desc->height);
+    int ret = drmtap_validate_fb_dims(desc->width, desc->height);
     if (ret == 0) {
         ret = validate_fb_size(desc->pitches[0], desc->height);
     }

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -484,6 +484,17 @@ static int validate_fb_size(uint32_t stride, uint32_t height) {
     return 0;
 }
 
+/* fb2->modifier is only meaningful when the framebuffer was created with the
+ * DRM_MODE_FB_MODIFIERS flag; with the flag clear the field is undefined (commonly
+ * 0, garbage on some drivers). Trusting a bogus LINEAR on a driver that is actually
+ * tiling corrupts the import, so report INVALID and let the layout be inferred.
+ * Open-coded identically at every frame-filling site; named here because the
+ * scanout-width decision needs the same answer. */
+static uint64_t fb2_effective_modifier(const drmModeFB2 *fb2) {
+    return (fb2->flags & DRM_MODE_FB_MODIFIERS) ? fb2->modifier
+                                                : DRM_FORMAT_MOD_INVALID;
+}
+
 /* Report the width the CRTC actually scans out, not the width of the framebuffer
  * OBJECT. A driver may allocate the scanout fb wider than the mode to satisfy a
  * pitch alignment: Apple's appletbdrm (the Touch Bar strip) drives a 60x2170 mode
@@ -513,11 +524,23 @@ static int validate_fb_size(uint32_t stride, uint32_t height) {
  * only through that one laptop. Reports through *why which branch was taken. */
 uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
                                  uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 drmtap_scanout_why *why) {
+                                 int layout_is_linear, drmtap_scanout_why *why) {
     drmtap_scanout_why w = DRMTAP_SCANOUT_AS_IS;
     uint32_t out = fb_width;
     if (mode_valid && hdisplay > 0 && hdisplay < fb_width) {
-        if (crtc_x == 0 && crtc_y == 0) {
+        if (!layout_is_linear) {
+            /* A TILED scanout must be reported at its framebuffer width, because
+             * the CPU deswizzle derives the tile grid from the width and uses it to
+             * address the SOURCE (deswizzle_*_tiled: tiles_x = ceil(width/tile_w),
+             * src_off = (tile_row * tiles_x + tx) * tile_size). Narrowing the width
+             * by a tile or more would shrink tiles_x and mis-address every tile row
+             * after the first -- a silently mangled image. The visible width and the
+             * width the tiling was laid out for are two different things, one level
+             * down from the mode-vs-framebuffer distinction this function exists for.
+             * No padded TILED scanout has been observed here, so this stays at the
+             * pre-existing behaviour rather than being narrowed on a guess. */
+            w = DRMTAP_SCANOUT_TILED_NOT_NARROWED;
+        } else if (crtc_x == 0 && crtc_y == 0) {
             out = hdisplay;
             w = DRMTAP_SCANOUT_NARROWED;
         } else {
@@ -530,7 +553,8 @@ uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
     return out;
 }
 
-static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
+static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
+                                     uint64_t modifier) {
     if (ctx->crtc_id == 0) {
         return fb_width;
     }
@@ -538,10 +562,16 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
     if (!crtc) {
         return fb_width;
     }
+    /* LINEAR and INVALID (unknown layout, handled downstream as linear) are the
+     * layouts whose only width-dependent consumer is the OUTPUT: rows are addressed
+     * through the stride, so narrowing the reported width is safe. Anything else is
+     * a real tiling. */
+    int linear = (modifier == DRM_FORMAT_MOD_LINEAR ||
+                  modifier == DRM_FORMAT_MOD_INVALID);
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
     uint32_t out = drmtap_scanout_width_of(fb_width, crtc->mode_valid,
                                            crtc->mode.hdisplay, crtc->x,
-                                           crtc->y, &why);
+                                           crtc->y, linear, &why);
     if (why != DRMTAP_SCANOUT_AS_IS && !ctx->logged_scanout_crop) {
         ctx->logged_scanout_crop = 1;
         if (why == DRMTAP_SCANOUT_NARROWED) {
@@ -549,6 +579,13 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width) {
                 "crtc %u scans out %u of the %u-pixel-wide scanout fb "
                 "(pitch padding); reporting %u",
                 ctx->crtc_id, crtc->mode.hdisplay, fb_width, out);
+        } else if (why == DRMTAP_SCANOUT_TILED_NOT_NARROWED) {
+            drmtap_debug_log(ctx,
+                "crtc %u scans out %u of the %u-pixel-wide scanout fb, but the "
+                "layout is tiled (modifier 0x%llx); reporting the whole fb "
+                "(narrowing a tiled width would mis-address the deswizzle)",
+                ctx->crtc_id, crtc->mode.hdisplay, fb_width,
+                (unsigned long long)modifier);
         } else {
             drmtap_debug_log(ctx,
                 "crtc %u viewport is %ux%u at +%d+%d inside a %u-pixel-wide "
@@ -717,7 +754,8 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         /* Narrow to what the CRTC scans out, exactly as the direct path does.
          * The helper reports the framebuffer, and the padding is the driver's,
          * so it is present on this path too. */
-        frame->width = drmtap_scanout_width(ctx, hresult.wire.width);
+        frame->width = drmtap_scanout_width(ctx, hresult.wire.width,
+                                            hresult.wire.modifier);
         frame->height = hresult.wire.height;
         frame->stride = hresult.wire.stride;
         frame->format = hresult.wire.format;
@@ -876,7 +914,8 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
 
     /* Fill frame info */
     memset(frame, 0, sizeof(*frame));
-    frame->width = drmtap_scanout_width(ctx, fb2->width);
+    frame->width = drmtap_scanout_width(ctx, fb2->width,
+                                        fb2_effective_modifier(fb2));
     frame->height = fb2->height;
     frame->stride = fb2->pitches[0];
     frame->format = fb2->pixel_format;
@@ -1778,7 +1817,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
         if (drmtap_gpu_egl_available(ctx)) {
             frame->data = NULL;
             frame->dma_buf_fd = prime_fd;
-            frame->width = drmtap_scanout_width(ctx, fb2->width);
+            frame->width = drmtap_scanout_width(ctx, fb2->width,
+                                                fb2_effective_modifier(fb2));
             frame->height = fb2->height;
             frame->stride = fb2->pitches[0];
             frame->format = fb2->pixel_format;
@@ -1834,7 +1874,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
      * geometry without paying another drmModeGetCrtc on the hot path. The mmap
      * size below deliberately stays on fb2->pitches[0] * fb2->height: the mapping
      * is of the whole padded framebuffer. */
-    ctx->fast_slots[slot].width = drmtap_scanout_width(ctx, fb2->width);
+    ctx->fast_slots[slot].width =
+        drmtap_scanout_width(ctx, fb2->width, fb2_effective_modifier(fb2));
     ctx->fast_slots[slot].height = fb2->height;
     ctx->fast_slots[slot].stride = fb2->pitches[0];
     ctx->fast_slots[slot].format = fb2->pixel_format;

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -770,3 +770,27 @@ int drmtap_drm_fd(drmtap_ctx *ctx) {
     }
     return ctx->drm_fd;
 }
+
+int drmtap_set_output_buffer(drmtap_ctx *ctx, void *dst, size_t len) {
+    if (!ctx) {
+        return -EINVAL;
+    }
+    if (!dst) {
+        /* Explicit reset: go back to the library-owned buffer. len is ignored so a
+         * caller can clear with (ctx, NULL, 0) without having to remember a size. */
+        ctx->user_out = NULL;
+        ctx->user_out_len = 0;
+        drmtap_debug_log(ctx, "output buffer cleared; conversions go back to the "
+                              "library-owned buffer");
+        return 0;
+    }
+    if (len == 0) {
+        drmtap_set_error(ctx, "output buffer length is 0 "
+                              "(pass dst=NULL to clear it instead)");
+        return -EINVAL;
+    }
+    ctx->user_out = dst;
+    ctx->user_out_len = len;
+    drmtap_debug_log(ctx, "output buffer set: %p (%zu bytes)", dst, len);
+    return 0;
+}

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -107,6 +107,12 @@ struct drmtap_ctx {
      * in drmtap_error(), it read as a broken cache (issue #36). */
     int      fast_no_privilege;
 
+    /* Set once the CRTC mode and the scanout framebuffer have been found to
+     * disagree on width, so the reason a frame is narrower than the fb (or is
+     * deliberately NOT narrowed) is stated once per context instead of per
+     * frame. See drmtap_scanout_width() in drm_grab.c. */
+    int      logged_scanout_crop;
+
     /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
      * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;
      * freed in drmtap_close(). */
@@ -269,5 +275,20 @@ int drmtap_convert_rgb16(const void *src, void *dst,
 int drmtap_convert_rgb16f(const void *src, void *dst,
                           uint32_t width, uint32_t height,
                           uint32_t src_stride, uint32_t dst_stride, int bgr);
+
+/* Which branch drmtap_scanout_width_of() took, so the caller can log the reason
+ * once and a test can assert the branch and not just the number. */
+typedef enum {
+    DRMTAP_SCANOUT_AS_IS = 0,          /* fb reported unchanged */
+    DRMTAP_SCANOUT_NARROWED,           /* padded fb narrowed to the mode width */
+    DRMTAP_SCANOUT_OFFSET_UNSUPPORTED, /* CRTC viewport is offset in a bigger fb */
+} drmtap_scanout_why;
+
+/* Decide the width a CRTC actually scans out of a framebuffer that may be wider
+ * than its mode. Pure (no DRM fd) so it is testable without the padding hardware.
+ * See the comment on the definition in drm_grab.c for the rules. */
+uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
+                                 uint32_t hdisplay, int crtc_x, int crtc_y,
+                                 drmtap_scanout_why *why);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -80,6 +80,11 @@ struct drmtap_ctx {
         void    *mmap_ptr;      /* persistent mmap */
         size_t   mmap_size;     /* mapped region size */
         uint32_t width, height, stride;
+        /* The framebuffer OBJECT width, kept alongside `width` (which is the
+         * SCANNED-OUT width and may be narrower on a padded scanout). Transfer and
+         * allocation geometry must use this one: a virtio transfer box describes the
+         * buffer being made coherent, not the visible sub-region of it. */
+        uint32_t fb_width;
         uint32_t format;
         uint64_t modifier;
         /* Full plane layout captured at cache-miss (GetFB2) time. Restaged
@@ -125,6 +130,20 @@ struct drmtap_ctx {
      * atomic commit is ever made, and no other client is affected. Sticky so the
      * cap is requested once rather than per frame. */
     int      atomic_cap_tried;
+
+    /* Memoized scanout-width decision for a PADDED scanout. Reading the plane rect
+     * costs a plane-resource sweep plus one drmModeGetProperty per property, and the
+     * answer only changes when the CRTC, the mode, the framebuffer width or the
+     * layout changes -- not per page flip. Keyed on all four so a modeset invalidates
+     * it (a mode change with an identical fb width and modifier would otherwise be
+     * served the stale answer). The cheap drmModeGetCrtc gate still runs per grab: it
+     * is the ioctl the code always did, and it supplies hdisplay for this key. */
+    uint32_t sw_key_crtc;
+    uint32_t sw_key_hdisplay;
+    uint32_t sw_key_fb_width;
+    uint64_t sw_key_modifier;
+    uint32_t sw_cached_width;
+    int      sw_cached;
 
     /* Caller-supplied destination for converted pixels (drmtap_set_output_buffer).
      * NULL means "use the ctx-owned deswizzle_buf". Set once by the caller, who
@@ -279,13 +298,13 @@ int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out);
  * size_t and hand a large write a small destination. Returns 0, -EINVAL (a zero
  * dimension) or -EFBIG (a dimension over DRMTAP_MAX_DIM, or more than
  * DRMTAP_MAX_FB_BYTES worth of pixels). (drm_grab.c) */
-int validate_fb_dims(uint32_t width, uint32_t height);
+int drmtap_validate_fb_dims(uint32_t width, uint32_t height);
 
 /* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
  * On success *out_data points at the resolved conversion destination: the caller's
- * output buffer when drmtap_set_output_buffer() set one, otherwise
- * ctx->deswizzle_buf (ctx-owned, grow-once,
- * valid until the next convert or drmtap_close) — which the caller must NOT free. fb_id keys the import-once EGLImage cache (0 = no caching); for an
+ * output buffer when drmtap_set_output_buffer() set one, otherwise ctx->deswizzle_buf
+ * (ctx-owned, grow-once, valid until the next convert or drmtap_close).
+ * The caller must NOT free it. fb_id keys the import-once EGLImage cache (0 = no caching); for an
  * fb_id already cached with matching geometry dma_buf_fd may be -1. */
 int drmtap_gpu_egl_available(drmtap_ctx *ctx);
 int drmtap_gpu_egl_convert(drmtap_ctx *ctx,

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -315,6 +315,7 @@ typedef enum {
     DRMTAP_SCANOUT_AS_IS = 0,          /* fb reported unchanged */
     DRMTAP_SCANOUT_NARROWED,           /* padded fb narrowed to the mode width */
     DRMTAP_SCANOUT_OFFSET_UNSUPPORTED, /* CRTC viewport is offset in a bigger fb */
+    DRMTAP_SCANOUT_TILED_NOT_NARROWED, /* padded, but tiled: width feeds tile math */
 } drmtap_scanout_why;
 
 /* Decide the width a CRTC actually scans out of a framebuffer that may be wider
@@ -322,6 +323,6 @@ typedef enum {
  * See the comment on the definition in drm_grab.c for the rules. */
 uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
                                  uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 drmtap_scanout_why *why);
+                                 int layout_is_linear, drmtap_scanout_why *why);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -117,6 +117,15 @@ struct drmtap_ctx {
      * frame. See drmtap_scanout_width() in drm_grab.c. */
     int      logged_scanout_crop;
 
+    /* 1 = DRM_CLIENT_CAP_ATOMIC has been requested on drm_fd. Set LAZILY, only when
+     * a scanout framebuffer turns out to be wider than its mode, because the plane
+     * SRC_W/CRTC_W properties that settle whether that is pitch padding or a scaling
+     * plane are hidden from a non-atomic client (measured: the same plane reports
+     * SRC_W with the cap and nothing without it). Per-fd, needs no privilege, no
+     * atomic commit is ever made, and no other client is affected. Sticky so the
+     * cap is requested once rather than per frame. */
+    int      atomic_cap_tried;
+
     /* Caller-supplied destination for converted pixels (drmtap_set_output_buffer).
      * NULL means "use the ctx-owned deswizzle_buf". Set once by the caller, who
      * owns the memory and must keep it alive; libdrmtap never frees or reallocates
@@ -312,17 +321,31 @@ int drmtap_convert_rgb16f(const void *src, void *dst,
 /* Which branch drmtap_scanout_width_of() took, so the caller can log the reason
  * once and a test can assert the branch and not just the number. */
 typedef enum {
-    DRMTAP_SCANOUT_AS_IS = 0,          /* fb reported unchanged */
-    DRMTAP_SCANOUT_NARROWED,           /* padded fb narrowed to the mode width */
-    DRMTAP_SCANOUT_OFFSET_UNSUPPORTED, /* CRTC viewport is offset in a bigger fb */
-    DRMTAP_SCANOUT_TILED_NOT_NARROWED, /* padded, but tiled: width feeds tile math */
+    DRMTAP_SCANOUT_AS_IS = 0,           /* fb reported unchanged */
+    DRMTAP_SCANOUT_NARROWED,            /* padded fb narrowed to what is scanned out */
+    DRMTAP_SCANOUT_OFFSET_UNSUPPORTED,  /* plane reads from an offset in a bigger fb */
+    DRMTAP_SCANOUT_TILED_NOT_NARROWED,  /* padded, but tiled: width feeds tile math */
+    DRMTAP_SCANOUT_SCALING_NOT_NARROWED,/* plane genuinely scales; fb is all visible */
+    DRMTAP_SCANOUT_NO_PLANE_RECT,       /* plane rect unreadable: cannot tell, so do not */
 } drmtap_scanout_why;
+
+/* The primary plane rectangle: which region of the framebuffer the plane reads and
+ * where it lands on the CRTC. Whole pixels (the kernel SRC_* properties are 16.16
+ * fixed point; the fractional part is dropped by the reader). `valid` is 0 when the
+ * properties could not be read, which is a distinct case from "no scaling" and must
+ * not be treated as one. */
+typedef struct {
+    int      valid;
+    uint32_t src_x, src_y, src_w, src_h;
+    uint32_t crtc_w, crtc_h;
+} drmtap_plane_rect;
 
 /* Decide the width a CRTC actually scans out of a framebuffer that may be wider
  * than its mode. Pure (no DRM fd) so it is testable without the padding hardware.
  * See the comment on the definition in drm_grab.c for the rules. */
-uint32_t drmtap_scanout_width_of(uint32_t fb_width, int mode_valid,
-                                 uint32_t hdisplay, int crtc_x, int crtc_y,
-                                 int layout_is_linear, drmtap_scanout_why *why);
+uint32_t drmtap_scanout_width_of(uint32_t fb_width,
+                                 const drmtap_plane_rect *rect,
+                                 int layout_is_linear,
+                                 drmtap_scanout_why *why);
 
 #endif /* DRMTAP_INTERNAL_H */

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -282,9 +282,10 @@ int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out);
 int validate_fb_dims(uint32_t width, uint32_t height);
 
 /* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
- * On success *out_data points at ctx->deswizzle_buf (ctx-owned, grow-once,
- * valid until the next convert or drmtap_close) — the caller must NOT free
- * it. fb_id keys the import-once EGLImage cache (0 = no caching); for an
+ * On success *out_data points at the resolved conversion destination: the caller's
+ * output buffer when drmtap_set_output_buffer() set one, otherwise
+ * ctx->deswizzle_buf (ctx-owned, grow-once,
+ * valid until the next convert or drmtap_close) — which the caller must NOT free. fb_id keys the import-once EGLImage cache (0 = no caching); for an
  * fb_id already cached with matching geometry dma_buf_fd may be -1. */
 int drmtap_gpu_egl_available(drmtap_ctx *ctx);
 int drmtap_gpu_egl_convert(drmtap_ctx *ctx,

--- a/src/drmtap_internal.h
+++ b/src/drmtap_internal.h
@@ -33,6 +33,10 @@
  * ~126 MB). */
 #define DRMTAP_MAX_FB_BYTES ((size_t)7680 * 4320 * 4)
 
+/* Per-dimension ceiling, used to make width*height wrap-proof before the multiply.
+ * Far above any real scanout; the byte cap above is what actually binds. */
+#define DRMTAP_MAX_DIM 32768u
+
 struct drmtap_ctx {
     /* DRM device */
     int drm_fd;
@@ -112,6 +116,16 @@ struct drmtap_ctx {
      * deliberately NOT narrowed) is stated once per context instead of per
      * frame. See drmtap_scanout_width() in drm_grab.c. */
     int      logged_scanout_crop;
+
+    /* Caller-supplied destination for converted pixels (drmtap_set_output_buffer).
+     * NULL means "use the ctx-owned deswizzle_buf". Set once by the caller, who
+     * owns the memory and must keep it alive; libdrmtap never frees or reallocates
+     * it, and refuses a frame that would not fit rather than writing short. Every
+     * path that produces converted pixels resolves its destination through
+     * drmtap_ensure_out(), so the EGL detile and the CPU conversions behave
+     * identically -- a caller must not have to know which one ran. */
+    void   *user_out;
+    size_t  user_out_len;
 
     /* Deswizzle shadow buffer (for read-only mmap'd DMA-BUFs).
      * Grow-once and reused across grabs; capped at DRMTAP_MAX_FB_BYTES;
@@ -238,6 +252,25 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
  * at DRMTAP_MAX_FB_BYTES. Contents are not preserved across a grow. Returns
  * 0, -EINVAL (zero size), -EFBIG (over the cap) or -ENOMEM. (drm_grab.c) */
 int drmtap_ensure_buf(void **buf, size_t *cap, size_t size);
+
+/* Resolve where this frame's converted pixels must be written: the caller's
+ * buffer when drmtap_set_output_buffer() set one (checked against `size`, so a
+ * geometry change that no longer fits fails the grab instead of writing short or
+ * overflowing), otherwise the ctx-owned grow-once deswizzle buffer. Returns 0 and
+ * sets *out, or -ENOSPC / whatever drmtap_ensure_buf returns. Every producer of
+ * converted pixels must go through this and must NOT reference
+ * ctx->deswizzle_buf directly, or the caller's buffer would be honoured on some
+ * paths and silently ignored on others. (drm_grab.c) */
+int drmtap_ensure_out(drmtap_ctx *ctx, size_t size, void **out);
+
+/* Reject framebuffer DIMENSIONS that cannot be a real scanout, before anything
+ * multiplies them. validate_fb_size() bounds stride*height, which does NOT bound
+ * width: a wire or IPC peer that sends a huge width with a small stride passes it,
+ * and every converted output is sized width*height*4 -- a product that can wrap
+ * size_t and hand a large write a small destination. Returns 0, -EINVAL (a zero
+ * dimension) or -EFBIG (a dimension over DRMTAP_MAX_DIM, or more than
+ * DRMTAP_MAX_FB_BYTES worth of pixels). (drm_grab.c) */
+int validate_fb_dims(uint32_t width, uint32_t height);
 
 /* GPU backend: EGL/GLES2 universal detiling (gpu_egl.c).
  * On success *out_data points at ctx->deswizzle_buf (ctx-owned, grow-once,

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -1067,7 +1067,7 @@ static int egl_convert_impl(drmtap_ctx *ctx,
      * could wrap that product and give a large glReadPixels a small destination --
      * now more than a library-internal concern, since the destination can be the
      * caller's buffer (drmtap_set_output_buffer). */
-    int dim = validate_fb_dims(width, height);
+    int dim = drmtap_validate_fb_dims(width, height);
     if (dim != 0) {
         drmtap_set_error(ctx, "refusing %ux%u scanout: implausible geometry", width,
                          height);
@@ -1295,6 +1295,13 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     void *dst = NULL;
     ret = drmtap_ensure_out(ctx, rgba_size, &dst);
     if (ret != 0) {
+        /* ensure_out names the caller-buffer refusal itself; say something for the
+         * library-owned allocation failure too, or the caller gets a bare errno out
+         * of a detile with drmtap_error() still holding an older message. */
+        if (ret != -ENOSPC) {
+            drmtap_set_error(ctx, "cannot allocate %zu bytes for the %ux%u detile "
+                             "output: %s", rgba_size, width, height, strerror(-ret));
+        }
         goto cleanup;
     }
     glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, dst);

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -1061,6 +1061,18 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     if (!ctx || !out_data || !out_size) {
         return -EINVAL;
     }
+    /* Bound the dimensions before anything multiplies them. The readback below is
+     * sized width*height*4, and width does not go through validate_fb_size (which
+     * bounds stride*height only), so an out-of-range width from a wire/IPC peer
+     * could wrap that product and give a large glReadPixels a small destination --
+     * now more than a library-internal concern, since the destination can be the
+     * caller's buffer (drmtap_set_output_buffer). */
+    int dim = validate_fb_dims(width, height);
+    if (dim != 0) {
+        drmtap_set_error(ctx, "refusing %ux%u scanout: implausible geometry", width,
+                         height);
+        return dim;
+    }
 
     /* Lazy-init this thread's EGL context. `state` is the file-scope
      * thread-local defined above; it is freed by drmtap_gpu_egl_thread_cleanup()
@@ -1272,20 +1284,22 @@ static int egl_convert_impl(drmtap_ctx *ctx,
     /* Ensure GPU rendering is complete before reading back */
     glFinish();
 
-    /* Read linear pixels straight into the ctx-owned grow-once buffer
-     * (drmtap_ensure_buf caps it at DRMTAP_MAX_FB_BYTES), so steady-state
-     * conversion performs zero per-frame allocations. The buffer belongs to
-     * the context and is freed in drmtap_close(); callers must not free it. */
+    /* Read the linear pixels straight into the destination, which is the CALLER's
+     * buffer when it set one (drmtap_set_output_buffer) and otherwise the ctx-owned
+     * grow-once buffer (capped at DRMTAP_MAX_FB_BYTES), so steady-state conversion
+     * performs zero per-frame allocations. glReadPixels writes wherever it is
+     * pointed, so a caller-supplied destination costs nothing here and removes the
+     * caller's whole-frame memcpy. The internal buffer belongs to the context and
+     * is freed in drmtap_close(); callers must not free it. */
     size_t rgba_size = (size_t)width * height * 4;
-    ret = drmtap_ensure_buf(&ctx->deswizzle_buf, &ctx->deswizzle_buf_size,
-                            rgba_size);
+    void *dst = NULL;
+    ret = drmtap_ensure_out(ctx, rgba_size, &dst);
     if (ret != 0) {
         goto cleanup;
     }
-    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
-                 ctx->deswizzle_buf);
+    glReadPixels(0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE, dst);
     /* A GL error across the render + readback (notably GL_CONTEXT_LOST after a GPU
-     * reset/TDR) means deswizzle_buf holds stale or undefined pixels. Fail closed
+     * reset/TDR) means the destination holds stale or undefined pixels. Fail closed
      * instead of returning them as a valid frame. This glGetError also drains the
      * error state so the next convert starts clean. */
     GLenum gl_err = glGetError();
@@ -1300,7 +1314,7 @@ static int egl_convert_impl(drmtap_ctx *ctx,
      * orientation. The previous CPU flip was compensating for a shader-
      * based X flip (1.0 - v_texcoord.x) that has since been removed. */
 
-    *out_data = ctx->deswizzle_buf;
+    *out_data = dst;
     *out_size = rgba_size;
     ret = 0;
 

--- a/tests/test_outbuf.c
+++ b/tests/test_outbuf.c
@@ -77,8 +77,12 @@ static void test_one_byte_too_small_is_refused_untouched(void) {
     unsigned char mine[64];
     memset(mine, 0xAB, sizeof mine);
     TEST_ASSERT(drmtap_set_output_buffer(ctx, mine, sizeof mine) == 0);
-    void *out = (void *)0x1;
+    /* Pre-set with a valid address, not an integer cast, so the assertion below is
+     * about ensure_out leaving *out alone on refusal and not about a bogus pointer. */
+    void *sentinel = &ctx;
+    void *out = sentinel;
     TEST_ASSERT(drmtap_ensure_out(ctx, sizeof mine + 1, &out) == -ENOSPC);
+    TEST_ASSERT(out == sentinel);   /* untouched on refusal */
     for (size_t i = 0; i < sizeof mine; i++) {
         TEST_ASSERT(mine[i] == 0xAB);
     }
@@ -128,9 +132,11 @@ static void test_argument_checks(void) {
  * unlock a frame bigger than this library handles. */
 static void test_the_frame_cap_still_applies(void) {
     drmtap_ctx *ctx = bare_ctx();
-    /* Claim a length past the cap without allocating it -- ensure_out must refuse
-     * on the size alone, before it ever looks at the pointer. */
-    ctx->user_out = (void *)0xDEAD0000;
+    /* A REAL address with a length that lies about how much is behind it: ensure_out
+     * must refuse on the size alone and never dereference, so a valid pointer is
+     * enough and an integer cast would only muddy what is being asserted. */
+    unsigned char small[16];
+    ctx->user_out = small;
     ctx->user_out_len = DRMTAP_MAX_FB_BYTES * 4;
     void *out = NULL;
     TEST_ASSERT(drmtap_ensure_out(ctx, DRMTAP_MAX_FB_BYTES + 1, &out) == -EFBIG);
@@ -150,18 +156,18 @@ static void test_zero_size_is_rejected(void) {
  * a hostile or corrupt geometry could size a destination small and then have the
  * detile write the real, much larger frame into it. */
 static void test_dimension_bound_is_wrap_proof(void) {
-    TEST_ASSERT(validate_fb_dims(1920, 1080) == 0);
-    TEST_ASSERT(validate_fb_dims(7680, 4320) == 0);      /* 8K, the documented cap */
-    TEST_ASSERT(validate_fb_dims(0, 1080) == -EINVAL);
-    TEST_ASSERT(validate_fb_dims(1920, 0) == -EINVAL);
+    TEST_ASSERT(drmtap_validate_fb_dims(1920, 1080) == 0);
+    TEST_ASSERT(drmtap_validate_fb_dims(7680, 4320) == 0);      /* 8K, the documented cap */
+    TEST_ASSERT(drmtap_validate_fb_dims(0, 1080) == -EINVAL);
+    TEST_ASSERT(drmtap_validate_fb_dims(1920, 0) == -EINVAL);
     /* Over the per-dimension ceiling: refused before anything multiplies it. */
-    TEST_ASSERT(validate_fb_dims(DRMTAP_MAX_DIM + 1, 1) == -EFBIG);
-    TEST_ASSERT(validate_fb_dims(1, DRMTAP_MAX_DIM + 1) == -EFBIG);
+    TEST_ASSERT(drmtap_validate_fb_dims(DRMTAP_MAX_DIM + 1, 1) == -EFBIG);
+    TEST_ASSERT(drmtap_validate_fb_dims(1, DRMTAP_MAX_DIM + 1) == -EFBIG);
     /* The exact values that would wrap a 64-bit width*height*4. */
-    TEST_ASSERT(validate_fb_dims(0xFFFFFFFFu, 0xFFFFFFFFu) == -EFBIG);
-    TEST_ASSERT(validate_fb_dims(0x80000000u, 0x80000000u) == -EFBIG);
+    TEST_ASSERT(drmtap_validate_fb_dims(0xFFFFFFFFu, 0xFFFFFFFFu) == -EFBIG);
+    TEST_ASSERT(drmtap_validate_fb_dims(0x80000000u, 0x80000000u) == -EFBIG);
     /* In range per dimension, but too many pixels together. */
-    TEST_ASSERT(validate_fb_dims(DRMTAP_MAX_DIM, DRMTAP_MAX_DIM) == -EFBIG);
+    TEST_ASSERT(drmtap_validate_fb_dims(DRMTAP_MAX_DIM, DRMTAP_MAX_DIM) == -EFBIG);
 }
 
 int main(void) {

--- a/tests/test_outbuf.c
+++ b/tests/test_outbuf.c
@@ -1,0 +1,180 @@
+/*
+ * libdrmtap — DRM/KMS screen capture library for Linux
+ * https://github.com/fxd0h/libdrmtap
+ *
+ * Copyright (c) 2026 Mariano Abad <weimaraner@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file test_outbuf.c
+ * @brief Unit test — caller-supplied output buffer, and its bounds
+ *
+ * No hardware needed. drmtap_set_output_buffer() hands conversion code a pointer
+ * and a length that come from OUTSIDE the library, so the bound is the whole
+ * safety story: a frame that does not fit must be refused, never written short and
+ * never written past the end. These tests pin the refusal, the argument checks and
+ * the dimension bound that keeps width*height*4 from wrapping size_t.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "drmtap.h"
+#include "drmtap_internal.h"
+
+#define TEST_ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        exit(1); \
+    } \
+} while (0)
+
+/* drmtap_ensure_out is the single place every converted-pixel producer resolves
+ * its destination, so testing it tests all of them. A bare context is enough: it
+ * touches only user_out/user_out_len and the owned buffer. */
+static drmtap_ctx *bare_ctx(void) {
+    drmtap_ctx *ctx = calloc(1, sizeof(*ctx));
+    TEST_ASSERT(ctx != NULL);
+    return ctx;
+}
+
+static void free_ctx(drmtap_ctx *ctx) {
+    free(ctx->deswizzle_buf);
+    free(ctx);
+}
+
+/* With no output buffer set, the destination is the library's own grow-once
+ * buffer -- the behaviour every existing caller already depends on. */
+static void test_default_uses_the_library_buffer(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    void *out = NULL;
+    TEST_ASSERT(drmtap_ensure_out(ctx, 4096, &out) == 0);
+    TEST_ASSERT(out == ctx->deswizzle_buf);
+    TEST_ASSERT(out != NULL);
+    free_ctx(ctx);
+}
+
+/* A buffer that fits is handed back as the destination, with no allocation. */
+static void test_a_fitting_buffer_is_used(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    unsigned char mine[4096];
+    TEST_ASSERT(drmtap_set_output_buffer(ctx, mine, sizeof mine) == 0);
+    void *out = NULL;
+    TEST_ASSERT(drmtap_ensure_out(ctx, sizeof mine, &out) == 0);
+    TEST_ASSERT(out == mine);
+    TEST_ASSERT(ctx->deswizzle_buf == NULL);  /* nothing allocated behind it */
+    free_ctx(ctx);
+}
+
+/* THE bound. One byte over must be refused, and the buffer must be left alone --
+ * a short frame is indistinguishable from a good one to the caller, and writing
+ * past the end is the whole class of bug this API could otherwise introduce. */
+static void test_one_byte_too_small_is_refused_untouched(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    unsigned char mine[64];
+    memset(mine, 0xAB, sizeof mine);
+    TEST_ASSERT(drmtap_set_output_buffer(ctx, mine, sizeof mine) == 0);
+    void *out = (void *)0x1;
+    TEST_ASSERT(drmtap_ensure_out(ctx, sizeof mine + 1, &out) == -ENOSPC);
+    for (size_t i = 0; i < sizeof mine; i++) {
+        TEST_ASSERT(mine[i] == 0xAB);
+    }
+    /* And it says how many bytes were needed, so the caller can resize instead of
+     * guessing. */
+    TEST_ASSERT(strstr(drmtap_error(ctx), "65") != NULL);
+    free_ctx(ctx);
+}
+
+/* Exactly the right size is not off by one in the other direction either. */
+static void test_exact_fit_is_accepted(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    unsigned char mine[100];
+    TEST_ASSERT(drmtap_set_output_buffer(ctx, mine, sizeof mine) == 0);
+    void *out = NULL;
+    TEST_ASSERT(drmtap_ensure_out(ctx, sizeof mine, &out) == 0);
+    TEST_ASSERT(out == mine);
+    free_ctx(ctx);
+}
+
+/* Clearing returns to the library buffer, so a caller can hand memory back before
+ * unmapping it. */
+static void test_clearing_returns_to_the_library_buffer(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    unsigned char mine[4096];
+    TEST_ASSERT(drmtap_set_output_buffer(ctx, mine, sizeof mine) == 0);
+    TEST_ASSERT(drmtap_set_output_buffer(ctx, NULL, 0) == 0);
+    void *out = NULL;
+    TEST_ASSERT(drmtap_ensure_out(ctx, 4096, &out) == 0);
+    TEST_ASSERT(out == ctx->deswizzle_buf);
+    free_ctx(ctx);
+}
+
+/* Argument checks. A non-NULL buffer with length 0 is a caller bug, not a request
+ * to clear: accepting it would set a zero-length destination that every frame then
+ * fails against, which reads as "capture is broken" instead of "fix the call". */
+static void test_argument_checks(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    unsigned char mine[16];
+    TEST_ASSERT(drmtap_set_output_buffer(NULL, mine, sizeof mine) == -EINVAL);
+    TEST_ASSERT(drmtap_set_output_buffer(ctx, mine, 0) == -EINVAL);
+    TEST_ASSERT(ctx->user_out == NULL);
+    free_ctx(ctx);
+}
+
+/* The frame cap applies to the caller's buffer too: owning a huge mapping must not
+ * unlock a frame bigger than this library handles. */
+static void test_the_frame_cap_still_applies(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    /* Claim a length past the cap without allocating it -- ensure_out must refuse
+     * on the size alone, before it ever looks at the pointer. */
+    ctx->user_out = (void *)0xDEAD0000;
+    ctx->user_out_len = DRMTAP_MAX_FB_BYTES * 4;
+    void *out = NULL;
+    TEST_ASSERT(drmtap_ensure_out(ctx, DRMTAP_MAX_FB_BYTES + 1, &out) == -EFBIG);
+    ctx->user_out = NULL;
+    free_ctx(ctx);
+}
+
+/* A zero-byte frame is nonsense on either destination. */
+static void test_zero_size_is_rejected(void) {
+    drmtap_ctx *ctx = bare_ctx();
+    void *out = NULL;
+    TEST_ASSERT(drmtap_ensure_out(ctx, 0, &out) == -EINVAL);
+    free_ctx(ctx);
+}
+
+/* The dimension bound that keeps width*height*4 from wrapping size_t. Without it,
+ * a hostile or corrupt geometry could size a destination small and then have the
+ * detile write the real, much larger frame into it. */
+static void test_dimension_bound_is_wrap_proof(void) {
+    TEST_ASSERT(validate_fb_dims(1920, 1080) == 0);
+    TEST_ASSERT(validate_fb_dims(7680, 4320) == 0);      /* 8K, the documented cap */
+    TEST_ASSERT(validate_fb_dims(0, 1080) == -EINVAL);
+    TEST_ASSERT(validate_fb_dims(1920, 0) == -EINVAL);
+    /* Over the per-dimension ceiling: refused before anything multiplies it. */
+    TEST_ASSERT(validate_fb_dims(DRMTAP_MAX_DIM + 1, 1) == -EFBIG);
+    TEST_ASSERT(validate_fb_dims(1, DRMTAP_MAX_DIM + 1) == -EFBIG);
+    /* The exact values that would wrap a 64-bit width*height*4. */
+    TEST_ASSERT(validate_fb_dims(0xFFFFFFFFu, 0xFFFFFFFFu) == -EFBIG);
+    TEST_ASSERT(validate_fb_dims(0x80000000u, 0x80000000u) == -EFBIG);
+    /* In range per dimension, but too many pixels together. */
+    TEST_ASSERT(validate_fb_dims(DRMTAP_MAX_DIM, DRMTAP_MAX_DIM) == -EFBIG);
+}
+
+int main(void) {
+    printf("== output buffer ==\n");
+    test_default_uses_the_library_buffer();
+    test_a_fitting_buffer_is_used();
+    test_one_byte_too_small_is_refused_untouched();
+    test_exact_fit_is_accepted();
+    test_clearing_returns_to_the_library_buffer();
+    test_argument_checks();
+    test_the_frame_cap_still_applies();
+    test_zero_size_is_rejected();
+    test_dimension_bound_is_wrap_proof();
+    printf("all output buffer tests passed\n");
+    return 0;
+}

--- a/tests/test_scanout.c
+++ b/tests/test_scanout.c
@@ -1,0 +1,100 @@
+/*
+ * libdrmtap — DRM/KMS screen capture library for Linux
+ * https://github.com/fxd0h/libdrmtap
+ *
+ * Copyright (c) 2026 Mariano Abad <weimaraner@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file test_scanout.c
+ * @brief Unit test — the scanned-out width of a padded scanout framebuffer
+ *
+ * No hardware needed. The case this covers was found on an Apple T2 MacBook,
+ * whose Touch Bar card (appletbdrm) drives a 60x2170 mode from a 64x2170
+ * framebuffer with a 256-byte pitch. Reporting the framebuffer width made a
+ * consumer see every frame as disagreeing with the display geometry it had
+ * enumerated. That is one laptop in the world, so the decision itself is a pure
+ * function and is asserted here instead of only on that machine.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "drmtap.h"
+#include "drmtap_internal.h"
+
+#define TEST_ASSERT(cond) do { \
+    if (!(cond)) { \
+        fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        exit(1); \
+    } \
+} while (0)
+
+/* The measured Touch Bar numbers: mode 60 wide, framebuffer 64 wide, viewport at
+ * the framebuffer origin. The four extra columns are pitch padding and were never
+ * scanned out, so the reported width must be the mode's. */
+static void test_padded_fb_is_narrowed_to_the_mode(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
+    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, &why) == 60);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_NARROWED);
+}
+
+/* The common case, measured on the same laptop's amdgpu panel (2880x1800 mode
+ * from a 2880x1800 framebuffer): nothing to narrow, and no reason logged. */
+static void test_unpadded_fb_is_untouched(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
+    TEST_ASSERT(drmtap_scanout_width_of(2880, 1, 2880, 0, 0, &why) == 2880);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
+}
+
+/* A framebuffer NARROWER than the mode is a CRTC scaling a smaller buffer up to
+ * its mode. That is a different image, not padding, so it must never be widened
+ * -- the function only ever shrinks. The consumer decides what to do with it. */
+static void test_upscaling_crtc_is_never_widened(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
+    TEST_ASSERT(drmtap_scanout_width_of(1280, 1, 3840, 0, 0, &why) == 1280);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
+}
+
+/* Several heads scanning out of one big framebuffer: the visible region does not
+ * start at the framebuffer origin, so narrowing the width alone would report the
+ * WRONG pixels (the left head's) for this CRTC. drmtap_dmabuf_desc has a frozen
+ * layout with nowhere to put a crop origin, so the whole framebuffer is reported
+ * and the caller is told why. Untested on hardware -- we have no such setup. */
+static void test_offset_viewport_is_left_whole(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
+    TEST_ASSERT(drmtap_scanout_width_of(3840, 1, 1920, 1920, 0, &why) == 3840);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_OFFSET_UNSUPPORTED);
+    /* A vertical stack is the same situation. */
+    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 1080, 0, 1080, &why) == 1920);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_OFFSET_UNSUPPORTED);
+}
+
+/* Without a valid mode there is no scanned-out width to clamp to, and a zero
+ * hdisplay must never produce a zero-width frame (it would divide by zero
+ * downstream and reads as a successful capture of nothing). */
+static void test_missing_mode_falls_back_to_the_fb(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
+    TEST_ASSERT(drmtap_scanout_width_of(1920, 0, 1080, 0, 0, &why) == 1920);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
+    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 0, 0, 0, &why) == 1920);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
+}
+
+/* The reason pointer is optional for callers that only want the number. */
+static void test_why_may_be_null(void) {
+    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, NULL) == 60);
+}
+
+int main(void) {
+    printf("== scanout width ==\n");
+    test_padded_fb_is_narrowed_to_the_mode();
+    test_unpadded_fb_is_untouched();
+    test_upscaling_crtc_is_never_widened();
+    test_offset_viewport_is_left_whole();
+    test_missing_mode_falls_back_to_the_fb();
+    test_why_may_be_null();
+    printf("all scanout width tests passed\n");
+    return 0;
+}

--- a/tests/test_scanout.c
+++ b/tests/test_scanout.c
@@ -10,12 +10,15 @@
  * @file test_scanout.c
  * @brief Unit test — the scanned-out width of a padded scanout framebuffer
  *
- * No hardware needed. The case this covers was found on an Apple T2 MacBook,
- * whose Touch Bar card (appletbdrm) drives a 60x2170 mode from a 64x2170
- * framebuffer with a 256-byte pitch. Reporting the framebuffer width made a
- * consumer see every frame as disagreeing with the display geometry it had
- * enumerated. That is one laptop in the world, so the decision itself is a pure
- * function and is asserted here instead of only on that machine.
+ * No hardware needed. The case this covers was found on an Apple T2 MacBook, whose
+ * Touch Bar card (appletbdrm) drives a 60x2170 mode from a 64x2170 framebuffer with
+ * a 256-byte pitch, its primary plane reading SRC 60x2170 onto a 60x2170 CRTC rect.
+ * Reporting the framebuffer width made a consumer see every frame as disagreeing
+ * with the display geometry it had enumerated. That is one laptop in the world, so
+ * the decision is a pure function and is asserted here instead of only on it.
+ *
+ * The cases that must NOT narrow matter more than the one that must, because each
+ * of them silently returns a WRONG image rather than failing.
  */
 
 #include <stdio.h>
@@ -24,8 +27,7 @@
 #include "drmtap.h"
 #include "drmtap_internal.h"
 
-/* The layout argument, named so the cases read as what they are. Only a linear
- * (or unknown-and-treated-as-linear) scanout may be narrowed; see the TILED case. */
+/* Layout argument, named so the cases read as what they are. */
 #define LINEAR 1
 #define TILED  0
 
@@ -36,87 +38,148 @@
     } \
 } while (0)
 
-/* The measured Touch Bar numbers: mode 60 wide, framebuffer 64 wide, viewport at
- * the framebuffer origin. The four extra columns are pitch padding and were never
- * scanned out, so the reported width must be the mode's. */
-static void test_padded_fb_is_narrowed_to_the_mode(void) {
+/* A plane showing its whole source 1:1 at the framebuffer origin. */
+static drmtap_plane_rect rect_1to1(uint32_t w, uint32_t h) {
+    drmtap_plane_rect r = {0};
+    r.valid = 1;
+    r.src_w = w; r.src_h = h;
+    r.crtc_w = w; r.crtc_h = h;
+    return r;
+}
+
+/* The measured Touch Bar numbers: framebuffer 64 wide, plane reads 60 columns 1:1.
+ * The four extra columns are pitch padding and are never scanned out. */
+static void test_padded_fb_is_narrowed_to_what_the_plane_reads(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
-    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, LINEAR, &why) == 60);
+    drmtap_plane_rect r = rect_1to1(60, 2170);
+    TEST_ASSERT(drmtap_scanout_width_of(64, &r, LINEAR, &why) == 60);
     TEST_ASSERT(why == DRMTAP_SCANOUT_NARROWED);
 }
 
-/* The common case, measured on the same laptop's amdgpu panel (2880x1800 mode
- * from a 2880x1800 framebuffer): nothing to narrow, and no reason logged. */
+/* The common case, measured on the same laptop's amdgpu panel (2880x1800 out of a
+ * 2880x1800 framebuffer): nothing to narrow, and no reason reported. */
 static void test_unpadded_fb_is_untouched(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
-    TEST_ASSERT(drmtap_scanout_width_of(2880, 1, 2880, 0, 0, LINEAR, &why) == 2880);
+    drmtap_plane_rect r = rect_1to1(2880, 1800);
+    TEST_ASSERT(drmtap_scanout_width_of(2880, &r, LINEAR, &why) == 2880);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
 }
 
-/* A framebuffer NARROWER than the mode is a CRTC scaling a smaller buffer up to
- * its mode. That is a different image, not padding, so it must never be widened
- * -- the function only ever shrinks. The consumer decides what to do with it. */
-static void test_upscaling_crtc_is_never_widened(void) {
-    drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
-    TEST_ASSERT(drmtap_scanout_width_of(1280, 1, 3840, 0, 0, LINEAR, &why) == 1280);
-    TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
-}
-
-/* Several heads scanning out of one big framebuffer: the visible region does not
- * start at the framebuffer origin, so narrowing the width alone would report the
- * WRONG pixels (the left head's) for this CRTC. drmtap_dmabuf_desc has a frozen
- * layout with nowhere to put a crop origin, so the whole framebuffer is reported
- * and the caller is told why. Untested on hardware -- we have no such setup. */
-static void test_offset_viewport_is_left_whole(void) {
+/* A plane that genuinely DOWNSCALES. The whole framebuffer is being displayed, just
+ * smaller, so narrowing would hand back the left part of the image and call it the
+ * screen. This looks identical to pitch padding if you only compare the framebuffer
+ * width against the mode, which is why the plane rect is consulted at all. Note the
+ * pitch cannot substitute: a 3840-wide framebuffer has pitch == width*4 exactly, the
+ * same as the padded 64-wide one does. */
+static void test_downscaling_plane_is_not_narrowed(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
-    TEST_ASSERT(drmtap_scanout_width_of(3840, 1, 1920, 1920, 0, LINEAR, &why) == 3840);
+    drmtap_plane_rect r = {0};
+    r.valid = 1;
+    r.src_w = 3840; r.src_h = 2160;    /* reads the whole 3840-wide fb ... */
+    r.crtc_w = 1920; r.crtc_h = 1080;  /* ... onto a 1920 mode */
+    TEST_ASSERT(drmtap_scanout_width_of(3840, &r, LINEAR, &why) == 3840);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_SCALING_NOT_NARROWED);
+    /* Upscaling is the same refusal: the source is not padded, it is stretched. */
+    drmtap_plane_rect u = {0};
+    u.valid = 1;
+    u.src_w = 1280; u.src_h = 720;
+    u.crtc_w = 3840; u.crtc_h = 2160;
+    TEST_ASSERT(drmtap_scanout_width_of(1280, &u, LINEAR, &why) == 1280);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_SCALING_NOT_NARROWED);
+}
+
+/* A framebuffer NARROWER than what the plane reads is not something to widen: this
+ * function only ever shrinks. */
+static void test_never_widens(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
+    drmtap_plane_rect r = rect_1to1(3840, 2160);
+    TEST_ASSERT(drmtap_scanout_width_of(1280, &r, LINEAR, &why) == 1280);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
+}
+
+/* Several heads scanning out of one big framebuffer: the plane reads from a non-zero
+ * origin, so narrowing the width alone would report the WRONG columns (the left
+ * head's) for this CRTC. drmtap_dmabuf_desc has a frozen layout with nowhere to put a
+ * crop origin, so the whole framebuffer is reported and the caller is told why.
+ * Untested on hardware - we have no such setup. */
+static void test_offset_source_is_left_whole(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
+    drmtap_plane_rect r = rect_1to1(1920, 1080);
+    r.src_x = 1920;
+    TEST_ASSERT(drmtap_scanout_width_of(3840, &r, LINEAR, &why) == 3840);
     TEST_ASSERT(why == DRMTAP_SCANOUT_OFFSET_UNSUPPORTED);
     /* A vertical stack is the same situation. */
-    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 1080, 0, 1080, LINEAR, &why) == 1920);
+    drmtap_plane_rect v = rect_1to1(1920, 1080);
+    v.src_y = 1080;
+    TEST_ASSERT(drmtap_scanout_width_of(1920, &v, LINEAR, &why) == 1920);
     TEST_ASSERT(why == DRMTAP_SCANOUT_OFFSET_UNSUPPORTED);
 }
 
-/* A PADDED TILED scanout must NOT be narrowed, even though it is exactly the shape
- * the linear case narrows. The CPU deswizzle derives its tile grid from the width
- * and uses it to address the SOURCE (tiles_x = ceil(width/tile_w), then
- * src_off = (tile_row * tiles_x + tx) * tile_size), so a width short by a tile or
- * more mis-addresses every tile row after the first and silently mangles the image.
- * The visible width and the width the tiling was laid out for are different things.
- * No padded tiled scanout has been observed on any hardware here, so this is the
- * conservative branch: report the framebuffer, exactly as before this feature. */
+/* A padded TILED scanout must NOT be narrowed either. The CPU deswizzle derives its
+ * tile grid from the width and uses it to address the SOURCE (tiles_x =
+ * ceil(width/tile_w), then src_off = (tile_row * tiles_x + tx) * tile_size), so a
+ * width short by a tile or more mis-addresses every tile row after the first and
+ * silently mangles the image. The visible width and the width the tiling was laid out
+ * for are different things. No padded tiled scanout has been observed on any hardware
+ * here, so this keeps the behaviour that predates the narrowing. */
 static void test_padded_tiled_fb_is_not_narrowed(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
-    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, TILED, &why) == 64);
+    drmtap_plane_rect r = rect_1to1(60, 2170);
+    TEST_ASSERT(drmtap_scanout_width_of(64, &r, TILED, &why) == 64);
     TEST_ASSERT(why == DRMTAP_SCANOUT_TILED_NOT_NARROWED);
-    /* A tiled scanout that needs no narrowing is still just as-is. */
-    TEST_ASSERT(drmtap_scanout_width_of(2880, 1, 2880, 0, 0, TILED, &why) == 2880);
+    /* A tiled scanout with nothing to narrow reports no reason at all. */
+    drmtap_plane_rect ok = rect_1to1(2880, 1800);
+    TEST_ASSERT(drmtap_scanout_width_of(2880, &ok, TILED, &why) == 2880);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
 }
 
-/* Without a valid mode there is no scanned-out width to clamp to, and a zero
- * hdisplay must never produce a zero-width frame (it would divide by zero
- * downstream and reads as a successful capture of nothing). */
-static void test_missing_mode_falls_back_to_the_fb(void) {
-    drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
-    TEST_ASSERT(drmtap_scanout_width_of(1920, 0, 1080, 0, 0, LINEAR, &why) == 1920);
+/* An unreadable plane rect is NOT the same as "no scaling", and must not be treated
+ * as one: without it, pitch padding and a downscaling plane are indistinguishable, so
+ * the safe answer is the framebuffer. The properties are atomic-only and are hidden
+ * from a client that has not asked for DRM_CLIENT_CAP_ATOMIC, which is exactly how
+ * this can happen in the field. */
+static void test_unreadable_plane_rect_does_not_narrow(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
+    drmtap_plane_rect r = {0};   /* valid == 0 */
+    TEST_ASSERT(drmtap_scanout_width_of(64, &r, LINEAR, &why) == 64);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_NO_PLANE_RECT);
+    /* A NULL rect is the same situation and must not dereference. */
+    why = DRMTAP_SCANOUT_AS_IS;
+    TEST_ASSERT(drmtap_scanout_width_of(64, NULL, LINEAR, &why) == 64);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_NO_PLANE_RECT);
+    /* Tiled with no rect: also unchanged, and no tiled reason to report since there
+     * is nothing known to narrow. */
+    why = DRMTAP_SCANOUT_NARROWED;
+    TEST_ASSERT(drmtap_scanout_width_of(64, NULL, TILED, &why) == 64);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
-    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 0, 0, 0, LINEAR, &why) == 1920);
+}
+
+/* A zero source width must never produce a zero-width frame: it would divide by zero
+ * downstream and read as a successful capture of nothing. */
+static void test_zero_source_width_never_yields_zero(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
+    drmtap_plane_rect r = {0};
+    r.valid = 1;                 /* readable, but reporting nothing useful */
+    TEST_ASSERT(drmtap_scanout_width_of(1920, &r, LINEAR, &why) == 1920);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
 }
 
 /* The reason pointer is optional for callers that only want the number. */
 static void test_why_may_be_null(void) {
-    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, LINEAR, NULL) == 60);
+    drmtap_plane_rect r = rect_1to1(60, 2170);
+    TEST_ASSERT(drmtap_scanout_width_of(64, &r, LINEAR, NULL) == 60);
 }
 
 int main(void) {
     printf("== scanout width ==\n");
-    test_padded_fb_is_narrowed_to_the_mode();
+    test_padded_fb_is_narrowed_to_what_the_plane_reads();
     test_unpadded_fb_is_untouched();
-    test_upscaling_crtc_is_never_widened();
-    test_offset_viewport_is_left_whole();
+    test_downscaling_plane_is_not_narrowed();
+    test_never_widens();
+    test_offset_source_is_left_whole();
     test_padded_tiled_fb_is_not_narrowed();
-    test_missing_mode_falls_back_to_the_fb();
+    test_unreadable_plane_rect_does_not_narrow();
+    test_zero_source_width_never_yields_zero();
     test_why_may_be_null();
     printf("all scanout width tests passed\n");
     return 0;

--- a/tests/test_scanout.c
+++ b/tests/test_scanout.c
@@ -24,6 +24,11 @@
 #include "drmtap.h"
 #include "drmtap_internal.h"
 
+/* The layout argument, named so the cases read as what they are. Only a linear
+ * (or unknown-and-treated-as-linear) scanout may be narrowed; see the TILED case. */
+#define LINEAR 1
+#define TILED  0
+
 #define TEST_ASSERT(cond) do { \
     if (!(cond)) { \
         fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #cond); \
@@ -36,7 +41,7 @@
  * scanned out, so the reported width must be the mode's. */
 static void test_padded_fb_is_narrowed_to_the_mode(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
-    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, &why) == 60);
+    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, LINEAR, &why) == 60);
     TEST_ASSERT(why == DRMTAP_SCANOUT_NARROWED);
 }
 
@@ -44,7 +49,7 @@ static void test_padded_fb_is_narrowed_to_the_mode(void) {
  * from a 2880x1800 framebuffer): nothing to narrow, and no reason logged. */
 static void test_unpadded_fb_is_untouched(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
-    TEST_ASSERT(drmtap_scanout_width_of(2880, 1, 2880, 0, 0, &why) == 2880);
+    TEST_ASSERT(drmtap_scanout_width_of(2880, 1, 2880, 0, 0, LINEAR, &why) == 2880);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
 }
 
@@ -53,7 +58,7 @@ static void test_unpadded_fb_is_untouched(void) {
  * -- the function only ever shrinks. The consumer decides what to do with it. */
 static void test_upscaling_crtc_is_never_widened(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
-    TEST_ASSERT(drmtap_scanout_width_of(1280, 1, 3840, 0, 0, &why) == 1280);
+    TEST_ASSERT(drmtap_scanout_width_of(1280, 1, 3840, 0, 0, LINEAR, &why) == 1280);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
 }
 
@@ -64,11 +69,28 @@ static void test_upscaling_crtc_is_never_widened(void) {
  * and the caller is told why. Untested on hardware -- we have no such setup. */
 static void test_offset_viewport_is_left_whole(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
-    TEST_ASSERT(drmtap_scanout_width_of(3840, 1, 1920, 1920, 0, &why) == 3840);
+    TEST_ASSERT(drmtap_scanout_width_of(3840, 1, 1920, 1920, 0, LINEAR, &why) == 3840);
     TEST_ASSERT(why == DRMTAP_SCANOUT_OFFSET_UNSUPPORTED);
     /* A vertical stack is the same situation. */
-    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 1080, 0, 1080, &why) == 1920);
+    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 1080, 0, 1080, LINEAR, &why) == 1920);
     TEST_ASSERT(why == DRMTAP_SCANOUT_OFFSET_UNSUPPORTED);
+}
+
+/* A PADDED TILED scanout must NOT be narrowed, even though it is exactly the shape
+ * the linear case narrows. The CPU deswizzle derives its tile grid from the width
+ * and uses it to address the SOURCE (tiles_x = ceil(width/tile_w), then
+ * src_off = (tile_row * tiles_x + tx) * tile_size), so a width short by a tile or
+ * more mis-addresses every tile row after the first and silently mangles the image.
+ * The visible width and the width the tiling was laid out for are different things.
+ * No padded tiled scanout has been observed on any hardware here, so this is the
+ * conservative branch: report the framebuffer, exactly as before this feature. */
+static void test_padded_tiled_fb_is_not_narrowed(void) {
+    drmtap_scanout_why why = DRMTAP_SCANOUT_AS_IS;
+    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, TILED, &why) == 64);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_TILED_NOT_NARROWED);
+    /* A tiled scanout that needs no narrowing is still just as-is. */
+    TEST_ASSERT(drmtap_scanout_width_of(2880, 1, 2880, 0, 0, TILED, &why) == 2880);
+    TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
 }
 
 /* Without a valid mode there is no scanned-out width to clamp to, and a zero
@@ -76,15 +98,15 @@ static void test_offset_viewport_is_left_whole(void) {
  * downstream and reads as a successful capture of nothing). */
 static void test_missing_mode_falls_back_to_the_fb(void) {
     drmtap_scanout_why why = DRMTAP_SCANOUT_NARROWED;
-    TEST_ASSERT(drmtap_scanout_width_of(1920, 0, 1080, 0, 0, &why) == 1920);
+    TEST_ASSERT(drmtap_scanout_width_of(1920, 0, 1080, 0, 0, LINEAR, &why) == 1920);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
-    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 0, 0, 0, &why) == 1920);
+    TEST_ASSERT(drmtap_scanout_width_of(1920, 1, 0, 0, 0, LINEAR, &why) == 1920);
     TEST_ASSERT(why == DRMTAP_SCANOUT_AS_IS);
 }
 
 /* The reason pointer is optional for callers that only want the number. */
 static void test_why_may_be_null(void) {
-    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, NULL) == 60);
+    TEST_ASSERT(drmtap_scanout_width_of(64, 1, 60, 0, 0, LINEAR, NULL) == 60);
 }
 
 int main(void) {
@@ -93,6 +115,7 @@ int main(void) {
     test_unpadded_fb_is_untouched();
     test_upscaling_crtc_is_never_widened();
     test_offset_viewport_is_left_whole();
+    test_padded_tiled_fb_is_not_narrowed();
     test_missing_mode_falls_back_to_the_fb();
     test_why_may_be_null();
     printf("all scanout width tests passed\n");


### PR DESCRIPTION
Two changes that both came out of testing on an Apple T2 MacBook Pro, plus the security work the second one made necessary.

## 1. a grab reported the framebuffer width, not the scanned-out width

A driver may allocate the scanout framebuffer wider than the mode to satisfy a pitch alignment. Measured on that machine, `appletbdrm` drives the Touch Bar strip as a 60x2170 mode out of a 64x2170 framebuffer with a 256-byte pitch, and those four columns are padding that is never scanned out:

```
card0 appletbdrm  crtc 37  mode 60x2170    fb 64x2170    pitch 256    (= 64*4)
card2 amdgpu      crtc 61  mode 2880x1800  fb 2880x1800  pitch 11776
```

Reporting the framebuffer width hands the caller an image wider than the display it asked to capture. A consumer whose display list carries the CRTC mode reads that as a display that never matches its own geometry, rejects every frame and falls back. Reported geometry is now narrowed to the mode.

It only ever shrinks, and only the width:

- A framebuffer narrower than the mode means the CRTC is scaling a smaller buffer up. That is a different image, not padding, so it is left alone.
- A CRTC whose viewport does not start at the framebuffer origin (several heads out of one big framebuffer) needs an offset crop too. `drmtap_dmabuf_desc` has a frozen layout with nowhere to carry a crop origin, so such a frame is reported whole and the reason is logged once. No hardware here has that layout, so it is deliberately not guessed at.

Buffer-size arithmetic is unchanged: the mapping is still the whole padded framebuffer, only the reported width narrows and the caller reads rows at the unchanged stride.

## 2. drmtap_set_output_buffer

Closes the second half of #36. A converted frame landed in a library-owned buffer, so a consumer that has to end up with the pixels in specific memory paid a full-frame memcpy per frame: 14.7 MB at 2560x1440, every frame, for nothing. Nothing required it. The EGL detile ends in a `glReadPixels` and the CPU converters take a destination pointer, and both write wherever they are pointed.

Every producer of converted pixels now resolves its destination through one `drmtap_ensure_out()`, so the EGL detile, the CPU deswizzle, the 10/16-bit and HDR reductions and the padded-linear repack all behave the same. A caller must not have to know which path ran to know where the pixels went. It works on an unprivileged `drmtap_open_render()` context too, so the converting half of a split can write straight into the consumer buffer.

It does NOT apply where there is nothing to materialize: a linear 8-bit scanout is handed back as a direct pointer into the mapped scanout, with no intermediate buffer to redirect. The header says so rather than implying a promise it cannot keep.

## security

The pointer and the length come from outside the library, so the bound is the whole story.

- A frame needing more than `len` is refused with `-ENOSPC`, the buffer is left untouched, and `drmtap_error()` names the required byte count. A short frame would be indistinguishable from a good one.
- **A real hole, pre-existing, now closed.** `validate_fb_size` bounds `stride * height` and never constrained `width`, yet every converted output is sized `width * height * 4` - a product that can wrap `size_t` and give a large write a small destination. Reachable with a width from the helper wire or an IPC-supplied descriptor. It already existed against the library own buffer; this feature would have turned it into an overflow of a caller buffer. New `validate_fb_dims()` bounds each dimension before anything multiplies it, so the product cannot wrap even where `size_t` is 32-bit, then bounds the pixel count. Wired into all four entry points.
- The frame cap applies to a caller-supplied buffer as well, so owning a large mapping cannot unlock a frame larger than this library handles.
- `drmtap_frame_release` was audited: it frees `priv->mapped`, never `frame->data`, and `priv->mapped` is only ever the mmap or `MAP_FAILED`. Caller memory is never freed. No change needed.

Additive ABI only: 24 exported symbols, up from 23, and the only addition is the public function. `validate_fb_dims`, `drmtap_ensure_out` and `drmtap_scanout_width_of` stay local through the version script.

## verified, and where

Here:

- 10/10 tests, and 10/10 again under ASan and UBSan with no reports.
- `tests/test_scanout.c` (6 cases) and `tests/test_outbuf.c` (9 cases). Both decisions are pure functions on purpose: the padding case needs one laptop in the world to observe, and a rule that easy to get subtly wrong should not be checkable only there.
- Both Rust crates build and test, and `csrc/` is back in sync. That drift mattered: `libdrmtap-sys` compiles those copies, so a release would have shipped a crate with neither change while meson had both.

On hardware:

- The narrowing, on the machine that reproduces it: `FB2: 64x2170` in, `60x2170 stride=256` out, 475038 of 520800 bytes non-black, so real pixels read at the unchanged stride. The amdgpu panel is untouched at 2880x1800. Repeated after a reboot onto a different kernel, so the padding is not a quirk of one kernel.
- The output buffer, against a tiled `XR30` scanout on i915 (a real conversion): a buffer one byte short gives `-ENOSPC` with its contents intact, a correctly sized buffer receives the frame with 4 KB guard bytes either side untouched, and clearing goes back to the library buffer. Clean under ASan and UBSan on that same path.

Not verified: the consumer in #36, whose validation belongs to whoever runs it, and the offset-viewport case, for which no hardware here qualifies.
