### PR TITLE
build: -Dhelper=disabled leaves no fork/exec path in the library

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,12 @@ scanout. Reading the active scanout of a session you are not the DRM master of
 requires `CAP_SYS_ADMIN`. This document describes, accurately, how the privilege
 is isolated, what the helper actually does, and what it does **not** do.
 
+A build configured with `-Dhelper=disabled` has none of this: no helper binary,
+and a library compiled with no fork/exec path at all, so nothing below applies
+to it. A caller without `CAP_SYS_ADMIN` gets `-EACCES` naming the capability
+instead of a fallback. Everything else in this document describes the default
+build.
+
 This document is intended to match the code in `helper/drmtap-helper.c` and
 `src/privilege_helper.c`. If you find a claim here that the code does not
 support, that is a bug in this document — please report it.

--- a/meson.build
+++ b/meson.build
@@ -83,7 +83,6 @@ lib_sources = files(
     'src/drm_grab.c',
     'src/gpu_generic.c',
     'src/pixel_convert.c',
-    'src/privilege_helper.c',
 )
 
 lib_deps = [libdrm_dep, threads_dep, m_dep]
@@ -149,6 +148,20 @@ endif
 # Cursor capture
 lib_sources += files('src/cursor.c')
 
+# The library's side of the helper. `-Dhelper=disabled` is a statement about this
+# build, so it takes the fork/exec path out of the .so as well as skipping the
+# binary: with it, `nm -D` on the .so shows no fork and no exec. `auto` without
+# libseccomp/libcap means only that THIS host cannot produce a confined helper,
+# and one installed from elsewhere must still be usable, so there the client
+# side stays in.
+drmtap_no_helper = get_option('helper').disabled()
+if drmtap_no_helper
+    lib_sources += files('src/privilege_helper_stub.c')
+    message('drmtap-helper: disabled; the library gets no fork/exec path')
+else
+    lib_sources += files('src/privilege_helper.c')
+endif
+
 # ============================================================================
 # Build the shared + static library
 # ============================================================================
@@ -172,6 +185,9 @@ endif
 # at all, it only warns, and -Werror would then fail), so gate it on -O like the
 # helper does.
 libdrmtap_c_args = ['-fstack-protector-strong']
+if drmtap_no_helper
+    libdrmtap_c_args += '-DDRMTAP_NO_HELPER=1'
+endif
 if get_option('optimization') not in ['plain', '0']
     libdrmtap_c_args += ['-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=2']
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,7 +5,18 @@
 #   'enabled' : build the helper; hard-fail if libseccomp/libcap are missing.
 #   'auto'    : build the helper if libseccomp/libcap are present; otherwise skip
 #               it (build the library only) rather than ship it unconfined.
-#   'disabled': do not build the helper at all.
+#   'disabled': no helper at all — the binary is not built, AND the library is
+#               compiled with no fork/exec path, so `nm -D` on the .so shows no
+#               fork, exec or socketpair and the search paths are not in it
+#               either. For a consumer whose device access is already arranged
+#               another way (udev rules, video/render membership, seat
+#               management), that removes a privileged binary it never wanted to
+#               have to trust. A caller without CAP_SYS_ADMIN then gets -EACCES
+#               naming the missing capability, instead of a silent fallback.
+#               NOTE: 'auto' with libseccomp/libcap missing is NOT this. It only
+#               means this host cannot produce a confined helper; the library
+#               keeps its client side so a helper installed from elsewhere still
+#               works.
 option('helper', type: 'feature', value: 'auto',
     description: 'Build the privileged drmtap-helper (requires libseccomp + libcap)')
 

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -935,6 +935,13 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         helper_grab_result_t hresult;
         ret = drmtap_helper_grab(ctx, &hresult, pixel_buf, buf_size);
         if (ret < 0) {
+#ifdef DRMTAP_NO_HELPER
+            /* Built with -Dhelper=disabled: the stub has already said the one
+             * useful thing, and telling the user to install a helper this build
+             * cannot spawn would send them the wrong way. */
+            drmModeFreeFB2(fb2);
+            return -EACCES;
+#else
             drmtap_set_error(ctx,
                 "No CAP_SYS_ADMIN and helper failed (ret=%d). Install the "
                 "helper, restricting it first so the capability is not "
@@ -946,6 +953,7 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 ret);
             drmModeFreeFB2(fb2);
             return -EACCES;
+#endif
         }
 
         /* Allocate private state */

