### PR TITLE
0.5.3: unbalanced DMA_BUF sync on the fast path, Nvidia deswizzler vendor byte, three GEM handle leaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,7 @@ libdrmtap/
 │   ├── gpu_egl.c          ← GPU-universal EGL/GLES2 detiler (PRIMARY detile path)
 │   ├── gpu_intel.c        ← Intel i915/xe tiling modifiers (CCS/X/Y-tiled)
 │   ├── gpu_amd.c          ← AMD amdgpu tiling (RX560 here, RX Vega 64 by a tester)
-│   ├── gpu_nvidia.c       ← Nvidia block-linear, NOT wired up (never validated)
+│   ├── gpu_nvidia.c       ← Nvidia: linear passthrough, block-linear -> -ENOTSUP (no CPU decoder)
 │   ├── gpu_generic.c      ← Generic/VM linear backend (virtio-gpu, simple VMs)
 │   └── privilege_helper.c ← Helper spawn + SCM_RIGHTS / DMA-BUF passing
 ├── helper/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -385,7 +385,7 @@ libdrmtap/
 │   ├── gpu_egl.c          ← GPU-universal EGL/GLES2 detiler (PRIMARY detile path)
 │   ├── gpu_intel.c        ← Intel i915/xe tiling modifiers (CCS/X/Y-tiled)
 │   ├── gpu_amd.c          ← AMD amdgpu tiling (RX560 here, RX Vega 64 by a tester)
-│   ├── gpu_nvidia.c       ← Nvidia block-linear handling (incl. Tegra/Jetson)
+│   ├── gpu_nvidia.c       ← Nvidia block-linear, NOT wired up (never validated)
 │   ├── gpu_generic.c      ← Generic/VM linear backend (virtio-gpu, simple VMs)
 │   └── privilege_helper.c ← Helper spawn + SCM_RIGHTS / DMA-BUF passing
 ├── helper/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,30 +7,109 @@ wrapper had its own 0.3.x line).
 
 ## [Unreleased]
 
-Three fixes from the audit of the C sources that RustDesk `dlopen`s into its root
-service. No API or ABI change.
+Four fixes from the audit of the C sources that RustDesk `dlopen`s into its root
+service, and the diagnostics that would have turned issue #45 into a one-line answer
+instead of a day. No API or ABI change.
 
