### PR TITLE
Sync csrc/ after the helper-disabled change

### DIFF
--- a/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
+++ b/bindings/rust/libdrmtap-sys/csrc/drm_grab.c
@@ -935,6 +935,13 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
         helper_grab_result_t hresult;
         ret = drmtap_helper_grab(ctx, &hresult, pixel_buf, buf_size);
         if (ret < 0) {
+#ifdef DRMTAP_NO_HELPER
+            /* Built with -Dhelper=disabled: the stub has already said the one
+             * useful thing, and telling the user to install a helper this build
+             * cannot spawn would send them the wrong way. */
+            ret = -EACCES;
+            goto cleanup;
+#else
             drmtap_set_error(ctx,
                 "No CAP_SYS_ADMIN and helper failed (ret=%d). Install the "
                 "helper, restricting it first so the capability is not "
@@ -944,8 +951,9 @@ static int do_grab(drmtap_ctx *ctx, drmtap_frame_info *frame, int do_mmap) {
                 "sudo setcap cap_sys_admin+ep /usr/local/bin/drmtap-helper "
                 "(see SECURITY.md)",
                 ret);
-            drmModeFreeFB2(fb2);
-            return -EACCES;
+            ret = -EACCES;
+            goto cleanup;
+#endif
         }
 
         /* Allocate private state */


### PR DESCRIPTION
`main` is red on **Version & crate-source coherence**: #54 edited `src/drm_grab.c` and left
`bindings/rust/libdrmtap-sys/csrc/drm_grab.c` untouched, so the two drifted.

Regenerated with `tools/sync-crate.sh`. The only change is the guard #54 added, so the crate takes
the `#else` branch exactly as before — `build.rs` never defines `DRMTAP_NO_HELPER` and has no
equivalent build option, which is also why the stub is deliberately not copied into `csrc/`.
Verified the sys crate still builds.

```
checking csrc/ source drift...
csrc/ is in sync with the library
version coherence OK
```

For the record: this check was already failing on the #54 branch at 21:50 and 21:59. I read the
review and merged without looking at CI, which is how a red reached `main`.