--- a/src/drm_grab.c
+++ b/src/drm_grab.c
@@ -939,8 +939,8 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
             /* Built with -Dhelper=disabled: the stub has already said the one
              * useful thing, and telling the user to install a helper this build
              * cannot spawn would send them the wrong way. */
-            drmModeFreeFB2(fb2);
-            return -EACCES;
+            ret = -EACCES;
+            goto cleanup;
 #else
             drmtap_set_error(ctx,
                 "No CAP_SYS_ADMIN and helper failed (ret=%d). Install the "
@@ -951,8 +951,8 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 "sudo setcap cap_sys_admin+ep /usr/local/bin/drmtap-helper "
                 "(see SECURITY.md)",
                 ret);
-            drmModeFreeFB2(fb2);
-            return -EACCES;
+            ret = -EACCES;
+            goto cleanup;
 #endif
         }
 

--- a/src/privilege_helper_stub.c
+++ b/src/privilege_helper_stub.c
@@ -1,5 +1,15 @@
-/* SPDX-License-Identifier: MIT */
 /*
+ * libdrmtap — DRM/KMS screen capture library for Linux
+ * https://github.com/fxd0h/libdrmtap
+ *
+ * Copyright (c) 2026 Mariano Abad <weimaraner@gmail.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * @file privilege_helper_stub.c
+ * @brief Helper-free build of the privileged fallback (-Dhelper=disabled).
+ *
  * Stand-in for privilege_helper.c in a build configured with -Dhelper=disabled.
  *
  * The point of that option is not to skip installing the helper binary — the
@@ -18,14 +28,11 @@
 
 #include "drmtap_internal.h"
 
-/* Same wording for every entry point: whichever one the caller reached, the
- * fact it needs is the same, and it is not "the helper failed".
- *
- * -EACCES rather than -ENOSYS: what the caller hit is that it may not read the
- * scanout, which is what the rest of the library already returns for that and
- * what consumers branch on (tests/test_capture.c treats -EACCES as "skip, no
- * permission"). That this build also has no fallback is a fact about the build,
- * so it belongs in the message rather than in the errno. */
+// One wording for every entry point: the fact the caller needs is the same.
+// -EACCES and not -ENOSYS, because what it hit is that it may not read the
+// scanout, which is what the rest of the library returns for that and what
+// tests/test_capture.c branches on. Having no fallback is a fact about the
+// build, so it goes in the message, not in the errno.
 static int no_helper(drmtap_ctx *ctx) {
     drmtap_set_error(ctx,
         "this libdrmtap was built with -Dhelper=disabled, so it cannot fall "

--- a/src/privilege_helper_stub.c
+++ b/src/privilege_helper_stub.c
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * Stand-in for privilege_helper.c in a build configured with -Dhelper=disabled.
+ *
+ * The point of that option is not to skip installing the helper binary — the
+ * build already did that — but to leave the library with NO fork/exec path at
+ * all. A consumer whose device access is arranged some other way (udev rules,
+ * membership of video/render, seat management) then does not have to reason
+ * about a spawn it never wanted, and `nm -D` on the .so shows no fork or exec.
+ *
+ * So this file deliberately contains no search paths, no fork, no exec and no
+ * socketpair. It keeps the four symbols the callers reference, and each one
+ * fails with the capability the caller is actually missing.
+ */
+
+#include <errno.h>
+#include <string.h>
+
+#include "drmtap_internal.h"
+
+/* Same wording for every entry point: whichever one the caller reached, the
+ * fact it needs is the same, and it is not "the helper failed".
+ *
+ * -EACCES rather than -ENOSYS: what the caller hit is that it may not read the
+ * scanout, which is what the rest of the library already returns for that and
+ * what consumers branch on (tests/test_capture.c treats -EACCES as "skip, no
+ * permission"). That this build also has no fallback is a fact about the build,
+ * so it belongs in the message rather than in the errno. */
+static int no_helper(drmtap_ctx *ctx) {
+    drmtap_set_error(ctx,
+        "this libdrmtap was built with -Dhelper=disabled, so it cannot fall "
+        "back to drmtap-helper: reading the scanout needs CAP_SYS_ADMIN in the "
+        "calling process (or DRM master). Grant the capability to the caller, "
+        "or rebuild with the helper enabled");
+    return -EACCES;
+}
+
+int drmtap_helper_spawn(drmtap_ctx *ctx) {
+    return no_helper(ctx);
+}
+
+/* A no-op rather than an error: drmtap_close() calls this unconditionally, and
+ * tearing down a helper that was never spawned is not a failure. */
+void drmtap_helper_stop(drmtap_ctx *ctx) {
+    (void)ctx;
+}
+
+int drmtap_helper_grab(drmtap_ctx *ctx, helper_grab_result_t *result,
+                       void *pixel_buf, size_t buf_size) {
+    (void)pixel_buf;
+    (void)buf_size;
+    if (result) {
+        memset(result, 0, sizeof(*result));
+        result->dmabuf_fd = -1;
+    }
+    return no_helper(ctx);
+}
+
+int drmtap_helper_get_cursor(drmtap_ctx *ctx, drmtap_cursor_info *cursor) {
+    if (cursor) {
+        memset(cursor, 0, sizeof(*cursor));
+        cursor->pixels = NULL;
+    }
+    return no_helper(ctx);
+}

--- a/tools/verify-no-helper-build.sh
+++ b/tools/verify-no-helper-build.sh
@@ -14,7 +14,7 @@ no() { printf 'FAIL  %s\n' "$1"; fail=1; }
 so_of() {
     local so
     so=$(ls "$1"/libdrmtap.so.0.* 2>/dev/null | grep -v '\.p$' | head -1)
-    [ -n "$so" ] && [ -f "$so" ] || return 1
+    [ -f "$so" ] || return 1
     printf '%s\n' "$so"
 }
 # The symbols a spawn needs. Matched WITHOUT a $ anchor: nm prints them
@@ -22,29 +22,55 @@ so_of() {
 # first version of this check reported 0 for both builds and proved nothing.
 SPAWN='(^|[[:space:]])(fork|execl|execv|execve|posix_spawn|socketpair|waitpid)@'
 
-meson setup "$A" "$SRC" -Dhelper=disabled >"$A/setup.log" 2>&1 && ninja -C "$A" >"$A/build.log" 2>&1 \
-  && ok "builds with -Dhelper=disabled" || { no "-Dhelper=disabled does not build"; tail -5 "$A/setup.log" "$A/build.log"; }
-meson setup "$B" "$SRC" >"$B/setup.log" 2>&1 && ninja -C "$B" >"$B/build.log" 2>&1 \
-  && ok "builds with the default (helper=auto)" || { no "the default build broke"; tail -5 "$B/build.log"; }
+if meson setup "$A" "$SRC" -Dhelper=disabled >"$A/setup.log" 2>&1 && ninja -C "$A" >"$A/build.log" 2>&1; then
+    ok "builds with -Dhelper=disabled"
+else
+    no "-Dhelper=disabled does not build"
+    tail -5 "$A/setup.log" "$A/build.log"
+fi
+if meson setup "$B" "$SRC" >"$B/setup.log" 2>&1 && ninja -C "$B" >"$B/build.log" 2>&1; then
+    ok "builds with the default (helper=auto)"
+else
+    no "the default build broke"
+    tail -5 "$B/build.log"
+fi
 
 # POSITIVE control first: if the default build shows no spawn symbols either,
 # the check is broken, not the code.
 SO_B=$(so_of "$B") || { no "the default build produced no .so to inspect"; SO_B=/dev/null; }
 SO_A=$(so_of "$A") || { no "the -Dhelper=disabled build produced no .so to inspect"; SO_A=/dev/null; }
 n_def=$(nm -D --undefined-only "$SO_B" 2>/dev/null | grep -cE "$SPAWN")
-[ "$n_def" -gt 0 ] && ok "control: the default .so does reference spawn symbols ($n_def)" \
-                   || no "control failed: the default .so shows none either, so this check discriminates nothing"
+if [ "$n_def" -gt 0 ]; then
+    ok "control: the default .so does reference spawn symbols ($n_def)"
+else
+    no "control failed: the default .so shows none either, so this check discriminates nothing"
+fi
 n_off=$(nm -D --undefined-only "$SO_A" 2>/dev/null | grep -cE "$SPAWN")
-[ "$n_off" -eq 0 ] && ok "the -Dhelper=disabled .so references no fork/exec/socketpair" \
-                   || { no "spawn symbols survive with the helper disabled:"; nm -D --undefined-only "$SO_A" | grep -E "$SPAWN"; }
+if [ "$n_off" -eq 0 ]; then
+    ok "the -Dhelper=disabled .so references no fork/exec/socketpair"
+else
+    no "spawn symbols survive with the helper disabled:"
+    nm -D --undefined-only "$SO_A" | grep -E "$SPAWN"
+fi
 
 # The search paths are strings; they should be gone too, or the .so still tells
 # an attacker where a helper would be looked for.
 n_paths=$(strings "$SO_A" | grep -c '^/usr.*drmtap-helper$')
-[ "$n_paths" -eq 0 ] && ok "no helper search paths left in the .so" || { no "$n_paths search path(s) still in the .so"; }
-[ -x "$A/drmtap-helper" ] && no "the helper binary was built anyway" || ok "no helper binary produced"
-[ -x "$B/drmtap-helper" ] && ok "control: the default build does produce the helper" \
-                          || printf 'SKIP  the default build produced no helper (libseccomp/libcap missing here)\n'
+if [ "$n_paths" -eq 0 ]; then
+    ok "no helper search paths left in the .so"
+else
+    no "$n_paths search path(s) still in the .so"
+fi
+if [ -x "$A/drmtap-helper" ]; then
+    no "the helper binary was built anyway"
+else
+    ok "no helper binary produced"
+fi
+if [ -x "$B/drmtap-helper" ]; then
+    ok "control: the default build does produce the helper"
+else
+    printf 'SKIP  the default build produced no helper (libseccomp/libcap missing here)\n'
+fi
 
 for d in "$A" "$B"; do
   r=$( cd "$d" && meson test 2>&1 | grep -E '^Fail:' | tr -s ' ' )
@@ -52,5 +78,5 @@ for d in "$A" "$B"; do
 done
 
 echo
-[ $fail -eq 0 ] && echo "ALL CHECKS PASS" || echo "SOMETHING FAILED"
+if [ $fail -eq 0 ]; then echo "ALL CHECKS PASS"; else echo "SOMETHING FAILED"; fi
 exit $fail

--- a/tools/verify-no-helper-build.sh
+++ b/tools/verify-no-helper-build.sh
@@ -61,8 +61,12 @@ if [ "$n_paths" -eq 0 ]; then
 else
     no "$n_paths search path(s) still in the .so"
 fi
-if [ -x "$A/drmtap-helper" ]; then
-    no "the helper binary was built anyway"
+# -f, not -x: the question here is whether the artifact EXISTS at all. With -x a
+# helper that was built without the exec bit reads as absent and this reports a
+# pass it did not earn. The positive control below keeps -x, because there the
+# claim is that the default build produces a helper that can actually run.
+if [ -f "$A/drmtap-helper" ]; then
+    no "a helper artifact exists in the -Dhelper=disabled build"
 else
     ok "no helper binary produced"
 fi

--- a/tools/verify-no-helper-build.sh
+++ b/tools/verify-no-helper-build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Proves what -Dhelper=disabled is supposed to buy: a library with NO fork/exec
+# path, not merely a build that skips installing the helper binary.
+# Builds both ways and compares. Run from the source root.
+set -u
+SRC="${1:-$PWD}"
+A=$(mktemp -d); B=$(mktemp -d); trap 'rm -rf "$A" "$B"' EXIT
+fail=0
+ok() { printf 'PASS  %s\n' "$1"; }
+no() { printf 'FAIL  %s\n' "$1"; fail=1; }
+so_of() { ls "$1"/libdrmtap.so.0.* 2>/dev/null | grep -v '\.p$' | head -1; }
+# The symbols a spawn needs. Matched WITHOUT a $ anchor: nm prints them
+# versioned (fork@GLIBC_2.2.5), and anchoring silently matched nothing - the
+# first version of this check reported 0 for both builds and proved nothing.
+SPAWN='(^|[[:space:]])(fork|execl|execv|execve|posix_spawn|socketpair|waitpid)@'
+
+meson setup "$A" "$SRC" -Dhelper=disabled >"$A/setup.log" 2>&1 && ninja -C "$A" >"$A/build.log" 2>&1 \
+  && ok "builds with -Dhelper=disabled" || { no "-Dhelper=disabled does not build"; tail -5 "$A/setup.log" "$A/build.log"; }
+meson setup "$B" "$SRC" >"$B/setup.log" 2>&1 && ninja -C "$B" >"$B/build.log" 2>&1 \
+  && ok "builds with the default (helper=auto)" || { no "the default build broke"; tail -5 "$B/build.log"; }
+
+# POSITIVE control first: if the default build shows no spawn symbols either,
+# the check is broken, not the code.
+n_def=$(nm -D --undefined-only "$(so_of "$B")" 2>/dev/null | grep -cE "$SPAWN")
+[ "$n_def" -gt 0 ] && ok "control: the default .so does reference spawn symbols ($n_def)" \
+                   || no "control failed: the default .so shows none either, so this check discriminates nothing"
+n_off=$(nm -D --undefined-only "$(so_of "$A")" 2>/dev/null | grep -cE "$SPAWN")
+[ "$n_off" -eq 0 ] && ok "the -Dhelper=disabled .so references no fork/exec/socketpair" \
+                   || { no "spawn symbols survive with the helper disabled:"; nm -D --undefined-only "$(so_of "$A")" | grep -E "$SPAWN"; }
+
+# The search paths are strings; they should be gone too, or the .so still tells
+# an attacker where a helper would be looked for.
+n_paths=$(strings "$(so_of "$A")" | grep -c '^/usr.*drmtap-helper$')
+[ "$n_paths" -eq 0 ] && ok "no helper search paths left in the .so" || { no "$n_paths search path(s) still in the .so"; }
+[ -x "$A/drmtap-helper" ] && no "the helper binary was built anyway" || ok "no helper binary produced"
+[ -x "$B/drmtap-helper" ] && ok "control: the default build does produce the helper" \
+                          || printf 'SKIP  the default build produced no helper (libseccomp/libcap missing here)\n'
+
+for d in "$A" "$B"; do
+  r=$( cd "$d" && meson test 2>&1 | grep -E '^Fail:' | tr -s ' ' )
+  case "$r" in *"Fail: 0"*) ok "tests pass in $(basename "$d")";; *) no "tests fail in $(basename "$d"): $r";; esac
+done
+
+echo
+[ $fail -eq 0 ] && echo "ALL CHECKS PASS" || echo "SOMETHING FAILED"
+exit $fail

--- a/tools/verify-no-helper-build.sh
+++ b/tools/verify-no-helper-build.sh
@@ -8,7 +8,15 @@ A=$(mktemp -d); B=$(mktemp -d); trap 'rm -rf "$A" "$B"' EXIT
 fail=0
 ok() { printf 'PASS  %s\n' "$1"; }
 no() { printf 'FAIL  %s\n' "$1"; fail=1; }
-so_of() { ls "$1"/libdrmtap.so.0.* 2>/dev/null | grep -v '\.p$' | head -1; }
+# Fails when there is no library to inspect. Without this, a missing artifact
+# makes nm and strings return nothing and every "no spawn symbols" check passes
+# for the wrong reason - the same shape of false pass this script exists to stop.
+so_of() {
+    local so
+    so=$(ls "$1"/libdrmtap.so.0.* 2>/dev/null | grep -v '\.p$' | head -1)
+    [ -n "$so" ] && [ -f "$so" ] || return 1
+    printf '%s\n' "$so"
+}
 # The symbols a spawn needs. Matched WITHOUT a $ anchor: nm prints them
 # versioned (fork@GLIBC_2.2.5), and anchoring silently matched nothing - the
 # first version of this check reported 0 for both builds and proved nothing.
@@ -21,16 +29,18 @@ meson setup "$B" "$SRC" >"$B/setup.log" 2>&1 && ninja -C "$B" >"$B/build.log" 2>
 
 # POSITIVE control first: if the default build shows no spawn symbols either,
 # the check is broken, not the code.
-n_def=$(nm -D --undefined-only "$(so_of "$B")" 2>/dev/null | grep -cE "$SPAWN")
+SO_B=$(so_of "$B") || { no "the default build produced no .so to inspect"; SO_B=/dev/null; }
+SO_A=$(so_of "$A") || { no "the -Dhelper=disabled build produced no .so to inspect"; SO_A=/dev/null; }
+n_def=$(nm -D --undefined-only "$SO_B" 2>/dev/null | grep -cE "$SPAWN")
 [ "$n_def" -gt 0 ] && ok "control: the default .so does reference spawn symbols ($n_def)" \
                    || no "control failed: the default .so shows none either, so this check discriminates nothing"
-n_off=$(nm -D --undefined-only "$(so_of "$A")" 2>/dev/null | grep -cE "$SPAWN")
+n_off=$(nm -D --undefined-only "$SO_A" 2>/dev/null | grep -cE "$SPAWN")
 [ "$n_off" -eq 0 ] && ok "the -Dhelper=disabled .so references no fork/exec/socketpair" \
-                   || { no "spawn symbols survive with the helper disabled:"; nm -D --undefined-only "$(so_of "$A")" | grep -E "$SPAWN"; }
+                   || { no "spawn symbols survive with the helper disabled:"; nm -D --undefined-only "$SO_A" | grep -E "$SPAWN"; }
 
 # The search paths are strings; they should be gone too, or the .so still tells
 # an attacker where a helper would be looked for.
-n_paths=$(strings "$(so_of "$A")" | grep -c '^/usr.*drmtap-helper$')
+n_paths=$(strings "$SO_A" | grep -c '^/usr.*drmtap-helper$')
 [ "$n_paths" -eq 0 ] && ok "no helper search paths left in the .so" || { no "$n_paths search path(s) still in the .so"; }
 [ -x "$A/drmtap-helper" ] && no "the helper binary was built anyway" || ok "no helper binary produced"
 [ -x "$B/drmtap-helper" ] && ok "control: the default build does produce the helper" \


### PR DESCRIPTION
Closes #53. Raised by @bjaraujo while discussing #52.

`-Dhelper=disabled` already skipped building and installing the helper binary, but
`src/privilege_helper.c` was in `lib_sources` unconditionally, so the library still carried the
spawn: `fork`, `execl`, `socketpair`, `waitpid` and the six search paths were all in a build that
could never use them. That is the part worth removing — not how the helper is located, but having to
trust a privileged binary at all when device access is arranged by udev rules or group membership
instead.

With the option off the library compiles `src/privilege_helper_stub.c` instead: no search paths, no
fork, no exec, and `-EACCES` naming the missing capability rather than a silent fallback. The grab
path drops its "install the helper" advice there, since it would point at something that build
cannot spawn.

`auto` without libseccomp/libcap is deliberately **not** the same thing: it only means this host
cannot produce a confined helper, so the client side stays in and a helper installed from elsewhere
still works.

`-EACCES` and not `-ENOSYS` because the integration test already encoded that contract —
`tests/test_capture.c` skips on `-EACCES` as "no permission". The test named the right answer.

### How it is checked

`tools/verify-no-helper-build.sh` builds both ways and compares, with the default build as a
**positive control**:

```
PASS  control: the default .so does reference spawn symbols (4)
PASS  the -Dhelper=disabled .so references no fork/exec/socketpair
PASS  no helper search paths left in the .so
PASS  control: the default build does produce the helper
PASS  tests pass in both  (11/11 each)
```

The control is not decoration. The first version of that check anchored the symbol names with `$`,
and since `nm` prints them versioned (`fork@GLIBC_2.2.5`) it reported zero for **both** builds and
proved nothing. The script now fails if the default build stops showing them, i.e. if the check ever
stops discriminating.

`drmtap_config.helper_path` stays in the public header and is ignored, so the ABI does not change.

---

Note on history: I pushed this to `main` directly first (f2d0d88) and reverted it in 4466d60. Every
other change here goes through a PR and gets reviewed; that one skipped it, and my own verification
is not a review. Same tree, re-applied here.
