### PR TITLE
Release 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,35 @@ the `libdrmtap` wrapper crate all share ONE version. 0.5.0 declared that move an
 did not complete it - the wrapper still shipped 0.3.4 pinned to a `-sys` range that
 could not reach 0.5.0 - so the shared line only actually holds from 0.5.1.
 
-## [Unreleased]
+## [0.5.5] - 2026-09-07
+
+### Added: build without the privileged helper at all
+
+`-Dhelper=disabled` already skipped building and installing `drmtap-helper`, but
+`src/privilege_helper.c` was compiled into the library unconditionally, so the `.so`
+still carried the spawn: `fork`, `execl`, `socketpair`, `waitpid` and the six absolute
+search paths, in a build that could never use any of them. The option now selects
+`src/privilege_helper_stub.c` instead, and `nm -D` on such a build reports none of those
+symbols and none of the paths.
+
+The point is not the binary, which the option already handled, but the trust: a consumer
+whose device access is arranged some other way - udev rules, membership of `video` or
+`render`, seat management - no longer carries a `CAP_SYS_ADMIN` binary it never wanted to
+reason about. Raised by @bjaraujo in #52, tracked as #53.
+
+With the option off, a caller that lacks `CAP_SYS_ADMIN` gets `-EACCES` naming the
+capability rather than a silent fallback, and the grab path drops its advice to install a
+helper, which would point at something that build cannot spawn. `-EACCES` and not
+`-ENOSYS` because the caller hit a permission it does not have, which is what the rest of
+the library returns for that and what `tests/test_capture.c` branches on.
+
+`-Dhelper=auto` without libseccomp or libcap is deliberately NOT the same thing. It means
+only that this host cannot produce a confined helper, so the client side stays in and a
+helper installed from elsewhere still works.
+
+`tools/verify-no-helper-build.sh` builds both ways and compares, with the default build as
+a positive control: it fails if the default `.so` ever stops referencing the spawn symbols,
+that is, if the check stops discriminating.
 
 ### Docs: the cursor plane position was documented as unavailable, and it is not
 
@@ -701,6 +729,7 @@ entry point is additive and would not on its own have justified more than a patc
   fixes.
 
 [0.5.2]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.2
+[0.5.5]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.5
 [0.5.4]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.4
 [0.5.3]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.3
 [0.5.1]: https://github.com/fxd0h/libdrmtap/releases/tag/v0.5.1

--- a/bindings/rust/libdrmtap-sys/Cargo.toml
+++ b/bindings/rust/libdrmtap-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap-sys"
-version = "0.5.4"
+version = "0.5.5"
 links = "drmtap"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]

--- a/bindings/rust/libdrmtap-sys/csrc/drmtap.h
+++ b/bindings/rust/libdrmtap-sys/csrc/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 5
-#define DRMTAP_VERSION_PATCH 4
+#define DRMTAP_VERSION_PATCH 5
 
 /**
  * @brief Get the library version as a packed integer.

--- a/bindings/rust/libdrmtap/Cargo.toml
+++ b/bindings/rust/libdrmtap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdrmtap"
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 authors = ["Mariano Abad <weimaraner@gmail.com>"]
 description = "Safe Rust wrapper for libdrmtap — DRM/KMS screen capture for Linux (login screen, Wayland, headless)"
@@ -13,7 +13,7 @@ keywords = ["drm", "kms", "screen-capture", "wayland", "remote-desktop"]
 categories = ["multimedia::video", "os::linux-apis"]
 
 [dependencies]
-libdrmtap-sys = { version = "0.5.4", path = "../libdrmtap-sys" }
+libdrmtap-sys = { version = "0.5.5", path = "../libdrmtap-sys" }
 
 [[example]]
 name = "capture_test"

--- a/include/drmtap.h
+++ b/include/drmtap.h
@@ -31,7 +31,7 @@ extern "C" {
  * `libdrmtap` Rust wrapper crate carries its own, separate version line. */
 #define DRMTAP_VERSION_MAJOR 0
 #define DRMTAP_VERSION_MINOR 5
-#define DRMTAP_VERSION_PATCH 4
+#define DRMTAP_VERSION_PATCH 5
 
 /**
  * @brief Get the library version as a packed integer.

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 project('libdrmtap', 'c',
-    version: '0.5.4',
+    version: '0.5.5',
     license: 'MIT',
     default_options: [
         'c_std=c11',


### PR DESCRIPTION
Cuts 0.5.5.

Contents: the `-Dhelper=disabled` build option (#54, raised by @bjaraujo in #52 and tracked as #53),
its csrc sync (#55), and the doc corrections plus the `patches/rustdesk/` removal that had been
sitting in Unreleased since #51.

Patch bump, so nothing downstream has to move: rustdesk pins ABI major 0 / minor 5 with a patch
floor of 0, and the published wrapper's caret range on `libdrmtap-sys` resolves forward on its own.
The `.so` filename does change to `libdrmtap.so.0.5.5` while the soname stays `libdrmtap.so.0`
(checked with `readelf -d`), so anything that names the file rather than the soname needs updating.

Checks:

```
version coherence OK          (six sites, csrc in sync)
11/11 tests
verify-no-helper-build.sh     9/9 with both controls
exported symbols              identical to 0.5.4
soname                        libdrmtap.so.0
```

The advisory from `check-version.sh` was read in full: every remaining version string is genuine
history ("shipped in 0.4.4", "since 0.5.1"), not a stale current pointer.

The changelog section was written against `git diff v0.5.4..HEAD`, not against the previous entry,
so the release covers all three sources of change rather than only the newest one.