-Connector names covered nine of the twenty-one types the kernel defines, so LVDS,
-DSI, USB, Composite, SVIDEO, Component, DIN, TV, DPI, Writeback and SPI all came back
-as `Unknown` (#46). That is the built-in panel of any pre-eDP laptop, the built-in
-panel of an ARM board, and both DisplayLink and the T2 MacBook Touch Bar. The label
-being wrong is the visible half; the real cost is that `connector_type_id` counts per
-type, so collapsing eleven types onto one prefix collapsed their id spaces too and an
-LVDS panel next to a DSI panel enumerated as two displays both called `Unknown-1`.
-The table is now the kernel's own, the one `/sys/class/drm/card*-<name>` is built
-from, and it is a pure function with a unit test rather than a switch reachable only
-on hardware that has the connector.
+### A tiled scanout was handed back relabelled linear, reported as success
 
-`DMA_BUF_IOCTL_SYNC` was unbalanced on the direct-mmap grab path (#43): two STARTs
-and one END per frame, or one START and no END when the mmap failed and EGL took
-over, which left a CPU access open from the exporter's point of view. The first
-START had nothing to invalidate and is gone.
+`drmtap_deswizzle` decoded Intel modifiers `0x01`-`0x03`, answered `-ENOTSUP` for
+`0x05`-`0x08`, and sent **everything else** to a linear memcpy that returned 0. So an
+unrecognised layout was copied out row by row and reported as a successfully
+converted frame. That covered `Y_TILED_CCS` (`0x04`, missed because the CCS list
+started at `0x05`), the **entire Tile4 family** (`0x09` `4_TILED` plus the DG2 / MTL /
+LNL / BMG CCS variants `0x0a`-`0x11`) which is what current Intel actually scans out,
+and every AMD-vendor modifier.
 
-The auxiliary planes of a compressed scanout reached `eglCreateImage` unvalidated
-(#44), while plane 0 was checked thoroughly against the real fd size. They are now
-bounded as well -- offset plus one row must lie inside the buffer, which is as strong
-a bound as is computable without the per-format plane height -- and an offset or
-pitch above `INT32_MAX` is rejected instead of narrowed into a negative `EGLint`.
+Measured on a Meteor Lake scanout, modifier `0x10000000000000f`, same machine and a
+static screen: the CPU path returned a full screen of tile noise and the EGL path
+returned the desktop, differing in 3922556 of 3932177 bytes, while cpu-vs-cpu and
+egl-vs-egl were byte-identical. Both reported success.
+
+This is the half #38 (0.5.0-era, "fail closed on undecodable scanouts") did not
+reach. That release made sure a `-ENOTSUP` from the deswizzler was propagated rather
+than suppressed; what it never checked is whether the deswizzler *produced* one. For
+these modifiers it did not.
+
+Any layout that cannot be decoded now returns `-ENOTSUP`, so a consumer fails over
+(RustDesk demotes to PipeWire) instead of showing garbage.
+`DRM_FORMAT_MOD_INVALID` keeps its linear treatment, because it means the framebuffer
+stated no modifier rather than that it is known to be tiled. `gpu_intel.c` loses the
+same fail-open tail, the false claim that Gen12 CCS is decompressed transparently on
+a CPU read, and three constant names that were off by one against `drm_fourcc.h`.
+
+Not reachable from a RustDesk build, which asserts the built `.so` really carries the
+EGL backend and refuses a stub. Reachable for anyone building the library by hand.
+
+### Connector names covered nine of the twenty-one kernel types (#46)
+
+`LVDS`, `DSI`, `USB`, `Composite`, `SVIDEO`, `Component`, `DIN`, `TV`, `DPI`,
+`Writeback` and `SPI` all came back as `Unknown`: the built-in panel of any pre-eDP
+laptop, the built-in panel of an ARM board, and both DisplayLink and the T2 MacBook
+Touch Bar. The label being wrong is the visible half; the real cost is that
+`connector_type_id` counts per type, so collapsing eleven types onto one prefix
+collapsed their id spaces too, and an LVDS panel next to a DSI panel enumerated as
+two displays both called `Unknown-1`. The table is now the kernel's own, the one
+`/sys/class/drm/card*-<name>` is built from, extracted as a pure function with a unit
+test rather than a switch reachable only on hardware that has the connector.
+
+### `DMA_BUF_IOCTL_SYNC` was unbalanced in three places (#43)
+
+On the direct-mmap grab path: two STARTs and one END per frame, or one START and no
+END when the mmap failed and EGL took over. The first START had nothing to
+invalidate and is gone.
+
+On the **fast path** it was worse, and that one is not #43's fix repeated: three
+STARTs and no END at all, and because its `prime_fd` lives in a cached slot, one slot
+accumulated an unmatched START for every frame of its lifetime. The START there is
+load-bearing -- it is the only cache invalidation before the first read of a freshly
+populated slot -- so what was missing was the END, which now happens at the top of
+the next grab and in `drmtap_fast_cleanup`. And a third time in slot eviction, which
+closed the fd and cleared the slot while a window was still open. strace over six
+grabs: 6 SYNC ioctls, all START, before; 12 paired after.
+
+### Auxiliary planes reached `eglCreateImage` unvalidated (#44)
+
+Plane 0 was checked thoroughly against the real fd size; planes 1 and 2 got none of
+it. They are now bounded as well -- offset plus one row must lie inside the buffer,
+which is as strong a bound as is computable without the per-format plane height,
+since a CCS plane's height is a fraction of the image height and the obvious stronger
+bound would reject legitimate compressed scanouts. An offset or pitch above
+`INT32_MAX` is rejected rather than narrowed into a negative `EGLint`.
+
+### Diagnostics
+
+All twenty EGL diagnostics in `gpu_egl.c` passed `NULL` as the context, and that
+function returns immediately on a NULL context, so the whole set was dead code:
+`eglInitialize failed`, `eglChooseConfig failed`, `eglCreateContext failed`, shader
+compilation, `eglCreateImage failed`, the retry outcome, the GL error across convert.
+A capture that printed no EGL line at all now prints nine.
+
+A line at open time states whether the EGL backend is compiled in, next to the driver
+line so it lands in every bug report, and says so loudly when it is not. The
+fail-closed errors name which cause applies and, on a build without the backend,
+which packages to install; they no longer call every rejected modifier "compressed",
+which was not true for all of them. The `egl` feature still defaults to `auto`, so
+the README and CONTRIBUTING quick starts now pass `-Degl=enabled`, which fails at
+configure time instead of silently producing the CPU-only stub. That stub is what
+issue #45 turned out to be.
+
+### Documentation
+
+The tested-hardware claim was duplicated across eleven files and had drifted apart:
+three still presented an outside tester's RX Vega 64 as if it were ours, one said AMD
+was untested eight lines above another saying it was verified, and none carried the
+Raptor Lake confirmation from #45. Every claim now says whose machine it is --
+verified here on Intel Meteor Lake-P, AMD RX560, Jetson Orin Nano and virtio_gpu;
+confirmed by outside testers, one host each, on AMD RX Vega 64 (GK-Gaming) and Intel
+Raptor Lake (huzhifeng).
+
+The two crate READMEs had told people to build with `-Degl=enabled`, which is a Meson
+option that does nothing for a crate: `build.rs` always defines `HAVE_EGL`, so what a
+crate user needs is the EGL and GLES2 headers at build time. And the wrapper README
+still advertised `libdrmtap = "0.3"`, a range that cannot resolve to this library at
+all -- the exact failure 0.5.2 was released to correct, surviving in a line that
+release did not touch.
 
 ## [0.5.2] - 2026-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,11 @@ function returns immediately on a NULL context, so the whole set was dead code:
 compilation, `eglCreateImage failed`, the retry outcome, the GL error across convert.
 A capture that printed no EGL line at all now prints nine.
 
+Four fail-closed returns said their reason only to the debug log, so a caller with debug
+logging off got `-ENOTSUP` and an empty `drmtap_error()`: the Intel and Nvidia
+undecodable-modifier paths, the generic backend, and the missing-EGL-procs check. They
+set the context error now, like the equivalent returns in `drm_grab.c` already did.
+
 A line at open time states whether the EGL backend is compiled in, next to the driver
 line so it lands in every bug report, and says so loudly when it is not. The
 fail-closed errors name which cause applies and, on a build without the backend,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ wrapper had its own 0.3.x line).
 
 ## [0.5.3] - 2026-08-07
 
-Four fixes from the audit of the C sources that RustDesk `dlopen`s into its root
+Fixes from the audit of the C sources that RustDesk `dlopen`s into its root
 service, and the diagnostics that would have turned issue #45 into a one-line answer
-instead of a day. No API or ABI change.
+instead of a day.
+
+No ABI change: no signature, struct or symbol moved. `drmtap_deswizzle` does change
+its **contract**, and deliberately -- it now returns `-ENOTSUP` for layouts it used to
+copy out linearly and report as converted. A caller that ignored its return value was
+already getting garbage on those; one that checks it will start seeing failures where
+it saw false successes.
 
 ### A tiled scanout was handed back relabelled linear, reported as success
 
@@ -40,6 +46,40 @@ a CPU read, and three constant names that were off by one against `drm_fourcc.h`
 
 Not reachable from a RustDesk build, which asserts the built `.so` really carries the
 EGL backend and refuses a stub. Reachable for anyone building the library by hand.
+
+### The Nvidia backend tested a vendor byte that does not exist
+
+`gpu_nvidia.c` matched `modifier >> 56 == 0x10`. `DRM_FORMAT_MOD_VENDOR_NVIDIA` is
+`0x03` (`drm_fourcc.h:470`); `0x10` is the low byte of the block-linear encoding, not
+a vendor. So the branch never matched a real Nvidia modifier in any release, and every
+Nvidia-vendor scanout fell through to the linear copy described above and was reported
+as a converted frame.
+
+A unit test covered this and asserted the roundtrip **succeeded** for `0x10`, so the
+test certified the wrong constant instead of catching it. It now feeds a real
+`16BX2_BLOCK` modifier and asserts `-ENOTSUP`. The dead `deswizzle_nvidia_x_tiled`
+is gone rather than left to be trusted later.
+
+With the byte corrected, real Nvidia modifiers finally reach that branch -- and it
+answered by allocating `stride * height`, calling a decoder that cannot decode them,
+and throwing the buffer away; under memory pressure it reported `-ENOMEM` instead of
+the truth. It says so and returns `-ENOTSUP` directly.
+
+### GEM handles from `drmModeGetFB2` were leaked, on four counts
+
+`drmModeGetFB2` mints a handle the caller has to close. Three early returns between
+that call and the close did not: a rejected framebuffer geometry, and two failure
+paths below it. One handle leaked per grab attempt on each. The handle is now held in
+one place from the moment it is minted until ownership moves, so every error return
+closes it without needing to know how far the function got.
+
+And it mints one for **every plane** it reports, not just the first, while only
+`handles[0]` is ever used here: the dma-buf export and the EGL import both go through
+the single fd derived from it. On a scanout whose planes live in separate BOs -- CCS
+is where `num_planes >= 2` comes from -- the others were leaked, one per grab, on the
+slow path and the fast path alike. They are closed as soon as they arrive now,
+deduplicated first, because planes that share a BO come back as the SAME handle and a
+second close would free one the caller still owns.
 
 ### Connector names covered nine of the twenty-one kernel types (#46)
 
@@ -76,19 +116,6 @@ which is as strong a bound as is computable without the per-format plane height,
 since a CCS plane's height is a fraction of the image height and the obvious stronger
 bound would reject legitimate compressed scanouts. An offset or pitch above
 `INT32_MAX` is rejected rather than narrowed into a negative `EGLint`.
-
-### Two more from the CodeRabbit pass on the release PR
-
-`drmModeGetFB2` mints a GEM handle for **every** plane it reports, and a fresh one on
-every call; only `handles[0]` is ever used here, so on a scanout whose planes live in
-separate BOs the rest leaked one handle per grab, on both the slow and the fast path.
-They are now closed as soon as they arrive, deduplicated first because planes sharing
-a BO come back as the same handle and a second close would free one still owned.
-
-And the Nvidia branch no longer allocates a full frame on its way to `-ENOTSUP`. With
-the vendor byte corrected, real Nvidia modifiers reach a decoder that cannot decode
-them; going through it meant a `stride * height` allocation thrown away, and
-`-ENOMEM` instead of the truth if that allocation failed.
 
 ### Diagnostics
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,19 @@ since a CCS plane's height is a fraction of the image height and the obvious str
 bound would reject legitimate compressed scanouts. An offset or pitch above
 `INT32_MAX` is rejected rather than narrowed into a negative `EGLint`.
 
+### Two more from the CodeRabbit pass on the release PR
+
+`drmModeGetFB2` mints a GEM handle for **every** plane it reports, and a fresh one on
+every call; only `handles[0]` is ever used here, so on a scanout whose planes live in
+separate BOs the rest leaked one handle per grab, on both the slow and the fast path.
+They are now closed as soon as they arrive, deduplicated first because planes sharing
+a BO come back as the same handle and a second close would free one still owned.
+
+And the Nvidia branch no longer allocates a full frame on its way to `-ENOTSUP`. With
+the vendor byte corrected, real Nvidia modifiers reach a decoder that cannot decode
+them; going through it meant a `stride * height` allocation thrown away, and
+`-ENOMEM` instead of the truth if that allocation failed.
+
 ### Diagnostics
 
 All twenty EGL diagnostics in `gpu_egl.c` passed `NULL` as the context, and that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ semantic versioning. The C library, the meson project, the `libdrmtap-sys` crate
 the `libdrmtap` wrapper crate all share ONE version (since 0.5.0; before that the
 wrapper had its own 0.3.x line).
 
-## [Unreleased]
+## [0.5.3] - 2026-08-07
 
 Four fixes from the audit of the C sources that RustDesk `dlopen`s into its root
 service, and the diagnostics that would have turned issue #45 into a one-line answer
@@ -591,6 +591,7 @@ entry point is additive and would not on its own have justified more than a patc
   fixes.
 
 [0.5.2]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.2
+[0.5.3]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.3
 [0.5.1]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.1
 [0.5.0]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.0
 [0.4.15]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.4.15

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 | EGL/GLES2 GPU-universal detiling | ✅ Implemented (primary, all GPUs) |
 | Intel (i915/xe) X/Y-tiled deswizzle | ✅ CPU fallback |
 | AMD (amdgpu) deswizzle | ⛔ EGL only — no CPU decoder, fails closed |
-| Nvidia (nvidia-drm) blocklinear deswizzle | ⛔ EGL only — the CPU decoder is unvalidated and not wired up |
+| Nvidia (nvidia-drm) blocklinear deswizzle | ⛔ EGL only — there is no CPU decoder; the CPU path returns `-ENOTSUP` (0.5.3) |
 | HDR10 → SDR tone-map (AR30/XR30/AB30/XB30, XR48/AR48/XB48/AB48) | ✅ Implemented (P010 not yet) |
 | Frame differencing (dirty rects) | ✅ Implemented |
 | Thread-safe (one `drmtap_ctx` per thread) | ✅ By design |

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 | Security hardening (cap drop + seccomp) | ✅ Implemented |
 | EGL/GLES2 GPU-universal detiling | ✅ Implemented (primary, all GPUs) |
 | Intel (i915/xe) X/Y-tiled deswizzle | ✅ CPU fallback |
-| AMD (amdgpu) deswizzle | ✅ CPU fallback |
-| Nvidia (nvidia-drm) blocklinear deswizzle | ✅ CPU fallback |
+| AMD (amdgpu) deswizzle | ⛔ EGL only — no CPU decoder, fails closed |
+| Nvidia (nvidia-drm) blocklinear deswizzle | ⛔ EGL only — the CPU decoder is unvalidated and not wired up |
 | HDR10 → SDR tone-map (AR30/XR30/AB30/XB30, XR48/AR48/XB48/AB48) | ✅ Implemented (P010 not yet) |
 | Frame differencing (dirty rects) | ✅ Implemented |
 | Thread-safe (one `drmtap_ctx` per thread) | ✅ By design |
@@ -112,7 +112,7 @@ println!("{}x{} pixels captured", frame.width(), frame.height());
 >
 > Whichever GPU you have, most of this depends on the EGL detile backend. The
 > CPU path on its own still handles linear scanouts and the plain tilings (Intel
-> X/Y/Yf-tiled, Nvidia block-linear), but a **compressed** scanout, or any tiled
+> X/Y/Yf-tiled), but a **compressed** scanout, or any tiled
 > layout it has no deswizzler for, **fails closed** — it returns an error rather
 > than passing the raw bytes off as linear pixels. Current Intel and AMD desktops
 > scan out exactly those. The `egl` Meson feature defaults to `auto`, which

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.5.2"
+version = "0.5.3"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -76,16 +76,10 @@ static void drmtap_gem_close(drmtap_ctx *ctx, uint32_t handle) {
     drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
-/* `drmModeGetFB2` mints a GEM handle for EVERY plane it reports, and a fresh one on
- * every call even for a BO that already has one. Only `handles[0]` is ever used here:
- * the dma-buf export and the EGL import both go through the single fd derived from
- * it. So every other handle is dead the moment it arrives, and on a scanout whose
- * planes live in separate BOs -- CCS is where `num_planes >= 2` comes from -- one was
- * leaked per grab, forever.
- *
- * Deduplicated before closing, and never touching `handles[0]`: planes that share a
- * BO come back as the SAME handle, and closing it a second time would free one the
- * caller still owns. */
+// GetFB2 mints a handle per plane, fresh on every call; only handles[0] is used here,
+// so the rest leak one per grab when the planes live in separate BOs (CCS). Dedupe
+// before closing: planes sharing a BO return the SAME handle, and a second close
+// would free one the caller still owns.
 static void close_auxiliary_gem_handles(drmtap_ctx *ctx, const drmModeFB2 *fb2) {
     for (int p = 1; p < 4; p++) {
         uint32_t h = fb2->handles[p];

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -76,6 +76,35 @@ static void drmtap_gem_close(drmtap_ctx *ctx, uint32_t handle) {
     drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
+/* `drmModeGetFB2` mints a GEM handle for EVERY plane it reports, and a fresh one on
+ * every call even for a BO that already has one. Only `handles[0]` is ever used here:
+ * the dma-buf export and the EGL import both go through the single fd derived from
+ * it. So every other handle is dead the moment it arrives, and on a scanout whose
+ * planes live in separate BOs -- CCS is where `num_planes >= 2` comes from -- one was
+ * leaked per grab, forever.
+ *
+ * Deduplicated before closing, and never touching `handles[0]`: planes that share a
+ * BO come back as the SAME handle, and closing it a second time would free one the
+ * caller still owns. */
+static void close_auxiliary_gem_handles(drmtap_ctx *ctx, const drmModeFB2 *fb2) {
+    for (int p = 1; p < 4; p++) {
+        uint32_t h = fb2->handles[p];
+        if (h == 0 || h == fb2->handles[0]) {
+            continue;
+        }
+        int dup = 0;
+        for (int q = 1; q < p; q++) {
+            if (fb2->handles[q] == h) {
+                dup = 1;
+                break;
+            }
+        }
+        if (!dup) {
+            drmtap_gem_close(ctx, h);
+        }
+    }
+}
+
 /* Test hook: DRMTAP_FORCE_MMAP_FAIL=1 makes the fast-path cache-miss drop a
  * successful CPU mapping so the EGL-detile fd fallback runs on any EGL-capable GPU,
  * not only a discrete/tiled one that genuinely refuses the mmap. Off by default. */
@@ -840,6 +869,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
      * three returns on THIS path did not, and leaked one handle per grab. Set to 0
      * the moment ownership moves, so nothing is closed twice. */
     uint32_t pending_gem = fb2->handles[0];
+    close_auxiliary_gem_handles(ctx, fb2);
 
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
@@ -1990,6 +2020,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                          fb_id, strerror(errno));
         return ret;
     }
+
+    close_auxiliary_gem_handles(ctx, fb2);
 
     if (fb2->handles[0] == 0) {
         /* drmModeGetFB2 zeroes the GEM handles for a caller without CAP_SYS_ADMIN.

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -834,6 +834,13 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                      (const char *)&fb2->pixel_format,
                      (unsigned long)fb2->modifier);
 
+    /* drmModeGetFB2 minted a handle somebody has to close (see drmtap_gem_close).
+     * Hold it here until priv adopts it, so every error return below can close it
+     * without knowing how far the function got. The fast path already did this;
+     * three returns on THIS path did not, and leaked one handle per grab. Set to 0
+     * the moment ownership moves, so nothing is closed twice. */
+    uint32_t pending_gem = fb2->handles[0];
+
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
     ret = drmtap_validate_fb_dims(fb2->width, fb2->height);
@@ -843,6 +850,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     if (ret != 0) {
         drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
+        drmtap_gem_close(ctx, pending_gem);
         drmModeFreeFB2(fb2);
         return ret;
     }
@@ -873,6 +881,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
              * its per-frame V2/V3 success returns -- leaks it. */
             needs_helper = 1;
             drmtap_gem_close(ctx, fb2->handles[0]);
+            pending_gem = 0;
         } else if (ret < 0) {
             ret = -errno;
             drmtap_set_error(ctx, "drmPrimeHandleToFD failed: %s", strerror(errno));
@@ -1111,6 +1120,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     priv->prime_fd = prime_fd;
     priv->helper_drm_fd = -1;
     priv->gem_handle = fb2->handles[0];
+    pending_gem = 0;  /* priv owns it now */
     priv->mapped = MAP_FAILED;
     priv->mapped_size = 0;
 
@@ -1231,10 +1241,16 @@ cleanup:
     if (fb2) {
         drmModeFreeFB2(fb2);
     }
-    /* Close the GEM handle if this error path was reached after the direct grab
-     * adopted one (priv->gem_handle set); otherwise it leaks like every grab. */
+    /* Close the GEM handle. This used to run only `if (priv)`, but two of the paths
+     * that reach this label -- drmPrimeHandleToFD failing for anything other than
+     * EACCES/EPERM, and the priv calloc failing -- get here BEFORE priv exists, so
+     * the handle they minted was leaked once per grab attempt. pending_gem is
+     * whatever has not been handed over yet, and is 0 once priv owns it or the
+     * helper branch already closed it. */
     if (priv) {
         drmtap_gem_close(ctx, priv->gem_handle);
+    } else {
+        drmtap_gem_close(ctx, pending_gem);
     }
     free(priv);
     /* Leave the frame owning nothing on this error exit too, matching the

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -874,9 +874,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     if (ret != 0) {
         drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
-        drmtap_gem_close(ctx, pending_gem);
-        drmModeFreeFB2(fb2);
-        return ret;
+        goto cleanup;
     }
 
     /* Cache multi-plane info for EGL CCS import */

--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -700,6 +700,13 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
     int worth_looking = crtc->mode_valid && crtc->mode.hdisplay > 0 &&
                         crtc->mode.hdisplay < fb_width;
     uint32_t hdisplay = crtc->mode.hdisplay;
+    /* Both are copied out HERE because crtc is freed on the next line, so neither
+     * declaration can move down to its use. cppcheck 2.19 asks for exactly that
+     * for vdisplay, whose only use is the log line further down; taking that
+     * advice would read freed memory. The CI image carries an older cppcheck that
+     * does not report it, so suppress it rather than wait for the image to update
+     * and break the build. */
+    // cppcheck-suppress variableScope
     uint32_t vdisplay = crtc->mode.vdisplay;
     drmModeFreeCrtc(crtc);
     if (!worth_looking) {

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.c
@@ -237,7 +237,7 @@ static void detect_driver(drmtap_ctx *ctx) {
 #else
     drmtap_debug_log(ctx,
         "EGL detile backend: NOT COMPILED IN. The CPU path still decodes the "
-        "plain tilings (Intel X/Y/Yf-tiled, Nvidia block-linear) and linear "
+        "plain Intel tilings (X/Y/Yf-tiled) and linear "
         "scanouts, but a COMPRESSED scanout, or any tiled layout it does not "
         "decode, will fail closed -- and that is what current Intel and AMD "
         "desktops scan out. Install libegl-dev and libgles2-mesa-dev, then "

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -593,9 +593,14 @@ int drmtap_set_output_buffer(drmtap_ctx *ctx, void *dst, size_t len);
 /**
  * @brief Deswizzle tiled framebuffer data to linear.
  *
- * Converts GPU-tiled pixel data (Intel X/Y-tiled, Nvidia blocklinear)
- * to a linear row-by-row layout. The modifier tells which tiling format
- * to decode. Linear data (modifier == 0) is copied row-by-row.
+ * Converts Intel X/Y/Yf-tiled pixel data to a linear row-by-row layout, and
+ * copies linear data (modifier 0, or DRM_FORMAT_MOD_INVALID meaning the
+ * framebuffer stated no modifier) row by row.
+ *
+ * EVERY OTHER LAYOUT FAILS CLOSED with -ENOTSUP, including all the compressed
+ * Intel variants, the Tile4 family, and every AMD and Nvidia modifier: those
+ * need the GPU detile path. Returning them copied out linearly would hand back
+ * a tiled buffer relabelled linear, reported as a valid frame.
  *
  * @param src        Source (tiled) pixel data
  * @param dst        Destination (linear) buffer (must be allocated by caller)

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 5
-#define DRMTAP_VERSION_PATCH 2
+#define DRMTAP_VERSION_PATCH 3
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -575,7 +575,7 @@ static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
 
 static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     if (load_egl_procs() < 0) {
-        drmtap_debug_log(ctx, "egl: required EGL procs not available");
+        drmtap_set_error(ctx, "egl: required EGL procs not available");
         return -ENOTSUP;
     }
 

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -334,7 +334,9 @@ static int load_egl_procs(void) {
      * funnels through here (egl_init and drmtap_gpu_egl_available) before any
      * EGL/GL call is made, so this is the single lazy-load chokepoint. */
     if (load_gl_libraries() < 0) {
-        return -1;
+        /* -2 so the caller can say "no libEGL/libGLESv2 here", which is a missing package,
+         * rather than "the symbols are absent", which is a driver too old. */
+        return -2;
     }
 
     pfn_eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)
@@ -574,8 +576,11 @@ static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
 /* ========================================================================= */
 
 static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
-    if (load_egl_procs() < 0) {
-        drmtap_set_error(ctx, "egl: required EGL procs not available");
+    int procs = load_egl_procs();
+    if (procs < 0) {
+        drmtap_set_error(ctx, "%s", procs == -2
+            ? "egl: libEGL.so.1/libGLESv2.so.2 could not be loaded (install libegl1 and libgles2)"
+            : "egl: EGL libraries loaded but required procs are missing (driver too old?)");
         return -ENOTSUP;
     }
 

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_egl.c
@@ -142,6 +142,9 @@ static int load_gl_libraries(void) {
     static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
     pthread_mutex_lock(&lk);
     if (g_gl_libs_state == 0) {
+        /* -1 = the libraries are not here at all (a missing package); -2 = they loaded but a
+         * core symbol did not resolve (a driver too old). The caller reports different
+         * remedies, so the two cannot share a value. */
         g_gl_libs_state = -1;
         g_libegl_handle = dlopen("libEGL.so.1", RTLD_NOW | RTLD_LOCAL);
         if (!g_libegl_handle) {
@@ -152,6 +155,7 @@ static int load_gl_libraries(void) {
             g_libgles_handle = dlopen("libGLESv2.so", RTLD_NOW | RTLD_LOCAL);
         }
         if (g_libegl_handle && g_libgles_handle) {
+            g_gl_libs_state = -2;
             int ok = 1;
             /* *(void **)&pfn is the POSIX-documented way to store a dlsym
              * result into a function pointer without the pedantic
@@ -333,10 +337,9 @@ static int load_egl_procs(void) {
     /* Bring in libEGL/libGLESv2 first — every EGL entry point in this file
      * funnels through here (egl_init and drmtap_gpu_egl_available) before any
      * EGL/GL call is made, so this is the single lazy-load chokepoint. */
-    if (load_gl_libraries() < 0) {
-        /* -2 so the caller can say "no libEGL/libGLESv2 here", which is a missing package,
-         * rather than "the symbols are absent", which is a driver too old. */
-        return -2;
+    int libs = load_gl_libraries();
+    if (libs < 0) {
+        return libs;
     }
 
     pfn_eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)
@@ -578,7 +581,7 @@ static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
 static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     int procs = load_egl_procs();
     if (procs < 0) {
-        drmtap_set_error(ctx, "%s", procs == -2
+        drmtap_set_error(ctx, "%s", procs == -1
             ? "egl: libEGL.so.1/libGLESv2.so.2 could not be loaded (install libegl1 and libgles2)"
             : "egl: EGL libraries loaded but required procs are missing (driver too old?)");
         return -ENOTSUP;

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_generic.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_generic.c
@@ -66,7 +66,7 @@ int drmtap_gpu_generic_process(drmtap_ctx *ctx, void *data,
     (void)format;
 
     if (modifier != 0) {
-        drmtap_debug_log(ctx, "generic backend: unexpected modifier 0x%lx",
+        drmtap_set_error(ctx, "generic backend: unexpected modifier 0x%lx",
                          (unsigned long)modifier);
         return -ENOTSUP;
     }

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_intel.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_intel.c
@@ -111,7 +111,7 @@ int drmtap_gpu_intel_process(drmtap_ctx *ctx, void *data,
      * whole Tile4 family). "Passing through" with 0 used to leave the caller
      * holding the still-tiled mapping believing it was converted. Fail closed,
      * the same answer drmtap_deswizzle gives. */
-    drmtap_debug_log(ctx, "intel: modifier 0x%lx needs a GPU detile -- failing closed",
+    drmtap_set_error(ctx, "intel: modifier 0x%lx needs a GPU detile -- failing closed",
                      (unsigned long)modifier);
     return -ENOTSUP;
 }

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
@@ -29,14 +29,16 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include <drm_fourcc.h>
+
 #include "drmtap_internal.h"
 #include "drmtap.h"
 
-/* Nvidia modifier vendor byte */
-/* DRM_FORMAT_MOD_VENDOR_NVIDIA (drm_fourcc.h:470). This was 0x10, which is the low
- * byte of the block-linear encoding rather than a vendor, so this backend never
- * matched a real Nvidia modifier. See the note in pixel_convert.c. */
-#define NV_VENDOR 0x03
+/* The vendor byte comes from libdrm, never a literal: this was 0x10, which is the low
+ * byte of the block-linear encoding rather than a vendor, so the backend never matched
+ * a real Nvidia modifier. See the note in pixel_convert.c.
+ * https://gitlab.freedesktop.org/mesa/drm/-/blob/main/include/drm/drm_fourcc.h */
+#define NV_VENDOR DRM_FORMAT_MOD_VENDOR_NVIDIA
 
 /* ========================================================================= */
 /* Backend API                                                               */

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
@@ -80,7 +80,7 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
          * `drmtap_deswizzle` answers -ENOTSUP for this vendor, so going through it
          * would allocate a full frame only to throw it away -- and report -ENOMEM
          * instead of the truth if that allocation failed. Say it directly. */
-        drmtap_debug_log(ctx,
+        drmtap_set_error(ctx,
                          "nvidia: block-linear modifier 0x%lx has no CPU decoder; "
                          "use the EGL path or a linear scanout",
                          (unsigned long)modifier);

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
@@ -38,7 +38,7 @@
  * byte of the block-linear encoding rather than a vendor, so the backend never matched
  * a real Nvidia modifier. See the note in pixel_convert.c.
  * https://gitlab.freedesktop.org/mesa/drm/-/blob/main/include/drm/drm_fourcc.h */
-#define NV_VENDOR DRM_FORMAT_MOD_VENDOR_NVIDIA
+#define DRMTAP_NV_VENDOR DRM_FORMAT_MOD_VENDOR_NVIDIA
 
 /* ========================================================================= */
 /* Backend API                                                               */
@@ -73,7 +73,7 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
 
     /* Check if it's an Nvidia modifier */
     uint8_t vendor = (uint8_t)(modifier >> 56);
-    if (vendor == NV_VENDOR) {
+    if (vendor == DRMTAP_NV_VENDOR) {
         /* There is no CPU decoder for Nvidia block-linear here: the one that used to
          * be called from this branch tested vendor byte 0x10, which is not a vendor at
          * all, so it never ran on a real modifier and was removed rather than trusted.

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
@@ -56,6 +56,12 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
                               uint32_t stride, uint32_t format,
                               uint64_t modifier) {
     (void)format;
+    /* Only `modifier` decides anything on this backend now: linear needs no work and
+     * block-linear has no CPU decoder, so the pixel arguments are never read. */
+    (void)data;
+    (void)width;
+    (void)height;
+    (void)stride;
 
     /* Linear — no conversion needed (rare on Nvidia but possible) */
     if (modifier == 0) {
@@ -66,24 +72,17 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
     /* Check if it's an Nvidia modifier */
     uint8_t vendor = (uint8_t)(modifier >> 56);
     if (vendor == NV_VENDOR) {
+        /* There is no CPU decoder for Nvidia block-linear here: the one that used to
+         * be called from this branch tested vendor byte 0x10, which is not a vendor at
+         * all, so it never ran on a real modifier and was removed rather than trusted.
+         * `drmtap_deswizzle` answers -ENOTSUP for this vendor, so going through it
+         * would allocate a full frame only to throw it away -- and report -ENOMEM
+         * instead of the truth if that allocation failed. Say it directly. */
         drmtap_debug_log(ctx,
-                         "nvidia: blocklinear modifier 0x%lx, CPU deswizzle",
+                         "nvidia: block-linear modifier 0x%lx has no CPU decoder; "
+                         "use the EGL path or a linear scanout",
                          (unsigned long)modifier);
-
-        /* Deswizzle using our Nvidia X-TILED (16×128) algorithm */
-        size_t size = (size_t)stride * height;
-        void *tmp = malloc(size);
-        if (!tmp) {
-            return -ENOMEM;
-        }
-
-        int ret = drmtap_deswizzle(data, tmp, width, height,
-                                    stride, stride, modifier, size);
-        if (ret == 0) {
-            memcpy(data, tmp, size);
-        }
-        free(tmp);
-        return ret;
+        return -ENOTSUP;
     }
 
     /* nouveau may use different modifiers */

--- a/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
+++ b/bindings/rust/libdrmtap-sys/csrc/gpu_nvidia.c
@@ -33,7 +33,10 @@
 #include "drmtap.h"
 
 /* Nvidia modifier vendor byte */
-#define NV_VENDOR 0x10
+/* DRM_FORMAT_MOD_VENDOR_NVIDIA (drm_fourcc.h:470). This was 0x10, which is the low
+ * byte of the block-linear encoding rather than a vendor, so this backend never
+ * matched a real Nvidia modifier. See the note in pixel_convert.c. */
+#define NV_VENDOR 0x03
 
 /* ========================================================================= */
 /* Backend API                                                               */

--- a/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
+++ b/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
@@ -280,7 +280,7 @@ int drmtap_deswizzle(const void *src, void *dst,
     uint8_t vendor = (uint8_t)(modifier >> 56);
     uint8_t mod_type = (uint8_t)(modifier & 0xFF);
 
-    if (vendor == 0x01) {
+    if (vendor == DRM_FORMAT_MOD_VENDOR_INTEL) {
         if (mod_type == 0x01) {
             /* I915_FORMAT_MOD_X_TILED */
             return deswizzle_intel_x_tiled(src, dst, width, height,
@@ -334,7 +334,7 @@ int drmtap_deswizzle(const void *src, void *dst,
      * Nvidia scanout with EGL disabled and compares it against the EGL output.
      * Until then the EGL path is what serves Nvidia, which is what the Jetson
      * Orin runs today. */
-    if (vendor == 0x03) {
+    if (vendor == DRM_FORMAT_MOD_VENDOR_NVIDIA) {
         return -ENOTSUP;
     }
 

--- a/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
+++ b/bindings/rust/libdrmtap-sys/csrc/pixel_convert.c
@@ -159,55 +159,17 @@ static int deswizzle_intel_y_tiled(const void *src, void *dst,
 #define NV_TILE_WIDTH  16     /* pixels */
 #define NV_TILE_HEIGHT 128    /* rows */
 
-static int deswizzle_nvidia_x_tiled(const void *src, void *dst,
-                                    uint32_t width, uint32_t height,
-                                    uint32_t src_stride, uint32_t dst_stride,
-                                    size_t src_size) {
-    uint32_t bpp = 4;
-    uint32_t tile_w = NV_TILE_WIDTH;
-    uint32_t tile_h = NV_TILE_HEIGHT;
-    uint32_t tile_w_bytes = tile_w * bpp;
-    uint32_t tiles_x = (width + tile_w - 1) / tile_w;
+/* The Nvidia block-linear deswizzler lived here and was removed in this commit.
+ * It had never run: the dispatcher tested vendor 0x10, which is not a vendor at
+ * all (DRM_FORMAT_MOD_VENDOR_NVIDIA is 0x03; 0x10 is the low byte of the
+ * block-linear encoding), so no modifier any driver emits ever reached it, and
+ * the roundtrip test hard-coded the same wrong constant and certified it.
+ *
+ * Rather than switch on an untried decoder to satisfy a table in the README, the
+ * vendor now fails closed and the README says so. `git log -S deswizzle_nvidia_x_tiled`
+ * has the implementation for whoever validates it against a real Tegra scanout;
+ * tests/test_deswizzle.c still carries the tiling loop it was written against. */
 
-    (void)src_stride;
-
-    const uint8_t *s = (const uint8_t *)src;
-    uint8_t *d = (uint8_t *)dst;
-
-    for (uint32_t y = 0; y < height; y++) {
-        uint32_t tile_row = y / tile_h;
-        uint32_t tile_y = y % tile_h;
-
-        for (uint32_t tx = 0; tx < tiles_x; tx++) {
-            uint32_t tile_idx = tile_row * tiles_x + tx;
-            uint32_t tile_size = tile_w_bytes * tile_h;
-            uint32_t src_off = tile_idx * tile_size + tile_y * tile_w_bytes;
-
-            uint32_t dst_x = tx * tile_w;
-            uint32_t copy_w = (dst_x + tile_w > width)
-                              ? width - dst_x : tile_w;
-
-            /* Bound the row copy by the real source size (the block-linear
-             * footprint rounds height up to tile_h): copy only what is backed,
-             * zero-fill the rest, never read past src_size. */
-            uint8_t *drow = d + y * dst_stride + dst_x * bpp;
-            size_t want = (size_t)copy_w * bpp;
-            if ((size_t)src_off >= src_size) {
-                memset(drow, 0, want);
-            } else {
-                size_t avail = src_size - (size_t)src_off;
-                if (avail >= want) {
-                    memcpy(drow, s + src_off, want);
-                } else {
-                    memcpy(drow, s + src_off, avail);
-                    memset(drow + avail, 0, want - avail);
-                }
-            }
-        }
-    }
-
-    return 0;
-}
 
 /* ========================================================================= */
 /* Pixel format conversion                                                   */
@@ -355,10 +317,25 @@ int drmtap_deswizzle(const void *src, void *dst,
         return -ENOTSUP;
     }
 
-    /* Nvidia modifier: vendor = 0x10 (NVIDIA) */
-    if (vendor == 0x10) {
-        return deswizzle_nvidia_x_tiled(src, dst, width, height,
-                                         src_stride, dst_stride, src_size);
+    /* Nvidia, vendor 0x03 (DRM_FORMAT_MOD_VENDOR_NVIDIA, drm_fourcc.h:470).
+     *
+     * This branch used to test 0x10, which is not a vendor at all: it is the low
+     * byte of the block-linear encoding, fourcc_mod_code(NVIDIA, 0x10 | ...) at
+     * drm_fourcc.h:1013. So no real Nvidia modifier ever reached
+     * deswizzle_nvidia_x_tiled -- it has never run on a single frame -- and the
+     * roundtrip test hard-coded the same wrong constant, which is why the mistake
+     * survived: the test certified it.
+     *
+     * The constant is correct now, but the decoder is deliberately NOT wired back
+     * up. Its 16x128 tile geometry has never been checked against a real Tegra
+     * scanout, and turning on an unvalidated decoder would trade a clean failure
+     * for pixels nobody has confirmed -- the exact defect class the rest of this
+     * function was just fixed for. Fail closed until someone captures a tiled
+     * Nvidia scanout with EGL disabled and compares it against the EGL output.
+     * Until then the EGL path is what serves Nvidia, which is what the Jetson
+     * Orin runs today. */
+    if (vendor == 0x03) {
+        return -ENOTSUP;
     }
 
     /* DRM_FORMAT_MOD_INVALID means the framebuffer advertised NO modifier, so the

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]
 description = "Safe Rust wrapper for libdrmtap — DRM/KMS screen capture for Linux (login screen, Wayland, headless)"
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.5.2", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.5.3", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/docs/research/02_drm_kms_mechanism.md
+++ b/docs/research/02_drm_kms_mechanism.md
@@ -76,7 +76,10 @@ void *mapped = mmap(NULL, size, PROT_READ, MAP_SHARED, drm_fd, mreq.offset);
 ```
 **Advantage**: Simple, doesn't need VAAPI or Prime  
 **Problem**: Doesn't handle tiling well, needs manual deswizzle  
-**Note**: Nvidia requires X-TILED deswizzle (16×128)
+**Note**: Nvidia block-linear has no CPU decoder here. The 16×128 "X-TILED" one this document used
+to describe was removed in 0.5.3: it tested vendor byte `0x10`, which is not a vendor
+(`DRM_FORMAT_MOD_VENDOR_NVIDIA` is `0x03`), so it never ran on a real modifier and was never
+validated. EGL is the only path for these.
 
 ### Pipeline 3: Prime + direct mmap (simple fallback)
 ```c
@@ -99,7 +102,7 @@ Modern framebuffers are NOT stored in linear memory. Each GPU uses its own tilin
 | Intel i915 | I915_FORMAT_MOD_Y_TILED | 128×8 tiles | VAAPI |
 | Intel CCS | I915_FORMAT_MOD_CCS | Compressed | ❌ Doesn't work, requires `INTEL_DEBUG=noccs` |
 | AMD amdgpu | AMD_FMT_MOD_* | Variable | VAAPI or AMDGPU SDMA copy |
-| Nvidia | Custom | 16×128 tiles | Manual CPU deswizzle |
+| Nvidia | `fourcc_mod_code(NVIDIA, …)`, vendor `0x03` | block-linear | EGL only — CPU returns `-ENOTSUP` |
 | VM (vmwgfx, virtio) | DRM_FORMAT_MOD_LINEAR | Linear ✅ | Direct, no conversion |
 
 **Key for libdrmtap**: detect the modifier and route accordingly — linear buffers are mapped

--- a/docs/research/02_drm_kms_mechanism.md
+++ b/docs/research/02_drm_kms_mechanism.md
@@ -102,12 +102,17 @@ Modern framebuffers are NOT stored in linear memory. Each GPU uses its own tilin
 | Intel i915 | I915_FORMAT_MOD_Y_TILED | 128×8 tiles | VAAPI |
 | Intel CCS | I915_FORMAT_MOD_CCS | Compressed | ❌ Doesn't work, requires `INTEL_DEBUG=noccs` |
 | AMD amdgpu | AMD_FMT_MOD_* | Variable | VAAPI or AMDGPU SDMA copy |
-| Nvidia | `fourcc_mod_code(NVIDIA, …)`, vendor `0x03` | block-linear | EGL only — CPU returns `-ENOTSUP` |
+| Nvidia | `fourcc_mod_code(NVIDIA, …)`, vendor `0x03` | block-linear | Manual CPU deswizzle |
 | VM (vmwgfx, virtio) | DRM_FORMAT_MOD_LINEAR | Linear ✅ | Direct, no conversion |
 
 **Key for libdrmtap**: detect the modifier and route accordingly — linear buffers are mapped
 directly, and everything tiled/compressed (Intel X/Y + CCS, AMD, Nvidia block-linear) goes through
 the GPU-universal **EGL** detile path. No per-vendor VAAPI pipeline is required (see Key Findings #1).
+
+The "Solution" column above is what the ecosystem does, not what this library does. libdrmtap's CPU
+path decodes **only** Intel X/Y/Yf-tiled; every other modifier returns `-ENOTSUP` and requires EGL.
+Do not implement a row of that table from this page — the Nvidia one was implemented once and the
+result never ran, because it tested vendor byte `0x10` and the vendor is `0x03` (fixed in 0.5.3).
 
 ### Manual Deswizzle (kmsvnc)
 ```c

--- a/docs/research/06_github_issues_analysis.md
+++ b/docs/research/06_github_issues_analysis.md
@@ -166,6 +166,24 @@ Variants: Intel X-TILED, Intel CCS, Nvidia BLOCK_LINEAR, AMD DCC, Broadcom T-TIL
 No universal solution: each GPU needs its own code path
 ```
 
+### 3b. A vendor byte read from the wrong place (discovered 2026-08-06)
+
+`DRM_FORMAT_MOD_VENDOR_NVIDIA` is **`0x03`** (`drm_fourcc.h:470`). `gpu_nvidia.c` tested
+`0x10`, which is not a vendor at all: it is the low byte of the block-linear encoding.
+So the Nvidia branch never matched a real Nvidia modifier, and every Nvidia-vendor
+scanout fell through to the linear `memcpy` and was reported as a successfully
+converted frame -- the same fail-open shape as #4 below, one vendor over.
+
+Two things made it survive: the deswizzler was reached only on hardware nobody here
+runs the CPU path on, and a unit test asserted the behaviour of `0x10`, so the test
+certified the wrong constant rather than catching it.
+
+**Rule:** a vendor byte is `modifier >> 56` compared against a `DRM_FORMAT_MOD_VENDOR_*`
+macro, never a literal. If a literal appears, check it against `drm_fourcc.h` before
+trusting any test that exercises it. And a decoder that cannot decode must return
+`-ENOTSUP` from the branch itself, not travel through an allocation first: that path
+returned `-ENOMEM` under memory pressure and hid the real reason.
+
 ### 4. CCS-compressed framebuffers crash CPU deswizzle (discovered 2026-03-18)
 ```
 Affected projects: libdrmtap (our own!)
@@ -247,4 +265,5 @@ From reading all these issues, the library MUST:
 - [x] **Never CPU-deswizzle CCS modifiers** — `dumb_mmap` returns compressed data, only EGL can deswizzle. Return `-ENOTSUP` and require DMA-BUF fd + EGL (commit 7c7ce27)
 - [x] **V3 protocol: pass DMA-BUF fd via SCM_RIGHTS** for non-linear modifiers so parent can use EGL GPU deswizzle — shipped and now the default zero-copy capture path; Intel CCS detiles correctly in unprivileged/helper mode, with the V2 pixel copy as the fallback
 - [x] **Treat the convert descriptor as untrusted IPC input** — `drmtap_convert_dmabuf()` receives geometry and an fd from the other side of a process boundary. A descriptor claiming a frame larger than the fd actually backs made the CPU fallback mmap and read past the buffer, faulting the unprivileged converter with SIGBUS (a DoS). The fix requires a genuine DMA-BUF (a non-dma-buf fd is rejected; an immutable dma-buf cannot be truncated mid-read) and bounds the read against the buffer size from `lseek` (reliable across kernels, unlike `fstat` which reports 0 for a dma-buf before Linux 5.3), failing closed when the size is unknown. Discovered 2026-07-20 by the `fuzz/fuzz_convert.c` libFuzzer harness (a descriptor whose declared frame exceeds the fd size) and fixed in 0.4.12; the harness is committed and guards against a regression
-
+- [x] **Read the vendor byte against `drm_fourcc.h`, never a literal** — `gpu_nvidia.c` tested `0x10` where `DRM_FORMAT_MOD_VENDOR_NVIDIA` is `0x03`, so the branch was dead and Nvidia modifiers fell through to a linear copy reported as success. A unit test asserted the wrong constant. Fixed in 0.5.3
+- [x] **Close EVERY GEM handle `drmModeGetFB2` mints, not just `handles[0]`** — it creates a fresh handle per plane on every call, and only plane 0 is ever used here. On a scanout whose planes live in separate BOs (CCS is where `num_planes >= 2` comes from) the others leaked one handle per grab. Deduplicate first: planes sharing a BO come back as the SAME handle and a second close would free one still owned. Fixed in 0.5.3

--- a/docs/research/06_github_issues_analysis.md
+++ b/docs/research/06_github_issues_analysis.md
@@ -178,6 +178,12 @@ Two things made it survive: the deswizzler was reached only on hardware nobody h
 runs the CPU path on, and a unit test asserted the behaviour of `0x10`, so the test
 certified the wrong constant rather than catching it.
 
+Upstream definitions, for anyone verifying the encoding rather than trusting this
+page: [`drm_fourcc.h`](https://gitlab.freedesktop.org/mesa/drm/-/blob/main/include/drm/drm_fourcc.h)
+carries `DRM_FORMAT_MOD_VENDOR_NVIDIA` and the `fourcc_mod_code(vendor, val)` macro
+that packs the vendor into bits 56-63; the kernel copy is
+[`include/uapi/drm/drm_fourcc.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/drm/drm_fourcc.h).
+
 **Rule:** a vendor byte is `modifier >> 56` compared against a `DRM_FORMAT_MOD_VENDOR_*`
 macro, never a literal. If a literal appears, check it against `drm_fourcc.h` before
 trusting any test that exercises it. And a decoder that cannot decode must return

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -593,9 +593,14 @@ int drmtap_set_output_buffer(drmtap_ctx *ctx, void *dst, size_t len);
 /**
  * @brief Deswizzle tiled framebuffer data to linear.
  *
- * Converts GPU-tiled pixel data (Intel X/Y-tiled, Nvidia blocklinear)
- * to a linear row-by-row layout. The modifier tells which tiling format
- * to decode. Linear data (modifier == 0) is copied row-by-row.
+ * Converts Intel X/Y/Yf-tiled pixel data to a linear row-by-row layout, and
+ * copies linear data (modifier 0, or DRM_FORMAT_MOD_INVALID meaning the
+ * framebuffer stated no modifier) row by row.
+ *
+ * EVERY OTHER LAYOUT FAILS CLOSED with -ENOTSUP, including all the compressed
+ * Intel variants, the Tile4 family, and every AMD and Nvidia modifier: those
+ * need the GPU detile path. Returning them copied out linearly would hand back
+ * a tiled buffer relabelled linear, reported as a valid frame.
  *
  * @param src        Source (tiled) pixel data
  * @param dst        Destination (linear) buffer (must be allocated by caller)

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 5
-#define DRMTAP_VERSION_PATCH 2
+#define DRMTAP_VERSION_PATCH 3
 
 /**
  * @brief Get the library version as a packed integer.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.5.2',
+    version: '0.5.3',
     license: 'MIT',
     default_options: [
         'c_std=c11',

--- a/meson.build
+++ b/meson.build
@@ -310,7 +310,10 @@ test_formats = executable('test_formats',
 )
 test_deswizzle = executable('test_deswizzle',
     'tests/test_deswizzle.c',
-    dependencies: [libdrmtap_test_dep],
+    # libdrm too: the modifiers under test are built with fourcc_mod_code() from
+    # drm_fourcc.h rather than written out as literals, which is what let a wrong
+    # vendor byte sit in this file asserting the wrong behaviour (0.5.3).
+    dependencies: [libdrmtap_test_dep, libdrm_dep],
     include_directories: lib_include,
 )
 test_helper = executable('test_helper',

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -76,16 +76,10 @@ static void drmtap_gem_close(drmtap_ctx *ctx, uint32_t handle) {
     drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
-/* `drmModeGetFB2` mints a GEM handle for EVERY plane it reports, and a fresh one on
- * every call even for a BO that already has one. Only `handles[0]` is ever used here:
- * the dma-buf export and the EGL import both go through the single fd derived from
- * it. So every other handle is dead the moment it arrives, and on a scanout whose
- * planes live in separate BOs -- CCS is where `num_planes >= 2` comes from -- one was
- * leaked per grab, forever.
- *
- * Deduplicated before closing, and never touching `handles[0]`: planes that share a
- * BO come back as the SAME handle, and closing it a second time would free one the
- * caller still owns. */
+// GetFB2 mints a handle per plane, fresh on every call; only handles[0] is used here,
+// so the rest leak one per grab when the planes live in separate BOs (CCS). Dedupe
+// before closing: planes sharing a BO return the SAME handle, and a second close
+// would free one the caller still owns.
 static void close_auxiliary_gem_handles(drmtap_ctx *ctx, const drmModeFB2 *fb2) {
     for (int p = 1; p < 4; p++) {
         uint32_t h = fb2->handles[p];

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -76,6 +76,35 @@ static void drmtap_gem_close(drmtap_ctx *ctx, uint32_t handle) {
     drmIoctl(ctx->drm_fd, DRM_IOCTL_GEM_CLOSE, &gc);
 }
 
+/* `drmModeGetFB2` mints a GEM handle for EVERY plane it reports, and a fresh one on
+ * every call even for a BO that already has one. Only `handles[0]` is ever used here:
+ * the dma-buf export and the EGL import both go through the single fd derived from
+ * it. So every other handle is dead the moment it arrives, and on a scanout whose
+ * planes live in separate BOs -- CCS is where `num_planes >= 2` comes from -- one was
+ * leaked per grab, forever.
+ *
+ * Deduplicated before closing, and never touching `handles[0]`: planes that share a
+ * BO come back as the SAME handle, and closing it a second time would free one the
+ * caller still owns. */
+static void close_auxiliary_gem_handles(drmtap_ctx *ctx, const drmModeFB2 *fb2) {
+    for (int p = 1; p < 4; p++) {
+        uint32_t h = fb2->handles[p];
+        if (h == 0 || h == fb2->handles[0]) {
+            continue;
+        }
+        int dup = 0;
+        for (int q = 1; q < p; q++) {
+            if (fb2->handles[q] == h) {
+                dup = 1;
+                break;
+            }
+        }
+        if (!dup) {
+            drmtap_gem_close(ctx, h);
+        }
+    }
+}
+
 /* Test hook: DRMTAP_FORCE_MMAP_FAIL=1 makes the fast-path cache-miss drop a
  * successful CPU mapping so the EGL-detile fd fallback runs on any EGL-capable GPU,
  * not only a discrete/tiled one that genuinely refuses the mmap. Off by default. */
@@ -840,6 +869,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
      * three returns on THIS path did not, and leaked one handle per grab. Set to 0
      * the moment ownership moves, so nothing is closed twice. */
     uint32_t pending_gem = fb2->handles[0];
+    close_auxiliary_gem_handles(ctx, fb2);
 
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
@@ -1990,6 +2020,8 @@ int drmtap_grab_mapped_fast(drmtap_ctx *ctx, drmtap_frame_info *frame) {
                          fb_id, strerror(errno));
         return ret;
     }
+
+    close_auxiliary_gem_handles(ctx, fb2);
 
     if (fb2->handles[0] == 0) {
         /* drmModeGetFB2 zeroes the GEM handles for a caller without CAP_SYS_ADMIN.

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -834,6 +834,13 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                      (const char *)&fb2->pixel_format,
                      (unsigned long)fb2->modifier);
 
+    /* drmModeGetFB2 minted a handle somebody has to close (see drmtap_gem_close).
+     * Hold it here until priv adopts it, so every error return below can close it
+     * without knowing how far the function got. The fast path already did this;
+     * three returns on THIS path did not, and leaked one handle per grab. Set to 0
+     * the moment ownership moves, so nothing is closed twice. */
+    uint32_t pending_gem = fb2->handles[0];
+
     /* Bound the DIMENSIONS too, not just stride*height: width is unconstrained by
      * validate_fb_size, and every converted output is sized width*height*4. */
     ret = drmtap_validate_fb_dims(fb2->width, fb2->height);
@@ -843,6 +850,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     if (ret != 0) {
         drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
+        drmtap_gem_close(ctx, pending_gem);
         drmModeFreeFB2(fb2);
         return ret;
     }
@@ -873,6 +881,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
              * its per-frame V2/V3 success returns -- leaks it. */
             needs_helper = 1;
             drmtap_gem_close(ctx, fb2->handles[0]);
+            pending_gem = 0;
         } else if (ret < 0) {
             ret = -errno;
             drmtap_set_error(ctx, "drmPrimeHandleToFD failed: %s", strerror(errno));
@@ -1111,6 +1120,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     priv->prime_fd = prime_fd;
     priv->helper_drm_fd = -1;
     priv->gem_handle = fb2->handles[0];
+    pending_gem = 0;  /* priv owns it now */
     priv->mapped = MAP_FAILED;
     priv->mapped_size = 0;
 
@@ -1231,10 +1241,16 @@ cleanup:
     if (fb2) {
         drmModeFreeFB2(fb2);
     }
-    /* Close the GEM handle if this error path was reached after the direct grab
-     * adopted one (priv->gem_handle set); otherwise it leaks like every grab. */
+    /* Close the GEM handle. This used to run only `if (priv)`, but two of the paths
+     * that reach this label -- drmPrimeHandleToFD failing for anything other than
+     * EACCES/EPERM, and the priv calloc failing -- get here BEFORE priv exists, so
+     * the handle they minted was leaked once per grab attempt. pending_gem is
+     * whatever has not been handed over yet, and is 0 once priv owns it or the
+     * helper branch already closed it. */
     if (priv) {
         drmtap_gem_close(ctx, priv->gem_handle);
+    } else {
+        drmtap_gem_close(ctx, pending_gem);
     }
     free(priv);
     /* Leave the frame owning nothing on this error exit too, matching the

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -874,9 +874,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
     if (ret != 0) {
         drmtap_set_error(ctx, "rejecting framebuffer geometry %ux%u stride=%u",
                          fb2->width, fb2->height, fb2->pitches[0]);
-        drmtap_gem_close(ctx, pending_gem);
-        drmModeFreeFB2(fb2);
-        return ret;
+        goto cleanup;
     }
 
     /* Cache multi-plane info for EGL CCS import */

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -700,6 +700,13 @@ static uint32_t drmtap_scanout_width(drmtap_ctx *ctx, uint32_t fb_width,
     int worth_looking = crtc->mode_valid && crtc->mode.hdisplay > 0 &&
                         crtc->mode.hdisplay < fb_width;
     uint32_t hdisplay = crtc->mode.hdisplay;
+    /* Both are copied out HERE because crtc is freed on the next line, so neither
+     * declaration can move down to its use. cppcheck 2.19 asks for exactly that
+     * for vdisplay, whose only use is the log line further down; taking that
+     * advice would read freed memory. The CI image carries an older cppcheck that
+     * does not report it, so suppress it rather than wait for the image to update
+     * and break the build. */
+    // cppcheck-suppress variableScope
     uint32_t vdisplay = crtc->mode.vdisplay;
     drmModeFreeCrtc(crtc);
     if (!worth_looking) {

--- a/src/drmtap.c
+++ b/src/drmtap.c
@@ -237,7 +237,7 @@ static void detect_driver(drmtap_ctx *ctx) {
 #else
     drmtap_debug_log(ctx,
         "EGL detile backend: NOT COMPILED IN. The CPU path still decodes the "
-        "plain tilings (Intel X/Y/Yf-tiled, Nvidia block-linear) and linear "
+        "plain Intel tilings (X/Y/Yf-tiled) and linear "
         "scanouts, but a COMPRESSED scanout, or any tiled layout it does not "
         "decode, will fail closed -- and that is what current Intel and AMD "
         "desktops scan out. Install libegl-dev and libgles2-mesa-dev, then "

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -575,7 +575,7 @@ static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
 
 static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     if (load_egl_procs() < 0) {
-        drmtap_debug_log(ctx, "egl: required EGL procs not available");
+        drmtap_set_error(ctx, "egl: required EGL procs not available");
         return -ENOTSUP;
     }
 

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -334,7 +334,9 @@ static int load_egl_procs(void) {
      * funnels through here (egl_init and drmtap_gpu_egl_available) before any
      * EGL/GL call is made, so this is the single lazy-load chokepoint. */
     if (load_gl_libraries() < 0) {
-        return -1;
+        /* -2 so the caller can say "no libEGL/libGLESv2 here", which is a missing package,
+         * rather than "the symbols are absent", which is a driver too old. */
+        return -2;
     }
 
     pfn_eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)
@@ -574,8 +576,11 @@ static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
 /* ========================================================================= */
 
 static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
-    if (load_egl_procs() < 0) {
-        drmtap_set_error(ctx, "egl: required EGL procs not available");
+    int procs = load_egl_procs();
+    if (procs < 0) {
+        drmtap_set_error(ctx, "%s", procs == -2
+            ? "egl: libEGL.so.1/libGLESv2.so.2 could not be loaded (install libegl1 and libgles2)"
+            : "egl: EGL libraries loaded but required procs are missing (driver too old?)");
         return -ENOTSUP;
     }
 

--- a/src/gpu_egl.c
+++ b/src/gpu_egl.c
@@ -142,6 +142,9 @@ static int load_gl_libraries(void) {
     static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
     pthread_mutex_lock(&lk);
     if (g_gl_libs_state == 0) {
+        /* -1 = the libraries are not here at all (a missing package); -2 = they loaded but a
+         * core symbol did not resolve (a driver too old). The caller reports different
+         * remedies, so the two cannot share a value. */
         g_gl_libs_state = -1;
         g_libegl_handle = dlopen("libEGL.so.1", RTLD_NOW | RTLD_LOCAL);
         if (!g_libegl_handle) {
@@ -152,6 +155,7 @@ static int load_gl_libraries(void) {
             g_libgles_handle = dlopen("libGLESv2.so", RTLD_NOW | RTLD_LOCAL);
         }
         if (g_libegl_handle && g_libgles_handle) {
+            g_gl_libs_state = -2;
             int ok = 1;
             /* *(void **)&pfn is the POSIX-documented way to store a dlsym
              * result into a function pointer without the pedantic
@@ -333,10 +337,9 @@ static int load_egl_procs(void) {
     /* Bring in libEGL/libGLESv2 first — every EGL entry point in this file
      * funnels through here (egl_init and drmtap_gpu_egl_available) before any
      * EGL/GL call is made, so this is the single lazy-load chokepoint. */
-    if (load_gl_libraries() < 0) {
-        /* -2 so the caller can say "no libEGL/libGLESv2 here", which is a missing package,
-         * rather than "the symbols are absent", which is a driver too old. */
-        return -2;
+    int libs = load_gl_libraries();
+    if (libs < 0) {
+        return libs;
     }
 
     pfn_eglQueryDevicesEXT = (PFNEGLQUERYDEVICESEXTPROC)
@@ -578,7 +581,7 @@ static EGLDisplay egl_display_for_ctx(const drmtap_ctx *ctx) {
 static int egl_init(drmtap_ctx *ctx, egl_state_t *state) {
     int procs = load_egl_procs();
     if (procs < 0) {
-        drmtap_set_error(ctx, "%s", procs == -2
+        drmtap_set_error(ctx, "%s", procs == -1
             ? "egl: libEGL.so.1/libGLESv2.so.2 could not be loaded (install libegl1 and libgles2)"
             : "egl: EGL libraries loaded but required procs are missing (driver too old?)");
         return -ENOTSUP;

--- a/src/gpu_generic.c
+++ b/src/gpu_generic.c
@@ -66,7 +66,7 @@ int drmtap_gpu_generic_process(drmtap_ctx *ctx, void *data,
     (void)format;
 
     if (modifier != 0) {
-        drmtap_debug_log(ctx, "generic backend: unexpected modifier 0x%lx",
+        drmtap_set_error(ctx, "generic backend: unexpected modifier 0x%lx",
                          (unsigned long)modifier);
         return -ENOTSUP;
     }

--- a/src/gpu_intel.c
+++ b/src/gpu_intel.c
@@ -111,7 +111,7 @@ int drmtap_gpu_intel_process(drmtap_ctx *ctx, void *data,
      * whole Tile4 family). "Passing through" with 0 used to leave the caller
      * holding the still-tiled mapping believing it was converted. Fail closed,
      * the same answer drmtap_deswizzle gives. */
-    drmtap_debug_log(ctx, "intel: modifier 0x%lx needs a GPU detile -- failing closed",
+    drmtap_set_error(ctx, "intel: modifier 0x%lx needs a GPU detile -- failing closed",
                      (unsigned long)modifier);
     return -ENOTSUP;
 }

--- a/src/gpu_nvidia.c
+++ b/src/gpu_nvidia.c
@@ -29,14 +29,16 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include <drm_fourcc.h>
+
 #include "drmtap_internal.h"
 #include "drmtap.h"
 
-/* Nvidia modifier vendor byte */
-/* DRM_FORMAT_MOD_VENDOR_NVIDIA (drm_fourcc.h:470). This was 0x10, which is the low
- * byte of the block-linear encoding rather than a vendor, so this backend never
- * matched a real Nvidia modifier. See the note in pixel_convert.c. */
-#define NV_VENDOR 0x03
+/* The vendor byte comes from libdrm, never a literal: this was 0x10, which is the low
+ * byte of the block-linear encoding rather than a vendor, so the backend never matched
+ * a real Nvidia modifier. See the note in pixel_convert.c.
+ * https://gitlab.freedesktop.org/mesa/drm/-/blob/main/include/drm/drm_fourcc.h */
+#define NV_VENDOR DRM_FORMAT_MOD_VENDOR_NVIDIA
 
 /* ========================================================================= */
 /* Backend API                                                               */

--- a/src/gpu_nvidia.c
+++ b/src/gpu_nvidia.c
@@ -80,7 +80,7 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
          * `drmtap_deswizzle` answers -ENOTSUP for this vendor, so going through it
          * would allocate a full frame only to throw it away -- and report -ENOMEM
          * instead of the truth if that allocation failed. Say it directly. */
-        drmtap_debug_log(ctx,
+        drmtap_set_error(ctx,
                          "nvidia: block-linear modifier 0x%lx has no CPU decoder; "
                          "use the EGL path or a linear scanout",
                          (unsigned long)modifier);

--- a/src/gpu_nvidia.c
+++ b/src/gpu_nvidia.c
@@ -38,7 +38,7 @@
  * byte of the block-linear encoding rather than a vendor, so the backend never matched
  * a real Nvidia modifier. See the note in pixel_convert.c.
  * https://gitlab.freedesktop.org/mesa/drm/-/blob/main/include/drm/drm_fourcc.h */
-#define NV_VENDOR DRM_FORMAT_MOD_VENDOR_NVIDIA
+#define DRMTAP_NV_VENDOR DRM_FORMAT_MOD_VENDOR_NVIDIA
 
 /* ========================================================================= */
 /* Backend API                                                               */
@@ -73,7 +73,7 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
 
     /* Check if it's an Nvidia modifier */
     uint8_t vendor = (uint8_t)(modifier >> 56);
-    if (vendor == NV_VENDOR) {
+    if (vendor == DRMTAP_NV_VENDOR) {
         /* There is no CPU decoder for Nvidia block-linear here: the one that used to
          * be called from this branch tested vendor byte 0x10, which is not a vendor at
          * all, so it never ran on a real modifier and was removed rather than trusted.

--- a/src/gpu_nvidia.c
+++ b/src/gpu_nvidia.c
@@ -56,6 +56,12 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
                               uint32_t stride, uint32_t format,
                               uint64_t modifier) {
     (void)format;
+    /* Only `modifier` decides anything on this backend now: linear needs no work and
+     * block-linear has no CPU decoder, so the pixel arguments are never read. */
+    (void)data;
+    (void)width;
+    (void)height;
+    (void)stride;
 
     /* Linear — no conversion needed (rare on Nvidia but possible) */
     if (modifier == 0) {
@@ -66,24 +72,17 @@ int drmtap_gpu_nvidia_process(drmtap_ctx *ctx, void *data,
     /* Check if it's an Nvidia modifier */
     uint8_t vendor = (uint8_t)(modifier >> 56);
     if (vendor == NV_VENDOR) {
+        /* There is no CPU decoder for Nvidia block-linear here: the one that used to
+         * be called from this branch tested vendor byte 0x10, which is not a vendor at
+         * all, so it never ran on a real modifier and was removed rather than trusted.
+         * `drmtap_deswizzle` answers -ENOTSUP for this vendor, so going through it
+         * would allocate a full frame only to throw it away -- and report -ENOMEM
+         * instead of the truth if that allocation failed. Say it directly. */
         drmtap_debug_log(ctx,
-                         "nvidia: blocklinear modifier 0x%lx, CPU deswizzle",
+                         "nvidia: block-linear modifier 0x%lx has no CPU decoder; "
+                         "use the EGL path or a linear scanout",
                          (unsigned long)modifier);
-
-        /* Deswizzle using our Nvidia X-TILED (16×128) algorithm */
-        size_t size = (size_t)stride * height;
-        void *tmp = malloc(size);
-        if (!tmp) {
-            return -ENOMEM;
-        }
-
-        int ret = drmtap_deswizzle(data, tmp, width, height,
-                                    stride, stride, modifier, size);
-        if (ret == 0) {
-            memcpy(data, tmp, size);
-        }
-        free(tmp);
-        return ret;
+        return -ENOTSUP;
     }
 
     /* nouveau may use different modifiers */

--- a/src/gpu_nvidia.c
+++ b/src/gpu_nvidia.c
@@ -33,7 +33,10 @@
 #include "drmtap.h"
 
 /* Nvidia modifier vendor byte */
-#define NV_VENDOR 0x10
+/* DRM_FORMAT_MOD_VENDOR_NVIDIA (drm_fourcc.h:470). This was 0x10, which is the low
+ * byte of the block-linear encoding rather than a vendor, so this backend never
+ * matched a real Nvidia modifier. See the note in pixel_convert.c. */
+#define NV_VENDOR 0x03
 
 /* ========================================================================= */
 /* Backend API                                                               */

--- a/src/pixel_convert.c
+++ b/src/pixel_convert.c
@@ -280,7 +280,7 @@ int drmtap_deswizzle(const void *src, void *dst,
     uint8_t vendor = (uint8_t)(modifier >> 56);
     uint8_t mod_type = (uint8_t)(modifier & 0xFF);
 
-    if (vendor == 0x01) {
+    if (vendor == DRM_FORMAT_MOD_VENDOR_INTEL) {
         if (mod_type == 0x01) {
             /* I915_FORMAT_MOD_X_TILED */
             return deswizzle_intel_x_tiled(src, dst, width, height,
@@ -334,7 +334,7 @@ int drmtap_deswizzle(const void *src, void *dst,
      * Nvidia scanout with EGL disabled and compares it against the EGL output.
      * Until then the EGL path is what serves Nvidia, which is what the Jetson
      * Orin runs today. */
-    if (vendor == 0x03) {
+    if (vendor == DRM_FORMAT_MOD_VENDOR_NVIDIA) {
         return -ENOTSUP;
     }
 

--- a/src/pixel_convert.c
+++ b/src/pixel_convert.c
@@ -159,55 +159,17 @@ static int deswizzle_intel_y_tiled(const void *src, void *dst,
 #define NV_TILE_WIDTH  16     /* pixels */
 #define NV_TILE_HEIGHT 128    /* rows */
 
-static int deswizzle_nvidia_x_tiled(const void *src, void *dst,
-                                    uint32_t width, uint32_t height,
-                                    uint32_t src_stride, uint32_t dst_stride,
-                                    size_t src_size) {
-    uint32_t bpp = 4;
-    uint32_t tile_w = NV_TILE_WIDTH;
-    uint32_t tile_h = NV_TILE_HEIGHT;
-    uint32_t tile_w_bytes = tile_w * bpp;
-    uint32_t tiles_x = (width + tile_w - 1) / tile_w;
+/* The Nvidia block-linear deswizzler lived here and was removed in this commit.
+ * It had never run: the dispatcher tested vendor 0x10, which is not a vendor at
+ * all (DRM_FORMAT_MOD_VENDOR_NVIDIA is 0x03; 0x10 is the low byte of the
+ * block-linear encoding), so no modifier any driver emits ever reached it, and
+ * the roundtrip test hard-coded the same wrong constant and certified it.
+ *
+ * Rather than switch on an untried decoder to satisfy a table in the README, the
+ * vendor now fails closed and the README says so. `git log -S deswizzle_nvidia_x_tiled`
+ * has the implementation for whoever validates it against a real Tegra scanout;
+ * tests/test_deswizzle.c still carries the tiling loop it was written against. */
 
-    (void)src_stride;
-
-    const uint8_t *s = (const uint8_t *)src;
-    uint8_t *d = (uint8_t *)dst;
-
-    for (uint32_t y = 0; y < height; y++) {
-        uint32_t tile_row = y / tile_h;
-        uint32_t tile_y = y % tile_h;
-
-        for (uint32_t tx = 0; tx < tiles_x; tx++) {
-            uint32_t tile_idx = tile_row * tiles_x + tx;
-            uint32_t tile_size = tile_w_bytes * tile_h;
-            uint32_t src_off = tile_idx * tile_size + tile_y * tile_w_bytes;
-
-            uint32_t dst_x = tx * tile_w;
-            uint32_t copy_w = (dst_x + tile_w > width)
-                              ? width - dst_x : tile_w;
-
-            /* Bound the row copy by the real source size (the block-linear
-             * footprint rounds height up to tile_h): copy only what is backed,
-             * zero-fill the rest, never read past src_size. */
-            uint8_t *drow = d + y * dst_stride + dst_x * bpp;
-            size_t want = (size_t)copy_w * bpp;
-            if ((size_t)src_off >= src_size) {
-                memset(drow, 0, want);
-            } else {
-                size_t avail = src_size - (size_t)src_off;
-                if (avail >= want) {
-                    memcpy(drow, s + src_off, want);
-                } else {
-                    memcpy(drow, s + src_off, avail);
-                    memset(drow + avail, 0, want - avail);
-                }
-            }
-        }
-    }
-
-    return 0;
-}
 
 /* ========================================================================= */
 /* Pixel format conversion                                                   */
@@ -355,10 +317,25 @@ int drmtap_deswizzle(const void *src, void *dst,
         return -ENOTSUP;
     }
 
-    /* Nvidia modifier: vendor = 0x10 (NVIDIA) */
-    if (vendor == 0x10) {
-        return deswizzle_nvidia_x_tiled(src, dst, width, height,
-                                         src_stride, dst_stride, src_size);
+    /* Nvidia, vendor 0x03 (DRM_FORMAT_MOD_VENDOR_NVIDIA, drm_fourcc.h:470).
+     *
+     * This branch used to test 0x10, which is not a vendor at all: it is the low
+     * byte of the block-linear encoding, fourcc_mod_code(NVIDIA, 0x10 | ...) at
+     * drm_fourcc.h:1013. So no real Nvidia modifier ever reached
+     * deswizzle_nvidia_x_tiled -- it has never run on a single frame -- and the
+     * roundtrip test hard-coded the same wrong constant, which is why the mistake
+     * survived: the test certified it.
+     *
+     * The constant is correct now, but the decoder is deliberately NOT wired back
+     * up. Its 16x128 tile geometry has never been checked against a real Tegra
+     * scanout, and turning on an unvalidated decoder would trade a clean failure
+     * for pixels nobody has confirmed -- the exact defect class the rest of this
+     * function was just fixed for. Fail closed until someone captures a tiled
+     * Nvidia scanout with EGL disabled and compares it against the EGL output.
+     * Until then the EGL path is what serves Nvidia, which is what the Jetson
+     * Orin runs today. */
+    if (vendor == 0x03) {
+        return -ENOTSUP;
     }
 
     /* DRM_FORMAT_MOD_INVALID means the framebuffer advertised NO modifier, so the

--- a/tests/test_deswizzle.c
+++ b/tests/test_deswizzle.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <stdint.h>
 
+#include <drm_fourcc.h>
 #include "drmtap.h"
 
 #define TEST_ASSERT(cond) do { \
@@ -186,11 +187,12 @@ static void test_deswizzle_nvidia_x_tiled_roundtrip(void) {
      * been checked against a Tegra scanout. Assert THAT, so the day someone wires
      * it up they have to come here and say so. The tiling loop above is kept as
      * the reference for that work. */
-    uint64_t mod_nvidia = 0x0300000000000010ULL;  /* 16BX2_BLOCK, a real one */
+    uint64_t mod_nvidia =
+        fourcc_mod_code(NVIDIA, 0x10);  /* 16BX2_BLOCK, a real one */
     int ret = drmtap_deswizzle(tiled, result, w, h, stride, stride, mod_nvidia, (size_t)stride * h);
     TEST_ASSERT(ret == -ENOTSUP);
     TEST_ASSERT(drmtap_deswizzle(tiled, result, w, h, stride, stride,
-                                 0x0300000000000001ULL /* TEGRA_TILED */,
+                                 fourcc_mod_code(NVIDIA, 1) /* TEGRA_TILED */,
                                  (size_t)stride * h) == -ENOTSUP);
 
     free(linear);

--- a/tests/test_deswizzle.c
+++ b/tests/test_deswizzle.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <stdint.h>
 
 #include "drmtap.h"
@@ -173,18 +174,29 @@ static void test_deswizzle_nvidia_x_tiled_roundtrip(void) {
         }
     }
 
-    /* Deswizzle: Nvidia vendor = 0x10 */
-    uint64_t mod_nvidia = 0x1000000000000000ULL;
+    /* This used to feed 0x1000000000000000 and assert the roundtrip succeeded.
+     * 0x10 is not a vendor: DRM_FORMAT_MOD_VENDOR_NVIDIA is 0x03, and 0x10 is the
+     * low byte of the block-linear encoding. So the constant matched nothing the
+     * kernel produces, the library carried the same mistake, and this test
+     * certified it -- the roundtrip passed against a modifier no driver emits
+     * while every real Nvidia scanout took a different path entirely.
+     *
+     * What the library does now is fail closed for the whole vendor, because the
+     * decoder below has never run on a real frame and its tile geometry has never
+     * been checked against a Tegra scanout. Assert THAT, so the day someone wires
+     * it up they have to come here and say so. The tiling loop above is kept as
+     * the reference for that work. */
+    uint64_t mod_nvidia = 0x0300000000000010ULL;  /* 16BX2_BLOCK, a real one */
     int ret = drmtap_deswizzle(tiled, result, w, h, stride, stride, mod_nvidia, (size_t)stride * h);
-    TEST_ASSERT(ret == 0);
-
-    /* Verify */
-    TEST_ASSERT(memcmp(linear, result, stride * h) == 0);
+    TEST_ASSERT(ret == -ENOTSUP);
+    TEST_ASSERT(drmtap_deswizzle(tiled, result, w, h, stride, stride,
+                                 0x0300000000000001ULL /* TEGRA_TILED */,
+                                 (size_t)stride * h) == -ENOTSUP);
 
     free(linear);
     free(tiled);
     free(result);
-    printf("  PASS: Nvidia X-TILED roundtrip (32x128)\n");
+    printf("  PASS: Nvidia modifiers fail closed (no validated CPU deswizzle)\n");
 }
 
 /* ========================================================================= */


### PR DESCRIPTION
Cuts 0.5.3. No API or ABI change; the CHANGELOG entry has the detail.

- The Nvidia deswizzler branched on a vendor byte that does not exist (`0x10`, where `DRM_FORMAT_MOD_VENDOR_NVIDIA` is `0x03`), so it was unreachable and every Nvidia-vendor modifier fell through to the linear memcpy. Routed to `-ENOTSUP` and the dead function removed.
- Three GEM handle leaks in `drm_grab.c`, one per early return between `drmModeGetFB2` and the close.
- A cppcheck `variableScope` finding that would have gone red on the next CI bump.

Verified here: `meson test` 11/11, `tools/check-version.sh` clean across the six version sites, and a real capture through `examples/screenshot` on Intel Meteor Lake.

Publishing to crates.io is deliberately NOT part of this PR.